### PR TITLE
Add CDN webfont entrypoints

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -38,7 +38,7 @@ Web プロジェクトにおいて、head 内のスタイルシートの読み�
 <head>
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/400.css"
+    href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/cdn/400.css"
   />
 </head>
 ```
@@ -61,7 +61,7 @@ body {
 <head>
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/display-800.css"
+    href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/cdn/display-800.css"
   />
 </head>
 ```
@@ -80,6 +80,9 @@ h2 {
 - `all.css`: 全 16 ウェイトの CSS
 - `400.css`: Gen Interface JP Regular (400) の CSS
 - `display-400.css`: Gen Interface JP Display Regular (400) の CSS
+
+jsDelivr から直接読む場合は `cdn/*.css`、npm install 後やセルフホストでは
+相対 `./w/...` の WOFF2 参照を保つ通常の `.css` を使用してください。
 
 ## Repository
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ With [subsetting similar to Google Fonts](https://developers.googleblog.com/goog
 <head>
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/400.css"
+    href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/cdn/400.css"
   />
 </head>
 ```
@@ -60,7 +60,7 @@ body {
 <head>
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/display-800.css"
+    href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/cdn/display-800.css"
   />
 </head>
 ```
@@ -79,6 +79,10 @@ h2 {
 - `all.css`: All 16 weights
 - `400.css`: Gen Interface JP Regular (400)
 - `display-400.css`: Gen Interface JP Display Regular (400)
+
+Use `cdn/*.css` files when linking directly from jsDelivr. Use plain `.css`
+files after npm install or when self-hosting so they keep relative `./w/...`
+WOFF2 references.
 
 ## Repository
 

--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -99,6 +99,7 @@ dist/ttf/{family}/{family}-{weight}.ttf を読み込み
       .nam ファイル → 人間可読のコードポイント一覧
   → スライスごとに `unicode-range:` 付き @font-face を生成
   → all.css (フルファミリー) + ウェイト別 CSS を出力
+    npm / self-host 用に WOFF2 は相対 ./w/... URL で参照
   → manifest.json にサイズ / brotli サイズを記録
 ```
 
@@ -107,8 +108,9 @@ dist/ttf/{family}/{family}-{weight}.ttf を読み込み
 ```
 dist/ttf/ + dist/webfont/gen-interface-jp/ を要求
   → GenInterfaceJP-<version>.zip (TTF、全ウェイト × 両ファミリー)
-  → webfont package を npm/      にコピー (package.json 同梱)
+  → webfont package を npm/      にコピー (package.json + README.md 同梱)
   → webfont package を webfonts/ にコピー (Pages 配信用ミラー)
+  → バージョン固定の jsDelivr WOFF2 URL を持つ cdn/*.css を追加
   → manifest.json に version, tag, アセット URL を記録
 ```
 
@@ -272,6 +274,22 @@ dist/webfont/gen-interface-jp/
   manifest.json          # スライスごとのサイズ / brotli サイズ
 ```
 
+この段階の CSS は意図的に相対 `./w/...` の WOFF2 URL を使う。
+`release.build` は npm install 後やセルフホスト向けに通常の `.css` を残し、
+同時に WOFF2 URL をバージョン固定の jsDelivr 絶対 URL へ書き換えた
+`cdn/*.css` を出す:
+
+```
+dist/release/npm/
+  all.css
+  cdn/all.css
+  400.css
+  cdn/400.css
+  display-400.css
+  cdn/display-400.css
+  README.md              # CDN と self-host の使い分けを説明
+```
+
 `benchmark.mjs` (Node) はローカルサブセットに対する throttled fetch を
 再生し、スライス分割が単一フル WOFF2 比でペイするかを検証する。
 比較対象のフル WOFF2 は Regular TTF からオンデマンドで生成する
@@ -289,10 +307,12 @@ dist/webfont/gen-interface-jp/
   サブセット経由が本道、自前ホスティングする場合も TTF→WOFF2 変換は
   fontTools / pyftsubset で容易。
 - **npm パッケージ** (`dist/release/npm/`) — webfont サブセット +
-  自動生成された `package.json` (name, version, files, OFL-1.1 license)。
-  jsDelivr がパッケージのルートから `all.css` とウェイト別 CSS を配信する。
+  自動生成された `package.json` (name, version, files, OFL-1.1 license) と
+  `README.md`。通常の `all.css` / ウェイト別 CSS は npm install 後や
+  セルフホスト向けに相対 WOFF2 URL を使う。`cdn/*.css` は jsDelivr
+  直読み用に、バージョン固定の絶対 WOFF2 URL を使う。
 - **GitHub Pages ミラー** (`dist/release/webfonts/gen-interface-jp/`) —
-  npm と同じ webfont パッケージを、デモサイトの隣に静的ファイルとして配信。
+  webfont CSS / WOFF2 レイアウトの静的ミラーを、デモサイトの隣で配信。
 
 バージョンは `pyproject.toml` (CI では `GITHUB_REF_NAME`) から読む。
 github / npm / webfonts ディレクトリの隣にある `manifest.json` には
@@ -303,7 +323,8 @@ github / npm / webfonts ディレクトリの隣にある `manifest.json` には
 `site/` 配下の Vite 静的サイト。実行時に jsDelivr の npm CDN 経由で公開
 済み webfont パッケージをロードする — つまりライブサイトはサードパーティ
 コンシューマーが使うのと同じ npm 成果物を使い、エンドツーエンドでパッケージ
-の動作確認になる。GitHub Pages のデプロイは `.github/workflows/pages.yml`
+の動作確認になる。サイトは jsDelivr へ直接リンクするため `cdn/*.css` を使う。
+GitHub Pages のデプロイは `.github/workflows/pages.yml`
 で実行。
 
 ## テスト
@@ -328,7 +349,8 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
   feature 削除後の LangSys index 整合性)。
 - **`tests/test_release.py`** — 公開配布の契約: GitHub アセット URL の形
   (サイトのダウンロードボタンが参照)、npm パッケージのレイアウト
-  (`files` glob、`license` メタデータ、CSS エントリポイントの root 配置)。
+  (`files` glob、生成 README、`cdn/*.css` エントリポイント、`license`
+  メタデータ、CSS エントリポイントの root 配置)。
 - **`tests/test_webfont_build.py`** — コードポイント範囲のマージ、
   unicode-range のフォーマット (5 桁含む)、JIS 区 → コードポイント、
   サブセット計画の配置 / 非重複 / 完全カバレッジ、Google-Japanese
@@ -338,7 +360,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
 |---|---|---|
 | `test_font_build.py` | 55 | グリフ名パース、kana / CJK 分類、GSUB 走査、x-scale、bbox 除去、tracking |
 | `test_proportional.py` | 19 | palt 抽出、グリフ平行移動、GPOS feature 削除、3 バケット方針 |
-| `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、CSS root 配置) |
+| `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |
 
 ## コマンド

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -97,6 +97,7 @@ Read dist/ttf/{family}/{family}-{weight}.ttf
       .nam file → human-readable codepoint list
   → emit @font-face per slice with `unicode-range:` guard
   → write all.css (full family) + per-weight CSS files
+    using relative ./w/... WOFF2 URLs for npm/self-hosting
   → manifest.json with sizes / brotli sizes for benchmarking
 ```
 
@@ -105,8 +106,9 @@ Read dist/ttf/{family}/{family}-{weight}.ttf
 ```
 require dist/ttf/ + dist/webfont/gen-interface-jp/
   → zip GenInterfaceJP-<version>.zip (TTF, all weights × both families)
-  → copy webfont package → npm/      (with package.json)
+  → copy webfont package → npm/      (with package.json + README.md)
   → copy webfont package → webfonts/ (Pages-hosted mirror)
+  → add cdn/*.css entrypoints with version-pinned jsDelivr WOFF2 URLs
   → manifest.json with version, tag, asset URLs
 ```
 
@@ -276,6 +278,22 @@ dist/webfont/gen-interface-jp/
   manifest.json          # sizes / brotli sizes per slice
 ```
 
+These source webfont CSS files intentionally use relative `./w/...`
+WOFF2 URLs. `release.build` keeps them for npm installs and self-hosting,
+then writes `cdn/*.css` files whose WOFF2 URLs are absolute,
+version-pinned jsDelivr URLs:
+
+```
+dist/release/npm/
+  all.css
+  cdn/all.css
+  400.css
+  cdn/400.css
+  display-400.css
+  cdn/display-400.css
+  README.md              # documents CDN vs self-host entrypoints
+```
+
 `benchmark.mjs` (Node) replays a throttled fetch against the local
 subsets to validate the slicing pays off vs. a full single-file WOFF2.
 The benchmark generates the full WOFF2 from the Regular TTF on demand
@@ -294,11 +312,13 @@ Three downstream consumers, three outputs:
   flows through the npm subset package below; self-hosters can convert
   TTF→WOFF2 trivially with fontTools.
 - **npm package** (`dist/release/npm/`) — webfont subsets + a generated
-  `package.json` (name, version, files, OFL-1.1 license). jsDelivr serves
-  `all.css` and per-weight CSS from the package root.
+  `package.json` (name, version, files, OFL-1.1 license) and `README.md`.
+  Plain `all.css` / per-weight CSS use relative WOFF2 URLs for npm
+  installs and self-hosting. The `cdn/*.css` files use absolute,
+  version-pinned jsDelivr WOFF2 URLs for direct CDN linking.
 - **GitHub Pages mirror** (`dist/release/webfonts/gen-interface-jp/`) —
-  identical webfont package, served as static files alongside the demo
-  site.
+  static mirror of the webfont CSS / WOFF2 layout, served alongside the
+  demo site.
 
 Version is read from `pyproject.toml` (or `GITHUB_REF_NAME` in CI). The
 `manifest.json` next to the github / npm / webfonts dirs records release
@@ -309,6 +329,8 @@ URLs for downstream tooling.
 Vite static site under `site/`. Loads the published webfont package via
 jsDelivr's npm CDN at runtime — i.e. the live site uses the same npm
 artifact a third-party consumer would, exercising the package end-to-end.
+It uses the `cdn/*.css` entrypoints because the site links directly to
+jsDelivr.
 GitHub Pages deploys the build via `.github/workflows/pages.yml`.
 
 ## Tests
@@ -333,8 +355,8 @@ Tests live under `tests/`, split by surface:
   CFF rejection, LangSys index validity post-removal).
 - **`tests/test_release.py`** — public distribution contracts: GitHub
   asset URL shape (referenced by the site download button), npm package
-  layout including `files` glob and license metadata that jsDelivr /
-  `npm publish` consume.
+  layout including `files` glob, generated README, `cdn/*.css` entrypoints,
+  and license metadata that jsDelivr / `npm publish` consume.
 - **`tests/test_webfont_build.py`** — codepoint range merging, unicode-range
   formatting, JIS row → codepoint mapping, subset plan non-overlap +
   per-bucket placement, Google-Japanese strategy parsing including the
@@ -344,7 +366,7 @@ Tests live under `tests/`, split by surface:
 |---|---|---|
 | `test_font_build.py` | 55 | Glyph-name parsing, kana / CJK classification, GSUB walk, x-scale, bbox strip, tracking |
 | `test_proportional.py` | 19 | palt extraction, glyph translation, GPOS feature removal, three-bucket policy |
-| `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, CSS entrypoints at root) |
+| `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |
 
 ## Commands

--- a/site/README.md
+++ b/site/README.md
@@ -7,7 +7,7 @@ the GitHub Release download entry point.
 The site loads the published web font CSS from npm through jsDelivr:
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/all.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/cdn/all.css">
 ```
 
 Local `dist/ttf/` outputs are not required for site development or

--- a/site/index.html
+++ b/site/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:card" content="summary_large_image" />
 
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gen-interface-jp@%APP_VERSION%/all.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gen-interface-jp@%APP_VERSION%/cdn/all.css" />
   </head>
   <body class="site-loading">
     <div id="root"></div>

--- a/site/src/sections/Variations.tsx
+++ b/site/src/sections/Variations.tsx
@@ -154,10 +154,10 @@ export function Variations() {
 
   const linkFile =
     mode === "all"
-      ? "all.css"
+      ? "cdn/all.css"
       : mode === "normal"
-        ? `${weight}.css`
-        : `display-${weight}.css`;
+        ? `cdn/${weight}.css`
+        : `cdn/display-${weight}.css`;
 
   // Selection-aware underline: hide the underline on `.bitmap-tool__cmd-link`
   // while it (or any part of it) is part of a non-collapsed selection so the

--- a/src/release/README.md
+++ b/src/release/README.md
@@ -116,10 +116,14 @@ directory:
 ```text
 dist/release/npm/
   package.json
+  README.md
   OFL.txt
   all.css
   100.css ... 800.css
   display-100.css ... display-800.css
+  cdn/all.css
+  cdn/100.css ... cdn/800.css
+  cdn/display-100.css ... cdn/display-800.css
   w/normal/.../*.woff2
   w/display/.../*.woff2
 
@@ -128,6 +132,9 @@ dist/release/webfonts/
     all.css
     100.css ... 800.css
     display-100.css ... display-800.css
+    cdn/all.css
+    cdn/100.css ... cdn/800.css
+    cdn/display-100.css ... cdn/display-800.css
     w/normal/.../*.woff2
     w/display/.../*.woff2
 ```
@@ -142,10 +149,22 @@ the public directory. Example CSS path:
 Publishing `dist/release/npm/` to npm makes the jsDelivr URL:
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/all.css">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/400.css">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/display-400.css">
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/cdn/all.css"
+/>
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/cdn/400.css"
+/>
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/cdn/display-400.css"
+/>
 ```
 
-The WOFF2 URLs inside the CSS are relative, so the CSS files and `w/` only need
-to stay together at the package root.
+The plain `.css` files keep relative WOFF2 URLs, so npm installs and
+self-hosted copies only need to keep the CSS files and `w/` together at the
+package root. The `cdn/*.css` files rewrite those WOFF2 URLs to absolute,
+version-pinned jsDelivr URLs for direct CDN linking and for crawlers that
+resolve CSS relative URLs incorrectly.

--- a/src/release/build.py
+++ b/src/release/build.py
@@ -12,9 +12,11 @@ The GitHub zip is the downloadable asset for users who want the TTFs to
 install or to feed into other tools (Illustrator / Figma desktop /
 bitmap converters). The npm directory is laid out so jsDelivr can serve
 /all.css and weight-specific CSS entrypoints directly from the package
-root. Full single-file WOFF2 is intentionally not redistributed — web
-delivery flows through the subset package, and self-hosters can convert
-TTF→WOFF2 trivially with fontTools or pyftsubset.
+root, plus cdn/*.css variants whose WOFF2 URLs are absolute jsDelivr
+URLs for direct CDN linking. Full single-file WOFF2 is intentionally
+not redistributed — web delivery flows through the subset package, and
+self-hosters can convert TTF→WOFF2 trivially with fontTools or
+pyftsubset.
 """
 
 from __future__ import annotations
@@ -36,6 +38,7 @@ DIST_TTF_PATH = Path(DIST_TTF)
 DEFAULT_WEBFONT_SOURCE = ROOT_PATH / "dist" / "webfont" / "gen-interface-jp"
 DEFAULT_RELEASE_DIR = ROOT_PATH / "dist" / "release"
 DEFAULT_REPOSITORY = "yamatoiizuka/gen-interface-jp"
+NPM_PACKAGE_NAME = "gen-interface-jp"
 INTER_OFL = ROOT_PATH / "vendor" / "fonts" / "Inter-4.1" / "LICENSE.txt"
 
 
@@ -148,15 +151,118 @@ def write_npm_license_files(out_dir: Path) -> None:
     (out_dir / "OFL.txt").write_text(ofl_text(), encoding="utf-8")
 
 
+def cdn_base_url(version: str) -> str:
+    return f"https://cdn.jsdelivr.net/npm/{NPM_PACKAGE_NAME}@{version}/"
+
+
+def css_with_cdn_urls(css: str, version: str) -> str:
+    return css.replace('url("./w/', f'url("{cdn_base_url(version)}w/')
+
+
+def write_cdn_css_files(out_dir: Path, version: str) -> list[Path]:
+    """Write CDN-specific CSS entrypoints next to the self-host CSS files.
+
+    The source CSS keeps relative `./w/...` URLs so npm installers and
+    self-hosters can copy the package anywhere. The CDN variants point
+    at the exact version on jsDelivr, matching the Google Fonts hosted
+    CSS shape and avoiding bad relative-URL resolution by crawlers.
+    """
+    written: list[Path] = []
+    cdn_dir = out_dir / "cdn"
+    if cdn_dir.exists():
+        shutil.rmtree(cdn_dir)
+    cdn_dir.mkdir(parents=True, exist_ok=True)
+    for source in sorted(out_dir.glob("*.css")):
+        target = cdn_dir / source.name
+        target.write_text(
+            css_with_cdn_urls(source.read_text(encoding="utf-8"), version),
+            encoding="utf-8",
+        )
+        written.append(target)
+    return written
+
+
+def write_npm_readme(out_dir: Path, version: str) -> None:
+    base_url = cdn_base_url(version)
+    content = f"""# Gen Interface JP
+
+Gen Interface JP is a Japanese/Latin UI typeface built from Inter and
+Noto Sans JP. This package contains unicode-range WOFF2 subsets for web
+use.
+
+## Which CSS Should I Use?
+
+Use the `cdn/*.css` files when linking directly from jsDelivr:
+
+```html
+<link rel="stylesheet" href="{base_url}cdn/400.css">
+<link rel="stylesheet" href="{base_url}cdn/display-800.css">
+```
+
+The CDN CSS files contain absolute WOFF2 URLs such as:
+
+```css
+src: url("{base_url}w/normal/400/000.woff2") format("woff2");
+```
+
+Use the plain `.css` files when installing from npm or self-hosting:
+
+```js
+import "gen-interface-jp/400.css";
+import "gen-interface-jp/display-800.css";
+```
+
+Plain CSS files keep relative WOFF2 URLs:
+
+```css
+src: url("./w/normal/400/000.woff2") format("woff2");
+```
+
+That relative form is correct for browsers and lets bundlers, local
+servers, and self-hosted deployments keep the CSS and `w/` directory
+together without depending on jsDelivr.
+
+## Entry Points
+
+- `all.css`: self-host all weights and both families.
+- `100.css` ... `800.css`: self-host Gen Interface JP.
+- `display-100.css` ... `display-800.css`: self-host Gen Interface JP Display.
+
+- `cdn/all.css`: jsDelivr all weights and both families.
+- `cdn/100.css` ... `cdn/800.css`: jsDelivr Gen Interface JP.
+- `cdn/display-100.css` ... `cdn/display-800.css`: jsDelivr Gen Interface JP Display.
+
+## Font Families
+
+```css
+body {{
+  font-family: "Gen Interface JP", sans-serif;
+}}
+
+h1 {{
+  font-family: "Gen Interface JP Display", sans-serif;
+}}
+```
+
+## License
+
+Generated fonts are licensed under the SIL Open Font License 1.1. See
+`OFL.txt`.
+"""
+    (out_dir / "README.md").write_text(content, encoding="utf-8")
+
+
 def write_npm_package(out_dir: Path, version: str, repository: str) -> None:
     package = {
-        "name": "gen-interface-jp",
+        "name": NPM_PACKAGE_NAME,
         "version": version,
         "description": "Gen Interface JP web font subsets",
         "style": "all.css",
         "files": [
             "*.css",
+            "cdn",
             "manifest.json",
+            "README.md",
             "OFL.txt",
             "w",
         ],
@@ -167,7 +273,10 @@ def write_npm_package(out_dir: Path, version: str, repository: str) -> None:
         "homepage": f"https://github.com/{repository}",
         "license": "OFL-1.1",
     }
-    (out_dir / "package.json").write_text(json.dumps(package, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    (out_dir / "package.json").write_text(
+        json.dumps(package, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
 
 
 def asset_filename(version: str) -> str:
@@ -222,9 +331,12 @@ def build_release(args: argparse.Namespace) -> dict:
     )
     source = args.webfont_source.resolve()
     copy_webfont_package(source, npm_dir, include_nam=False)
+    write_cdn_css_files(npm_dir, version)
     write_npm_license_files(npm_dir)
+    write_npm_readme(npm_dir, version)
     write_npm_package(npm_dir, version, args.repository)
     copy_webfont_package(source, webfont_out)
+    write_cdn_css_files(webfont_out, version)
 
     manifest = {
         "version": version,
@@ -234,7 +346,9 @@ def build_release(args: argparse.Namespace) -> dict:
         "webfonts": {
             "npmPackage": "npm",
             "npmAllCss": "npm/all.css",
+            "npmAllCdnCss": "npm/cdn/all.css",
             "staticAllCss": "webfonts/gen-interface-jp/all.css",
+            "staticAllCdnCss": "webfonts/gen-interface-jp/cdn/all.css",
         },
     }
     manifest_path = release_dir / "manifest.json"

--- a/src/webfont/README.md
+++ b/src/webfont/README.md
@@ -59,21 +59,27 @@ subsets.
 
 ## Loading
 
-Subset delivery:
+For direct jsDelivr loading, use the `cdn/*.css` entrypoints emitted by
+the release package. They contain absolute WOFF2 URLs pinned to the
+package version:
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/all.css">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/400.css">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/display-400.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/cdn/all.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/cdn/400.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/cdn/display-400.css">
 ```
+
+For npm installs and self-hosting, use the plain `.css` files. They keep
+relative `./w/...` URLs so the CSS and `w/` directory can be copied or
+bundled together without depending on jsDelivr.
 
 Do not preload individual subset WOFF2 files. That would bypass the
 `unicode-range` behavior that lets the browser fetch only the ranges used by
 the page text. If preloading is needed, preload the CSS only:
 
 ```html
-<link rel="preload" as="style" href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/all.css">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/all.css">
+<link rel="preload" as="style" href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/cdn/all.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gen-interface-jp@latest/cdn/all.css">
 ```
 
 ## Benchmark

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -14,7 +14,13 @@ the test outweighs the protection.
 
 import json
 
-from release.build import copy_webfont_package, github_asset_urls, write_npm_package
+from release.build import (
+    copy_webfont_package,
+    github_asset_urls,
+    write_cdn_css_files,
+    write_npm_package,
+    write_npm_readme,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -34,7 +40,10 @@ def test_github_asset_urls_are_stable_for_site_downloads():
     download time.
     """
     urls = github_asset_urls("owner/repo", "v1.2.3", "1.2.3")
-    assert urls["bundle"] == "https://github.com/owner/repo/releases/download/v1.2.3/GenInterfaceJP-1.2.3.zip"
+    assert (
+        urls["bundle"]
+        == "https://github.com/owner/repo/releases/download/v1.2.3/GenInterfaceJP-1.2.3.zip"
+    )
     # No latestBundle: a versioned filename can't reliably resolve via
     # `latest/download/`, so the surface is intentionally tag-only.
     assert "latestBundle" not in urls
@@ -46,10 +55,10 @@ def test_github_asset_urls_are_stable_for_site_downloads():
 
 def test_copy_webfont_package_keeps_css_entrypoints_at_package_root(tmp_path):
     """jsDelivr serves the npm package as static files. Consumers reference
-    `…/gen-interface-jp/all.css` and per-weight CSS like `400.css` /
-    `display-400.css` directly from the package root — moving them into a
-    subdirectory or renaming them is a breaking change in the public CDN
-    URL space.
+    `.../gen-interface-jp/all.css` and per-weight CSS like `400.css` /
+    `display-400.css` directly from the package root, with `cdn/*.css`
+    variants for direct jsDelivr use. Moving them or renaming them is a
+    breaking change in the public CDN URL space.
 
     This test stages a minimal source tree, runs the same copy + package
     write that `release.build` performs, and asserts the resulting npm
@@ -61,25 +70,50 @@ def test_copy_webfont_package_keeps_css_entrypoints_at_package_root(tmp_path):
     source = tmp_path / "source"
     (source / "w" / "normal" / "400").mkdir(parents=True)
     (source / "nam").mkdir()
-    (source / "all.css").write_text("@font-face{}", encoding="utf-8")
-    (source / "400.css").write_text("@font-face{}", encoding="utf-8")
-    (source / "display-400.css").write_text("@font-face{}", encoding="utf-8")
+    (source / "all.css").write_text(
+        'src:url("./w/normal/400/000.woff2")',
+        encoding="utf-8",
+    )
+    (source / "400.css").write_text(
+        'src:url("./w/normal/400/000.woff2")',
+        encoding="utf-8",
+    )
+    (source / "display-400.css").write_text(
+        'src:url("./w/display/400/000.woff2")',
+        encoding="utf-8",
+    )
     (source / "manifest.json").write_text("{}", encoding="utf-8")
     (source / "nam" / "000.nam").write_text("0x20\n", encoding="utf-8")
     (source / "w" / "normal" / "400" / "000.woff2").write_bytes(b"woff2")
 
     out_dir = tmp_path / "npm"
-    copy_webfont_package(source, out_dir)
+    copy_webfont_package(source, out_dir, include_nam=False)
+    write_cdn_css_files(out_dir, "1.2.3")
+    write_npm_readme(out_dir, "1.2.3")
     write_npm_package(out_dir, "1.2.3", "owner/repo")
 
-    # Public CSS entrypoints stay at package root (jsDelivr-served paths).
+    # Public CSS entrypoints stay at package root.
     assert (out_dir / "all.css").is_file()
     assert (out_dir / "400.css").is_file()
     assert (out_dir / "display-400.css").is_file()
+    assert (out_dir / "cdn" / "all.css").is_file()
+    assert (out_dir / "cdn" / "400.css").is_file()
+    assert (out_dir / "cdn" / "display-400.css").is_file()
 
     # WOFF2 chunks live under w/{family}/{weight}/ — referenced by
     # `src: url("./w/normal/400/000.woff2")` from the CSS files.
     assert (out_dir / "w" / "normal" / "400" / "000.woff2").is_file()
+    assert 'url("./w/normal/400/000.woff2")' in (out_dir / "400.css").read_text(
+        encoding="utf-8"
+    )
+    assert (
+        'url("https://cdn.jsdelivr.net/npm/gen-interface-jp@1.2.3/w/normal/400/000.woff2")'
+        in (out_dir / "cdn" / "400.css").read_text(encoding="utf-8")
+    )
+    assert (
+        'url("https://cdn.jsdelivr.net/npm/gen-interface-jp@1.2.3/w/display/400/000.woff2")'
+        in (out_dir / "cdn" / "display-400.css").read_text(encoding="utf-8")
+    )
 
     package = json.loads((out_dir / "package.json").read_text(encoding="utf-8"))
     assert package["name"] == "gen-interface-jp"
@@ -91,8 +125,17 @@ def test_copy_webfont_package_keeps_css_entrypoints_at_package_root(tmp_path):
     # globs would publish an empty / broken package even if the local
     # build directory looked right.
     assert "*.css" in package["files"]
+    assert "cdn" in package["files"]
     assert "manifest.json" in package["files"]
+    assert "README.md" in package["files"]
     assert "w" in package["files"]
+    readme = (out_dir / "README.md").read_text(encoding="utf-8")
+    assert "cdn/400.css" in readme
+    assert "400.css" in readme
+    assert (
+        "https://cdn.jsdelivr.net/npm/gen-interface-jp@1.2.3/w/normal/400/000.woff2"
+        in readme
+    )
     # OFL.txt rides alongside the package as part of the OFL §2
     # "include this license" requirement for redistribution.
     assert "OFL.txt" in package["files"]


### PR DESCRIPTION
## Summary

- add CDN-specific webfont CSS entrypoints under `cdn/*.css` while keeping root CSS files for npm install and self-hosting
- generate npm README guidance that separates root self-host entrypoints from `cdn/` jsDelivr entrypoints
- update site examples, docs, and release tests for the new `cdn/` package layout

## Why

Root CSS entrypoints use relative `./w/...` WOFF2 URLs, which are correct for browsers and important for npm/self-host consumers. The new `cdn/*.css` files use version-pinned absolute jsDelivr WOFF2 URLs for direct CDN linking and for crawlers that resolve CSS relative URLs incorrectly.

## Validation

- `PYTHONPATH=src python3 -m pytest -q` -> 135 passed
- `npm run build` in `site/` -> passed
- `PYTHONPATH=src python3 -m release.build` -> passed
