### PR TITLE
[codex] Fix Noto symbol spacing policy

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -23,8 +23,9 @@ Gen Interface JP はフォントビルドパイプライン (アプリ/UI なし
         │         metadataMode=inheritBase                │
         │             ↓                                   │
         │   [2/3] Proportionalise — proportional.py       │
-        │         palt → hmtx (3 バケット方針)              │
-        │         tracking + 極端な bbox の除去              │
+        │         palt → hmtx (2 バケット方針)              │
+        │         tracking (連続記号は除外)              │
+        │         + 極端な bbox の除去                    │
         │             ↓                                   │
         │   [3/3] Merge — font-baker                      │
         │         Inter (sub) + proportional Noto (base)  │
@@ -67,13 +68,14 @@ FAMILIES × WEIGHTS の各組合せに対して:
                     inheritBase で designer/OFL/version を継承
                     weight だけを上書き
   → inst を再読込し、キャッシュした variable から palt 取得
-  → グリフを kana letters / reduced palt / squeeze SB に分類
-    (CJK 漢字と vert-only グリフは除外)
+  → palt グリフを kana letters / reduced palt に分類
+    (CJK 漢字、vert-only グリフ、palt なしグリフはメトリクス維持)
   → make_proportional で palt → hmtx に焼き込み
     palt/vpal/halt/vhal 削除
   → _apply_tracking で advance を広げ LSB を半分シフト
+    ただし family["trackingIgnore"] の連続・隙間なし記号は除外
   → _apply_glyph_spacing で family["glyphSpacing"] の個別調整を適用
-  → _strip_extreme_glyphs で繰り返し記号 〱〲 を無効化
+  → _strip_extreme_glyphs で縦組み用繰り返し記号 〱-〵 を無効化
     (yMax > 1200 / yMin < -400)
   → font-baker merge: Inter + proportional Noto
                      subFont.excludeCodepoints = SUB_EXCLUDE_CODEPOINTS で
@@ -133,16 +135,25 @@ inst に対して 4 つのサブパスを in-place で実行:
 1. **palt のベイク** (`proportional.make_proportional`) — palt 値は
    キャッシュ済みの variable から読む (instantiation で非デフォルト軸位置の
    palt ValueRecord が壊れることがあるため)。XPlacement / XAdvance を
-   LSB / advance に加算しアウトラインをシフト。3 バケット:
+   LSB / advance に加算しアウトラインをシフト。palt は 2 バケット:
    - **kana letters** — palt 全量
    - **reduced palt** (句読点等、デフォルト ⅓) — palt 対象だが kana letter
      ではないグリフ
-   - **squeeze SB** — palt 非対象、非 kana、非 CJK、非 vertical なグリフ;
-     LSB と RSB をそれぞれ `1 - squeeze_sb_scale` 分縮める
-   CJK 漢字と `vert` / `vrt2` の代替グリフは除外 — 全角メトリクスを保つ。
+   palt なしグリフは自動的に sidebearing を詰めない; 後続の明示的な
+   spacing ルールが触らない限り元の `hmtx` を維持する。CJK 漢字と
+   `vert` / `vrt2` の代替グリフは reduced palt から除外 — 全角メトリクスを保つ。
 2. **トラッキング** (`_apply_tracking`) — advance を `tracking` 分広げ、
    `tracking // 2` を LSB に加算してアウトラインを広がった枠の中央に
    配置。kana / 句読点はファミリー設定の `trackingKana` で別値。
+   `trackingIgnore` はコードポイント / 範囲を受け取り、cmap で解決した
+   グリフを完全にスキップする。デフォルトでは Noto の tracking stage で
+   Box Drawing (`U+2500-U+257F`)、Block Elements (`U+2580-U+259F`)、
+   2 点 / 中点 leader (`U+2025`, `U+22EF`)、中黒 (`U+30FB`, `U+FF65`)、
+   `U+3030`、
+   縦組み・互換 leader 形式 (`U+FE19`, `U+FE30-U+FE34`,
+   `U+FE49-U+FE4F`)、two-/three-em dash (`U+2E3A`, `U+2E3B`)、全角
+   low line (`U+FF3F`)、全角 macron (`U+FFE3`) を除外し、隙間なしで
+   反復される記号のリズムを保つ。
 3. **個別グリフのスペーシング** (`_apply_glyph_spacing`) — palt + 一律
    トラッキングだけでは追い込めない稀なグリフのための手動レイヤー。
    ファミリー設定の `glyphSpacing` がコードポイント (または 1 文字) を
@@ -213,14 +224,21 @@ Inter の Latin 専用挙動 (各行のグリフに応じた行高動的調整) 
 
 ### 削除するグリフ
 
-`_strip_extreme_glyphs` は `yMax > 1200` または `yMin < -400` (em = 1000
-基準) のグリフを無効化する。Noto Sans JP では実質、縦組み用イテレーション
-マークと `vert` / `vrt2` 代替に限定される。
+`_strip_extreme_glyphs` は縦組み用イテレーションマーク `U+3031-U+3035`
+を明示的に無効化し、さらに `yMax > 1200` または `yMin < -400`
+(em = 1000 基準) のグリフも無効化する。Noto Sans JP で bbox の外れ値に
+なるのは全形の縦組み用イテレーションマークと `vert` / `vrt2` 代替。
+上半分/下半分の名残 (`〳〴〵`) は bbox としては外れ値ではないが、横組み
+テキスト内で Adobe の Japanese コンポーザーを混乱させるため、コードポイント
+指定で削除する。
 
 | Glyph | Codepoint | 削除理由 |
 |---|---|---|
 | `uni3031` 〱 | U+3031 | 縦組み用繰り返し記号 |
 | `uni3032` 〲 | U+3032 | 縦組み用濁点付き繰り返し記号 |
+| `uni3033` 〳 | U+3033 | 縦組み用繰り返し記号の上半分 |
+| `uni3034` 〴 | U+3034 | 縦組み用濁点付き繰り返し記号の上半分 |
+| `uni3035` 〵 | U+3035 | 縦組み用繰り返し記号の下半分 |
 | (vert alternate) | (unmapped) | `uni3031` の vert/vrt2 代替 |
 | (vert alternate) | (unmapped) | `uni3032` の vert/vrt2 代替 |
 
@@ -345,8 +363,9 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
   `_apply_tracking`, `_get_variable_palt`。
 - **`tests/test_proportional.py`** — `_read_palt`, `_shift_glyph_x`,
   `_remove_prop_features`, `make_proportional` (palt ベイク、reduced palt
-  scale、squeeze SB の sidebearing 計算、palt_override の優先、CFF 拒否、
-  feature 削除後の LangSys index 整合性)。
+  scale、palt なしグリフのメトリクス維持、オプションの squeeze SB
+  sidebearing 計算、palt_override の優先、CFF 拒否、feature 削除後の
+  LangSys index 整合性)。
 - **`tests/test_release.py`** — 公開配布の契約: GitHub アセット URL の形
   (サイトのダウンロードボタンが参照)、npm パッケージのレイアウト
   (`files` glob、生成 README、`cdn/*.css` エントリポイント、`license`
@@ -358,8 +377,8 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 55 | グリフ名パース、kana / CJK 分類、GSUB 走査、x-scale、bbox 除去、tracking |
-| `test_proportional.py` | 19 | palt 抽出、グリフ平行移動、GPOS feature 削除、3 バケット方針 |
+| `test_font_build.py` | 76 | グリフ名パース、kana / CJK 分類、GSUB 走査、x-scale、bbox 除去、tracking |
+| `test_proportional.py` | 20 | palt 抽出、グリフ平行移動、GPOS feature 削除、2 バケット palt 方針 + optional squeeze helper |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,8 +23,9 @@ consumes the published webfont package.
         │         metadataMode=inheritBase                │
         │             ↓                                   │
         │   [2/3] Proportionalise — proportional.py       │
-        │         palt → hmtx (three-bucket policy)       │
-        │         tracking + strip extreme bbox           │
+        │         palt → hmtx (two-bucket policy)         │
+        │         tracking (with repeatable skips)        │
+        │         + strip extreme bbox                    │
         │             ↓                                   │
         │   [3/3] Merge — font-baker                      │
         │         Inter (sub) + proportional Noto (base)  │
@@ -67,12 +68,13 @@ For each (family, weight) in FAMILIES × WEIGHTS:
                     inheritBase passes designer/OFL/version
                     through; only weight is stamped
   → reload inst, read palt from cached variable font
-  → split glyphs into kana letters / reduced palt / squeeze SB
-    (CJK ideographs and vert-only glyphs excluded)
+  → split palt glyphs into kana letters / reduced palt
+    (CJK ideographs, vert-only glyphs, and non-palt glyphs keep metrics)
   → make_proportional bakes palt → hmtx, strips palt/vpal/halt/vhal
   → _apply_tracking widens advances + half-balances LSB
+    except repeatable no-gap symbols in family["trackingIgnore"]
   → _apply_glyph_spacing applies family["glyphSpacing"] sidebearing tweaks
-  → _strip_extreme_glyphs neutralises iteration marks 〱〲
+  → _strip_extreme_glyphs neutralises vertical iteration marks 〱-〵
     (yMax > 1200 / yMin < -400)
   → font-baker merge: Inter + proportional Noto
                      subFont.excludeCodepoints = SUB_EXCLUDE_CODEPOINTS
@@ -131,18 +133,26 @@ Four sub-passes, all in-place on the inst:
 1. **palt baking** (`proportional.make_proportional`) — palt values are
    read from the cached variable font (instantiation can corrupt palt's
    ValueRecords at non-default axis positions). XPlacement/XAdvance pairs
-   are added to LSB / advance, outlines shifted. Three buckets:
+   are added to LSB / advance, outlines shifted. Two palt buckets:
    - **kana letters** — full palt shrink
    - **reduced palt** (punctuation, by default ⅓ scale) — palt glyphs
      that aren't kana letters
-   - **squeeze SB** — non-palt, non-kana, non-CJK, non-vertical glyphs;
-     LSB and RSB each shrink by `1 - squeeze_sb_scale`
-   CJK ideographs and `vert`/`vrt2` alternates are excluded — they keep
-   full-width metrics.
+   Glyphs without palt entries are not automatically sidebearing-squeezed;
+   they keep their original `hmtx` unless a later explicit spacing rule
+   touches them. CJK ideographs and `vert`/`vrt2` alternates are excluded
+   from reduced palt — they keep full-width metrics.
 2. **Tracking** (`_apply_tracking`) — advance grows by `tracking`;
    `tracking // 2` is added to LSB so the outline sits centred in the
    wider slot. Kana / punctuation get a separate `trackingKana` value
-   when set on the family.
+   when set on the family. `trackingIgnore` accepts codepoints / ranges
+   and skips glyphs resolved through cmap. The default ignore list keeps
+   the Noto tracking stage from widening Box Drawing (`U+2500-U+257F`),
+   Block Elements (`U+2580-U+259F`), two-dot / midline leaders
+   (`U+2025`, `U+22EF`),
+   middle dots (`U+30FB`, `U+FF65`), `U+3030`, vertical/compat leader
+   forms (`U+FE19`, `U+FE30-U+FE34`, `U+FE49-U+FE4F`), two-/three-em
+   dashes (`U+2E3A`, `U+2E3B`), fullwidth low line (`U+FF3F`), and
+   fullwidth macron (`U+FFE3`).
 3. **Per-glyph spacing** (`_apply_glyph_spacing`) — manual fallback for
    the rare glyph whose sidebearings still read off after palt + uniform
    tracking. The family's `glyphSpacing` dict maps a codepoint or
@@ -216,14 +226,21 @@ of new text frames.
 
 ### Stripped glyphs
 
-`_strip_extreme_glyphs` neutralises any glyph with `yMax > 1200` or
-`yMin < -400` (em = 1000 baseline). In Noto Sans JP these are exclusively
-the vertical-text iteration marks and their `vert` / `vrt2` alternates.
+`_strip_extreme_glyphs` neutralises vertical-text iteration marks
+`U+3031-U+3035` explicitly, plus any glyph with `yMax > 1200` or
+`yMin < -400` (em = 1000 baseline). In Noto Sans JP the bbox outliers are
+the full vertical iteration marks and their `vert` / `vrt2` alternates;
+the upper/lower-half remnants (`〳〴〵`) are removed by codepoint because
+they are vertical-only and can confuse Adobe's Japanese composer in
+horizontal text.
 
 | Glyph | Codepoint | Reason |
 |---|---|---|
 | `uni3031` 〱 | U+3031 | Vertical kana repeat mark |
 | `uni3032` 〲 | U+3032 | Vertical voiced repeat mark |
+| `uni3033` 〳 | U+3033 | Vertical kana repeat mark upper half |
+| `uni3034` 〴 | U+3034 | Vertical voiced repeat mark upper half |
+| `uni3035` 〵 | U+3035 | Vertical kana repeat mark lower half |
 | (vert alternate) | (unmapped) | `uni3031` rotated form |
 | (vert alternate) | (unmapped) | `uni3032` rotated form |
 
@@ -351,8 +368,9 @@ Tests live under `tests/`, split by surface:
   `_apply_tracking`, `_get_variable_palt`.
 - **`tests/test_proportional.py`** — `_read_palt`, `_shift_glyph_x`,
   `_remove_prop_features`, `make_proportional` (palt baking, reduced
-  palt scaling, squeeze SB sidebearing math, palt_override precedence,
-  CFF rejection, LangSys index validity post-removal).
+  palt scaling, non-palt metric preservation, optional squeeze SB
+  sidebearing math, palt_override precedence, CFF rejection, LangSys
+  index validity post-removal).
 - **`tests/test_release.py`** — public distribution contracts: GitHub
   asset URL shape (referenced by the site download button), npm package
   layout including `files` glob, generated README, `cdn/*.css` entrypoints,
@@ -364,8 +382,8 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 55 | Glyph-name parsing, kana / CJK classification, GSUB walk, x-scale, bbox strip, tracking |
-| `test_proportional.py` | 19 | palt extraction, glyph translation, GPOS feature removal, three-bucket policy |
+| `test_font_build.py` | 76 | Glyph-name parsing, kana / CJK classification, GSUB walk, x-scale, bbox strip, tracking |
+| `test_proportional.py` | 20 | palt extraction, glyph translation, GPOS feature removal, two-bucket palt policy + optional squeeze helper |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |
 

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -26,7 +26,7 @@ import os
 import sys
 
 from fontTools.ttLib import TTFont
-from merge_fonts import merge_fonts
+from merge_fonts import merge_fonts, parse_codepoint_list
 from .proportional import make_proportional
 
 
@@ -53,12 +53,33 @@ WEIGHTS = [
     (800, "ExtraBold",   900),
 ]
 
+# Noto-sourced glyphs that should keep their original advance during the
+# tracking pass. These characters are normally repeated or tiled, so adding
+# artificial sidebearings breaks the intended no-gap rhythm.
+TRACKING_IGNORE_CODEPOINTS = (
+    "U+2500-U+257F",   # Box Drawing
+    "U+2580-U+259F",   # Block Elements
+    "U+2025",          # ‥ TWO DOT LEADER
+    "U+22EF",          # ⋯ MIDLINE HORIZONTAL ELLIPSIS
+    "U+30FB",          # ・ KATAKANA MIDDLE DOT
+    "U+3030",          # 〰 WAVY DASH
+    "U+FE19",          # ︙ PRESENTATION FORM FOR VERTICAL HORIZONTAL ELLIPSIS
+    "U+FE30-U+FE34",   # ︰ ︱ ︲ ︳ ︴
+    "U+FE49-U+FE4F",   # ﹉ ﹊ ﹋ ﹌ ﹍ ﹎ ﹏
+    "U+FF65",          # ･ HALFWIDTH KATAKANA MIDDLE DOT
+    "U+2E3A",          # ⸺ TWO-EM DASH
+    "U+2E3B",          # ⸻ THREE-EM DASH
+    "U+FF3F",          # ＿ FULLWIDTH LOW LINE
+    "U+FFE3",          # ￣ FULLWIDTH MACRON
+)
+
 FAMILIES = {
     "normal": {
         "familyName": "Gen Interface JP",
         "interPrefix": "Inter",
         "tracking": 30,
         "trackingKana": 40,
+        "trackingIgnore": TRACKING_IGNORE_CODEPOINTS,
         "halfPaltPunct": True,
         "folderPrefix": "GenInterfaceJP",
         # Per-glyph sidebearing tweaks applied after tracking. Map a
@@ -75,6 +96,7 @@ FAMILIES = {
         "interPrefix": "InterDisplay",
         "tracking": 0,
         "trackingKana": 0,
+        "trackingIgnore": TRACKING_IGNORE_CODEPOINTS,
         "halfPaltPunct": True,
         "folderPrefix": "GenInterfaceJPDisplay",
         "glyphSpacing": {
@@ -415,17 +437,18 @@ def _scale_gpos_x(st, scale: float) -> None:
 # glyphs we want to neutralise.
 _EXTREME_YMAX = 1200
 _EXTREME_YMIN = -400
+_VERTICAL_REPEAT_MARK_CODEPOINTS = tuple(range(0x3031, 0x3036))
 
 
 def _strip_extreme_glyphs(font: TTFont) -> None:
-    """Neutralise glyphs whose bbox extends far beyond the em-square.
+    """Neutralise vertical-only repeat marks and bbox outliers.
 
-    Targets vertical-text-only glyphs (kana iteration marks 〱〲 and their
-    vert/vrt2 alternates) that inflate head.yMax/yMin. Illustrator's text
-    frame auto-sizing reads head bbox, so these outliers force frames to
-    open with several extra hundred units of vertical padding even on a
-    short string of plain Latin. Acceptable trade-off for a horizontal-only
-    UI font: vertical typesetting is out of scope (see CLAUDE.md).
+    Targets vertical-text-only glyphs (kana iteration marks 〱〲〳〴〵 and
+    their vert/vrt2 alternates). The extreme full-form glyphs inflate
+    head.yMax/yMin, and the upper/lower-half remnants can confuse Adobe's
+    Japanese composer when pasted into horizontal text. Acceptable trade-off
+    for a horizontal-only UI font: vertical typesetting is out of scope
+    (see CLAUDE.md).
 
     Removing the glyph slots outright would shift every later index in
     GSUB / GPOS lookups. Instead we keep the slot in place and only
@@ -438,6 +461,12 @@ def _strip_extreme_glyphs(font: TTFont) -> None:
     glyf = font["glyf"]
     hmtx = font["hmtx"]
     to_remove = set()
+    cmap = font.getBestCmap() or {}
+    to_remove.update(
+        glyph_name
+        for cp, glyph_name in cmap.items()
+        if cp in _VERTICAL_REPEAT_MARK_CODEPOINTS
+    )
     for gname in font.getGlyphOrder():
         g = glyf[gname]
         if g.numberOfContours == 0:
@@ -479,7 +508,29 @@ def _strip_extreme_glyphs(font: TTFont) -> None:
 # Tracking
 # ---------------------------------------------------------------------------
 
-def _apply_tracking(font: TTFont, tracking: int, tracking_kana: int | None = None) -> None:
+def _tracking_ignore_glyphs(
+    font: TTFont,
+    tracking_ignore: list | tuple | set | None,
+) -> set[str]:
+    """Resolve tracking-ignore codepoints to glyph names via cmap."""
+    if not tracking_ignore:
+        return set()
+    entries = (
+        tuple(tracking_ignore)
+        if isinstance(tracking_ignore, set)
+        else tracking_ignore
+    )
+    codepoints = parse_codepoint_list(entries)
+    cmap = font.getBestCmap() or {}
+    return {glyph_name for cp, glyph_name in cmap.items() if cp in codepoints}
+
+
+def _apply_tracking(
+    font: TTFont,
+    tracking: int,
+    tracking_kana: int | None = None,
+    tracking_ignore: list | tuple | set | None = None,
+) -> None:
     """Widen every glyph's advance width and split the gap evenly L/R.
 
     Adding tracking to a glyph means growing its advance by ``t`` and
@@ -497,11 +548,19 @@ def _apply_tracking(font: TTFont, tracking: int, tracking_kana: int | None = Non
     families use this to give kana and punctuation a slightly looser
     rhythm than Latin — kana need more breathing room at small sizes
     to remain legible against the denser Han ideographs.
+
+    *tracking_ignore* accepts the same codepoint entry forms as font-baker's
+    excludeCodepoints config (e.g. ``"U+2500-U+257F"`` or ``0x3030``).
+    Matching cmap glyphs are skipped entirely, preserving no-gap rhythm for
+    box drawing, block elements, leaders, and similar repeatable symbols.
     """
     hmtx = font["hmtx"]
+    ignore_glyphs = _tracking_ignore_glyphs(font, tracking_ignore)
     for glyph_name in font.getGlyphOrder():
         aw, lsb = hmtx[glyph_name]
         if aw == 0:
+            continue
+        if glyph_name in ignore_glyphs:
             continue
         t = tracking
         if tracking_kana is not None and _is_kana_or_punct(glyph_name):
@@ -641,6 +700,7 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     # ── Step 2: Convert to proportional + apply tracking ──
     tracking = family["tracking"]
     tracking_kana = family["trackingKana"]
+    tracking_ignore = family.get("trackingIgnore")
     half_palt_punct = family.get("halfPaltPunct", False)
 
     desc = f"tracking +{tracking}"
@@ -658,19 +718,16 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     # is canonical across all weights.
     palt_data = _get_variable_palt()
 
-    # Three-bucket policy for proportional metrics, only active when
+    # Two-bucket policy for proportional metrics, only active when
     # ``halfPaltPunct`` is set on the family:
     #   - kana letters: keep the full palt shrink (unchanged below)
     #   - reduced_palt: glyphs that have palt entries but aren't kana
     #     letters — typically punctuation. These get a fraction of the
     #     full palt shift so punctuation doesn't pull as tight as kana.
-    #   - squeeze_sb: glyphs without palt at all — non-kana, non-CJK,
-    #     non-vertical. We squeeze their sidebearings by the same ratio
-    #     so the rhythm stays consistent across the whole font.
-    # CJK ideographs and vertical-only glyphs are excluded from both
-    # buckets — they keep full-width metrics (see CLAUDE.md).
+    # Glyphs without palt entries keep their original hmtx. CJK ideographs
+    # and vertical-only glyphs are excluded from reduced_palt — they keep
+    # full-width metrics (see CLAUDE.md).
     reduced_palt_glyphs = None
-    squeeze_sb_glyphs = None
     if half_palt_punct:
         palt_glyphs = set(palt_data.keys())
         vert_glyphs = _get_vert_alternates(font)
@@ -680,20 +737,13 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
             g for g in palt_glyphs
             if not _is_kana_letter(g) and g not in exclude
         }
-        squeeze_sb_glyphs = {
-            g for g in font.getGlyphOrder()
-            if g not in palt_glyphs
-            and g not in exclude
-            and not _is_kana_letter(g)
-        }
 
     make_proportional(
         font,
         reduced_palt=reduced_palt_glyphs,
-        squeeze_sb=squeeze_sb_glyphs,
         palt_override=palt_data,
     )
-    _apply_tracking(font, tracking, tracking_kana)
+    _apply_tracking(font, tracking, tracking_kana, tracking_ignore)
     spacing_adjusted = _apply_glyph_spacing(font, family.get("glyphSpacing"))
     if spacing_adjusted:
         print(f"          Per-glyph spacing: {spacing_adjusted} glyph(s) adjusted")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,12 +44,13 @@ NOTO_VARIABLE_PATH = REPO / "vendor" / "fonts" / "Noto_Sans_JP" / "NotoSansJP-Va
 #   - CJK punctuation (U+3001 、, U+3002 。, U+30FB ・)
 #   - CJK ideographs (U+4E00 一, U+6F22 漢)
 #   - Latin (U+0041 A, U+0061 a)
-#   - Iteration marks (U+3031 〱, U+3032 〲) — extreme bbox
+#   - Vertical iteration marks (U+3031 〱 .. U+3035 〵)
 #   - CJK-symbol numerals (U+3038 〸) — _is_cjk_codepoint boundary case
 _TEST_CODEPOINTS = [
     0x0020, 0x0041, 0x0061,   # space, A, a
     0x3001, 0x3002, 0x3000,   # 、 。 ideographic space (CJK punct)
     0x3031, 0x3032,           # 〱 〲 iteration marks (extreme bbox)
+    0x3033, 0x3034, 0x3035,   # 〳 〴 〵 iteration remnants (non-extreme)
     0x3038,                   # 〸 CJK numerals (range 3038..303B)
     0x3042, 0x304B,           # あ か (hiragana letters)
     0x30A2, 0x30AB,           # ア カ (katakana letters)
@@ -104,8 +105,10 @@ def _build_synthetic_ttf() -> TTFont:
 
     Glyph repertoire:
         .notdef, A (Latin), uni3042 (kana), uni30A2 (kana), uni4E00 (CJK),
-        uni3001 (CJK punct), uni3031 (extreme-bbox iteration mark),
-        uni3031.vert (vert alternate, also extreme-bbox)
+        uni2500 (box drawing), uni3001 (CJK punct), uni3030 (wavy dash),
+        uni3031 (extreme-bbox iteration mark), uni3033/uni3034/uni3035
+        (vertical iteration remnants), uni30FB (middle dot), uni3031.vert
+        (vert alternate, also extreme-bbox)
 
     Each glyph carries a simple square outline at varying sizes so that
     advance widths, sidebearings, bbox extents, and composite handling
@@ -121,8 +124,14 @@ def _build_synthetic_ttf() -> TTFont:
         "uni3042",
         "uni30A2",
         "uni4E00",
+        "uni2500",
         "uni3001",
+        "uni3030",
         "uni3031",
+        "uni3033",
+        "uni3034",
+        "uni3035",
+        "uni30FB",
         "uni3031.vert",
         "compositeA",  # composite of "A" — for _shift_glyph_x composite branch
     ]
@@ -132,8 +141,14 @@ def _build_synthetic_ttf() -> TTFont:
         0x3042: "uni3042",
         0x30A2: "uni30A2",
         0x4E00: "uni4E00",
+        0x2500: "uni2500",
         0x3001: "uni3001",
+        0x3030: "uni3030",
         0x3031: "uni3031",
+        0x3033: "uni3033",
+        0x3034: "uni3034",
+        0x3035: "uni3035",
+        0x30FB: "uni30FB",
     })
 
     def _square(x_min: int, y_min: int, x_max: int, y_max: int) -> "Glyph":
@@ -151,9 +166,15 @@ def _build_synthetic_ttf() -> TTFont:
         "uni3042": _square(50, 0, 950, 800),
         "uni30A2": _square(50, 0, 950, 800),
         "uni4E00": _square(0, 0, 1000, 800),
+        "uni2500": _square(0, 390, 1000, 450),
         "uni3001": _square(50, 0, 450, 200),
+        "uni3030": _square(0, 360, 1000, 500),
         # yMax = 1500 → past _EXTREME_YMAX, will be stripped
         "uni3031": _square(50, -500, 950, 1500),
+        "uni3033": _square(180, -120, 700, 820),
+        "uni3034": _square(180, -120, 870, 820),
+        "uni3035": _square(190, -50, 750, 880),
+        "uni30FB": _square(400, 300, 600, 500),
         # vert alternate of 3031 — also extreme
         "uni3031.vert": _square(50, -500, 950, 1500),
     }
@@ -169,8 +190,14 @@ def _build_synthetic_ttf() -> TTFont:
         "uni3042": (1000, 50),
         "uni30A2": (1000, 50),
         "uni4E00": (1000, 0),
+        "uni2500": (1000, 0),
         "uni3001": (1000, 50),
+        "uni3030": (1000, 0),
         "uni3031": (1000, 50),
+        "uni3033": (1000, 180),
+        "uni3034": (1000, 180),
+        "uni3035": (1000, 190),
+        "uni30FB": (1000, 400),
         "uni3031.vert": (1000, 50),
         "compositeA": (600, 100),
     })

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -15,6 +15,7 @@ from font.build import (
     _apply_x_scale,
     _EXTREME_YMAX,
     _EXTREME_YMIN,
+    _VERTICAL_REPEAT_MARK_CODEPOINTS,
     _get_cjk_glyphs,
     _get_variable_palt,
     _get_vert_alternates,
@@ -24,6 +25,7 @@ from font.build import (
     _is_kana_or_punct,
     _strip_extreme_glyphs,
     SUB_EXCLUDE_CODEPOINTS,
+    TRACKING_IGNORE_CODEPOINTS,
 )
 from merge_fonts import parse_codepoint_list
 
@@ -167,7 +169,7 @@ class TestIsKanaLetter:
     def test_cjk_block_iteration_marks_excluded(self):
         # 〱 〲 (U+3031, U+3032) live in the CJK Symbols & Punctuation
         # block, not the kana blocks — _is_kana_letter excludes them so
-        # the squeeze pass can route them through vert-alternate handling.
+        # they do not receive full kana palt treatment.
         assert not _is_kana_letter("uni3031")
         assert not _is_kana_letter("uni3032")
 
@@ -331,6 +333,23 @@ class TestStripExtremeGlyphs:
 
         assert 0x3031 not in synthetic_ttf.getBestCmap()
 
+    def test_strips_vertical_repeat_remnants_even_when_not_extreme(self, synthetic_ttf):
+        before = synthetic_ttf.getBestCmap()
+        for cp in (0x3033, 0x3034, 0x3035):
+            assert cp in before
+            glyph = synthetic_ttf["glyf"][before[cp]]
+            assert glyph.yMax <= _EXTREME_YMAX
+            assert glyph.yMin >= _EXTREME_YMIN
+
+        _strip_extreme_glyphs(synthetic_ttf)
+
+        after = synthetic_ttf.getBestCmap()
+        for cp in (0x3033, 0x3034, 0x3035):
+            assert cp not in after
+            glyph = synthetic_ttf["glyf"][f"uni{cp:04X}"]
+            assert glyph.numberOfContours == 0
+            assert synthetic_ttf["hmtx"][f"uni{cp:04X}"] == (0, 0)
+
     def test_keeps_non_extreme_glyphs_intact(self, synthetic_ttf):
         before = synthetic_ttf["glyf"]["A"]
         before_contours = before.numberOfContours
@@ -344,6 +363,9 @@ class TestStripExtremeGlyphs:
         # If the constants drift, several call sites assume yMax=1200/yMin=-400.
         assert _EXTREME_YMAX == 1200
         assert _EXTREME_YMIN == -400
+
+    def test_vertical_repeat_mark_policy_matches_unicode_range(self):
+        assert _VERTICAL_REPEAT_MARK_CODEPOINTS == tuple(range(0x3031, 0x3036))
 
 
 # ---------------------------------------------------------------------------
@@ -454,6 +476,49 @@ class TestApplyTracking:
         assert after_aw == before_aw + 11
         # 11 // 2 = 5 (floor), so RSB ends up 6 wider, LSB 5 wider.
         assert after_lsb == before_lsb + 5
+
+    def test_tracking_ignore_skips_codepoint_ranges_and_singles(self, synthetic_ttf):
+        before_line = synthetic_ttf["hmtx"]["uni2500"]
+        before_wavy = synthetic_ttf["hmtx"]["uni3030"]
+        before_middle_dot = synthetic_ttf["hmtx"]["uni30FB"]
+        before_punct = synthetic_ttf["hmtx"]["uni3001"]
+
+        _apply_tracking(
+            synthetic_ttf,
+            tracking=30,
+            tracking_kana=60,
+            tracking_ignore=["U+2500-U+257F", "U+3030", "U+30FB"],
+        )
+
+        assert synthetic_ttf["hmtx"]["uni2500"] == before_line
+        assert synthetic_ttf["hmtx"]["uni3030"] == before_wavy
+        assert synthetic_ttf["hmtx"]["uni30FB"] == before_middle_dot
+        assert synthetic_ttf["hmtx"]["uni3001"][0] == before_punct[0] + 60
+
+    def test_default_tracking_ignore_policy_matches_repeatable_symbols(self):
+        codepoints = parse_codepoint_list(TRACKING_IGNORE_CODEPOINTS)
+
+        assert 0x2500 in codepoints  # ─
+        assert 0x257F in codepoints  # ╿
+        assert 0x2580 in codepoints  # ▀
+        assert 0x259F in codepoints  # ▟
+        assert 0x2025 in codepoints  # ‥
+        assert 0x22EF in codepoints  # ⋯
+        assert 0x30FB in codepoints  # ・
+        assert 0x3030 in codepoints  # 〰
+        assert 0xFE30 in codepoints  # ︰
+        assert 0xFE4F in codepoints  # ﹏
+        assert 0xFF65 in codepoints  # ･
+        assert 0x2E3A in codepoints  # ⸺
+        assert 0x2E3B in codepoints  # ⸻
+        assert 0xFF3F in codepoints  # ＿
+        assert 0xFFE3 in codepoints  # ￣
+
+        # From the earlier "confirm visually" group, only U+3030 is opted in.
+        assert 0x301C not in codepoints  # 〜
+        assert 0x30FC not in codepoints  # ー
+        assert 0xFF0D not in codepoints  # －
+        assert 0xFF1D not in codepoints  # ＝
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_proportional.py
+++ b/tests/test_proportional.py
@@ -214,6 +214,25 @@ class TestMakeProportional:
         after_aw = noto_subset["hmtx"][kana_glyph][0]
         assert after_aw == before_aw - 30
 
+    def test_non_palt_glyph_keeps_metrics_without_squeeze(self, noto_subset):
+        palt = _read_palt(noto_subset)
+        cmap = noto_subset.getBestCmap()
+        candidate = None
+        for cp in (0x0041, 0x0061, 0x4E00):  # A, a, 一
+            gname = cmap.get(cp)
+            if gname and gname not in palt:
+                candidate = gname
+                break
+        if candidate is None:
+            import pytest
+            pytest.skip("no non-palt glyph available")
+
+        before = noto_subset["hmtx"][candidate]
+
+        make_proportional(noto_subset)
+
+        assert noto_subset["hmtx"][candidate] == before
+
     def test_squeeze_sb_narrows_non_palt_glyph(self, noto_subset):
         # Pick a glyph that has no palt entry; verify sidebearings shrink.
         palt = _read_palt(noto_subset)


### PR DESCRIPTION
## Summary

- skip tracking for repeatable Noto-sourced symbols such as box drawing, leaders, middle dots, and related no-gap forms
- stop applying the broad non-palt `squeeze_sb` pass in the Gen Interface JP build path
- strip vertical-only repeat marks `U+3031-U+3035` from the horizontal UI font pipeline
- update tests and architecture docs for the new spacing and glyph-removal policy

## Why

Non-palt Noto symbols were being sidebearing-squeezed even when their original full-width metrics were the safer behavior. This made glyphs such as `⋯` and related symbols look too cramped. Separately, the vertical repeat mark remnants `〳〴〵` could still survive after the original bbox cleanup removed only `〱〲`, and those vertical-only glyphs can confuse Illustrator's Japanese composer in horizontal text.

## Validation

- `PYTHONPATH=src python3 -m pytest -q` -> `140 passed`
- `PYTHONPATH=src python3 -m font.build normal Regular` -> passed
- confirmed `U+3031-U+3035` are absent from cmap in both `dist/intermediate/NotoSansJP-Regular-Prop.ttf` and `dist/ttf/Gen Interface JP/GenInterfaceJP-Regular.ttf`
