### PR TITLE
[codex] Simplify palt symbol spacing policy

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -23,7 +23,7 @@ Gen Interface JP はフォントビルドパイプライン (アプリ/UI なし
         │         metadataMode=inheritBase                │
         │             ↓                                   │
         │   [2/3] Proportionalise — proportional.py       │
-        │         palt → hmtx (2 バケット方針)              │
+        │         palt → hmtx (グループ別 palt 方針)        │
         │         tracking (連続記号は除外)              │
         │         + 極端な bbox の除去                    │
         │             ↓                                   │
@@ -68,8 +68,8 @@ FAMILIES × WEIGHTS の各組合せに対して:
                     inheritBase で designer/OFL/version を継承
                     weight だけを上書き
   → inst を再読込し、キャッシュした variable から palt 取得
-  → palt グリフを kana letters / reduced palt に分類
-    (CJK 漢字、vert-only グリフ、palt なしグリフはメトリクス維持)
+  → Noto の palt エントリを全量で焼き込み
+    (palt なしグリフはメトリクス維持)
   → make_proportional で palt → hmtx に焼き込み
     palt/vpal/halt/vhal 削除
   → _apply_tracking で advance を広げ LSB を半分シフト
@@ -135,21 +135,20 @@ inst に対して 4 つのサブパスを in-place で実行:
 1. **palt のベイク** (`proportional.make_proportional`) — palt 値は
    キャッシュ済みの variable から読む (instantiation で非デフォルト軸位置の
    palt ValueRecord が壊れることがあるため)。XPlacement / XAdvance を
-   LSB / advance に加算しアウトラインをシフト。palt は 2 バケット:
-   - **kana letters** — palt 全量
-   - **reduced palt** (句読点等、デフォルト ⅓) — palt 対象だが kana letter
-     ではないグリフ
-   palt なしグリフは自動的に sidebearing を詰めない; 後続の明示的な
-   spacing ルールが触らない限り元の `hmtx` を維持する。CJK 漢字と
-   `vert` / `vrt2` の代替グリフは reduced palt から除外 — 全角メトリクスを保つ。
+   LSB / advance に加算しアウトラインをシフト。Noto の palt エントリは
+   すべて全量で焼き込む; tracking-only / full-palt 記号リストのような
+   別分類は持たない。palt なしグリフは自動的に sidebearing を詰めない;
+   後続の明示的な spacing ルールが触らない限り元の `hmtx` を維持する。
+   `U+30FB` (・) は Noto では `U+2027` (‧) と同じ `uni2027` を共有して
+   いるため、palt ベイク前に `uni30FB` として分離する。これにより `‧` は
+   palt + tracking のみ、`・` は明示的な spacing 補正ありとして扱える。
 2. **トラッキング** (`_apply_tracking`) — advance を `tracking` 分広げ、
    `tracking // 2` を LSB に加算してアウトラインを広がった枠の中央に
    配置。kana / 句読点はファミリー設定の `trackingKana` で別値。
    `trackingIgnore` はコードポイント / 範囲を受け取り、cmap で解決した
    グリフを完全にスキップする。デフォルトでは Noto の tracking stage で
    Box Drawing (`U+2500-U+257F`)、Block Elements (`U+2580-U+259F`)、
-   2 点 / 中点 leader (`U+2025`, `U+22EF`)、中黒 (`U+30FB`, `U+FF65`)、
-   `U+3030`、
+   2 点 / 中点 leader (`U+2025`, `U+22EF`)、半角中黒 (`U+FF65`)、`U+3030`、
    縦組み・互換 leader 形式 (`U+FE19`, `U+FE30-U+FE34`,
    `U+FE49-U+FE4F`)、two-/three-em dash (`U+2E3A`, `U+2E3B`)、全角
    low line (`U+FF3F`)、全角 macron (`U+FFE3`) を除外し、隙間なしで
@@ -157,11 +156,14 @@ inst に対して 4 つのサブパスを in-place で実行:
 3. **個別グリフのスペーシング** (`_apply_glyph_spacing`) — palt + 一律
    トラッキングだけでは追い込めない稀なグリフのための手動レイヤー。
    ファミリー設定の `glyphSpacing` がコードポイント (または 1 文字) を
-   `(lsb_delta, rsb_delta)` ペアにマップする: `lsb_delta` はアウトラインを
-   スロット内で右にシフトしつつ advance を同量広げ、`rsb_delta` は
-   advance を右側だけ広げる。アウトライン座標は触らない。各エントリは
-   特定グリフを特定の隣接リズムに対して個別チューニングする想定なので、
-   慎重に追加すること。現在の調整値は `font/build.py` の `FAMILIES` を参照。
+   `(lsb_delta, rsb_delta)` ペアにマップする: `lsb_delta` は hmtx LSB と
+   advance を同量増やし、`rsb_delta` は advance を右側だけ広げる。
+   アウトライン座標は触らない。各エントリは特定グリフを特定の隣接リズムに
+   対して個別チューニングする想定なので、慎重に追加すること。現在の調整値は
+   `font/build.py` の `FAMILIES` を参照。`U+30FB` (・) は `trackingIgnore`
+   ではなくここで扱う: 他の調整対象の句読点と同じく tracking を通し、
+   Normal family では family-specific な spacing 値で最終 hmtx を従来の
+   目標に合わせる。
 4. **bbox 除去** (`_strip_extreme_glyphs`) — 下記 [垂直メトリクス] 参照。
 
 オプションの **横スケール** (`xScale` 設定、現在未使用) は上記の後に
@@ -360,7 +362,9 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
 - **`tests/test_font_build.py`** — `_glyph_codepoint`, `_is_kana_or_punct`,
   `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
   `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
-  `_apply_tracking`, `_get_variable_palt`。
+  `_apply_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
+  `_split_cmap_codepoint_glyph`, `_get_variable_palt`、明示的な palt
+  spacing 方針。
 - **`tests/test_proportional.py`** — `_read_palt`, `_shift_glyph_x`,
   `_remove_prop_features`, `make_proportional` (palt ベイク、reduced palt
   scale、palt なしグリフのメトリクス維持、オプションの squeeze SB
@@ -377,8 +381,8 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 76 | グリフ名パース、kana / CJK 分類、GSUB 走査、x-scale、bbox 除去、tracking |
-| `test_proportional.py` | 20 | palt 抽出、グリフ平行移動、GPOS feature 削除、2 バケット palt 方針 + optional squeeze helper |
+| `test_font_build.py` | 81 | グリフ名パース、kana / CJK 分類、GSUB 走査、x-scale、bbox 除去、tracking |
+| `test_proportional.py` | 20 | palt 抽出、グリフ平行移動、GPOS feature 削除、reduced-palt 方針 + optional squeeze helper |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,7 @@ consumes the published webfont package.
         │         metadataMode=inheritBase                │
         │             ↓                                   │
         │   [2/3] Proportionalise — proportional.py       │
-        │         palt → hmtx (two-bucket policy)         │
+        │         palt → hmtx (grouped palt policy)       │
         │         tracking (with repeatable skips)        │
         │         + strip extreme bbox                    │
         │             ↓                                   │
@@ -68,8 +68,8 @@ For each (family, weight) in FAMILIES × WEIGHTS:
                     inheritBase passes designer/OFL/version
                     through; only weight is stamped
   → reload inst, read palt from cached variable font
-  → split palt glyphs into kana letters / reduced palt
-    (CJK ideographs, vert-only glyphs, and non-palt glyphs keep metrics)
+  → bake every Noto palt entry at full strength
+    (glyphs without palt keep metrics)
   → make_proportional bakes palt → hmtx, strips palt/vpal/halt/vhal
   → _apply_tracking widens advances + half-balances LSB
     except repeatable no-gap symbols in family["trackingIgnore"]
@@ -133,14 +133,14 @@ Four sub-passes, all in-place on the inst:
 1. **palt baking** (`proportional.make_proportional`) — palt values are
    read from the cached variable font (instantiation can corrupt palt's
    ValueRecords at non-default axis positions). XPlacement/XAdvance pairs
-   are added to LSB / advance, outlines shifted. Two palt buckets:
-   - **kana letters** — full palt shrink
-   - **reduced palt** (punctuation, by default ⅓ scale) — palt glyphs
-     that aren't kana letters
-   Glyphs without palt entries are not automatically sidebearing-squeezed;
-   they keep their original `hmtx` unless a later explicit spacing rule
-   touches them. CJK ideographs and `vert`/`vrt2` alternates are excluded
-   from reduced palt — they keep full-width metrics.
+   are added to LSB / advance, outlines shifted. Every Noto palt entry is
+   baked at full strength; there is no separate tracking-only or full-palt
+   symbol list. Glyphs without palt entries are not automatically
+   sidebearing-squeezed; they keep their original `hmtx` unless a later
+   explicit spacing rule touches them.
+   `U+30FB` (・) is split from Noto's shared `uni2027` glyph before palt
+   baking so `U+2027` (‧) can remain palt + tracking only while `U+30FB`
+   receives explicit spacing compensation.
 2. **Tracking** (`_apply_tracking`) — advance grows by `tracking`;
    `tracking // 2` is added to LSB so the outline sits centred in the
    wider slot. Kana / punctuation get a separate `trackingKana` value
@@ -148,20 +148,23 @@ Four sub-passes, all in-place on the inst:
    and skips glyphs resolved through cmap. The default ignore list keeps
    the Noto tracking stage from widening Box Drawing (`U+2500-U+257F`),
    Block Elements (`U+2580-U+259F`), two-dot / midline leaders
-   (`U+2025`, `U+22EF`),
-   middle dots (`U+30FB`, `U+FF65`), `U+3030`, vertical/compat leader
+   (`U+2025`, `U+22EF`), halfwidth middle dot (`U+FF65`), `U+3030`,
+   vertical/compat leader
    forms (`U+FE19`, `U+FE30-U+FE34`, `U+FE49-U+FE4F`), two-/three-em
    dashes (`U+2E3A`, `U+2E3B`), fullwidth low line (`U+FF3F`), and
    fullwidth macron (`U+FFE3`).
 3. **Per-glyph spacing** (`_apply_glyph_spacing`) — manual fallback for
    the rare glyph whose sidebearings still read off after palt + uniform
    tracking. The family's `glyphSpacing` dict maps a codepoint or
-   character to a `(lsb_delta, rsb_delta)` pair: `lsb_delta` shifts the
-   outline right within the slot and grows advance by the same amount,
-   `rsb_delta` only grows advance on the right. Outline coordinates are
-   never touched. Populate sparingly — each entry hand-tuned for one
-   glyph against a specific neighbour rhythm. Refer to `FAMILIES` in
-   `font/build.py` for the current set of adjustments.
+   character to a `(lsb_delta, rsb_delta)` pair: `lsb_delta` increases
+   hmtx LSB and advance by the same amount, while `rsb_delta` only grows
+   advance on the right. Outline coordinates are never touched. Populate
+   sparingly — each entry hand-tuned for one glyph against a specific
+   neighbour rhythm. Refer to `FAMILIES` in `font/build.py` for the
+   current set of adjustments. `U+30FB` (・) is intentionally handled here
+   instead of `trackingIgnore`: it passes through tracking like other
+   adjusted punctuation, and Normal uses a family-specific spacing value so
+   the final hmtx matches the previous target.
 4. **Bbox strip** (`_strip_extreme_glyphs`) — see [Vertical metrics]
    below.
 
@@ -365,7 +368,9 @@ Tests live under `tests/`, split by surface:
 - **`tests/test_font_build.py`** — `_glyph_codepoint`, `_is_kana_or_punct`,
   `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
   `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
-  `_apply_tracking`, `_get_variable_palt`.
+  `_apply_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
+  `_split_cmap_codepoint_glyph`, `_get_variable_palt`, and the explicit
+  palt spacing policy.
 - **`tests/test_proportional.py`** — `_read_palt`, `_shift_glyph_x`,
   `_remove_prop_features`, `make_proportional` (palt baking, reduced
   palt scaling, non-palt metric preservation, optional squeeze SB
@@ -382,8 +387,8 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 76 | Glyph-name parsing, kana / CJK classification, GSUB walk, x-scale, bbox strip, tracking |
-| `test_proportional.py` | 20 | palt extraction, glyph translation, GPOS feature removal, two-bucket palt policy + optional squeeze helper |
+| `test_font_build.py` | 81 | Glyph-name parsing, kana / CJK classification, GSUB walk, x-scale, bbox strip, tracking |
+| `test_proportional.py` | 20 | palt extraction, glyph translation, GPOS feature removal, reduced-palt policy + optional squeeze helper |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |
 

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -22,6 +22,7 @@ TTF outputs — see src/webfont/.
 
 from __future__ import annotations
 
+import copy
 import os
 import sys
 
@@ -61,7 +62,6 @@ TRACKING_IGNORE_CODEPOINTS = (
     "U+2580-U+259F",   # Block Elements
     "U+2025",          # ‥ TWO DOT LEADER
     "U+22EF",          # ⋯ MIDLINE HORIZONTAL ELLIPSIS
-    "U+30FB",          # ・ KATAKANA MIDDLE DOT
     "U+3030",          # 〰 WAVY DASH
     "U+FE19",          # ︙ PRESENTATION FORM FOR VERTICAL HORIZONTAL ELLIPSIS
     "U+FE30-U+FE34",   # ︰ ︱ ︲ ︳ ︴
@@ -73,14 +73,80 @@ TRACKING_IGNORE_CODEPOINTS = (
     "U+FFE3",          # ￣ FULLWIDTH MACRON
 )
 
+# Glyphs listed here get full Noto palt like every other palt glyph, then
+# receive explicit hmtx spacing after tracking. The values are derived from
+# the canonical Noto palt records so that:
+#
+#   full palt + tracking + glyphSpacing == previous reduced-palt output
+#
+# for advance and hmtx LSB. This keeps the current visual rhythm for the
+# more spacing-sensitive punctuation while letting the pipeline express the
+# policy as "full palt, then explicit spacing compensation".
+PALT_SPACE_ADJUSTMENTS = {
+    "、": (6, 327),
+    "。": (-7, 340),
+    "，": (43, 290),
+    "．": (53, 280),
+    "〈": (317, 16),
+    "〉": (17, 316),
+    "《": (320, 13),
+    "》": (13, 320),
+    "「": (321, 12),
+    "」": (13, 320),
+    "『": (321, 12),
+    "』": (13, 320),
+    "【": (317, 16),
+    "】": (16, 317),
+    "〔": (314, 19),
+    "〕": (19, 314),
+    "〖": (333, 0),
+    "〗": (0, 333),
+    "〘": (320, 13),
+    "〙": (13, 320),
+    "〚": (333, 0),
+    "〛": (0, 333),
+    "（": (309, 24),
+    "）": (24, 309),
+    "｛": (320, 13),
+    "｝": (13, 320),
+    "｟": (315, 18),
+    "｠": (19, 314),
+    "〝": (312, 21),
+    "〞": (0, 333),
+    "〟": (21, 312),
+    "［": (321, 12),
+    "］": (13, 320),
+    "！": (167, 166),
+    "？": (89, 100),
+    "・": (167, 166),
+    "：": (167, 166),
+    "；": (167, 166),
+}
+
+
+NORMAL_TRACKING = 30
+NORMAL_TRACKING_KANA = 40
+DISPLAY_TRACKING = 0
+DISPLAY_TRACKING_KANA = 0
+
+NORMAL_PALT_SPACE_ADJUSTMENTS = {
+    **PALT_SPACE_ADJUSTMENTS,
+    # U+30FB used to skip tracking in the legacy pipeline. It now passes
+    # through tracking like the other Group A symbols, so Normal uses a
+    # family-specific spacing value to keep the same final hmtx target.
+    "・": (147, 146),
+}
+
+DISPLAY_PALT_SPACE_ADJUSTMENTS = PALT_SPACE_ADJUSTMENTS
+
+
 FAMILIES = {
     "normal": {
         "familyName": "Gen Interface JP",
         "interPrefix": "Inter",
-        "tracking": 30,
-        "trackingKana": 40,
+        "tracking": NORMAL_TRACKING,
+        "trackingKana": NORMAL_TRACKING_KANA,
         "trackingIgnore": TRACKING_IGNORE_CODEPOINTS,
-        "halfPaltPunct": True,
         "folderPrefix": "GenInterfaceJP",
         # Per-glyph sidebearing tweaks applied after tracking. Map a
         # codepoint (int) or single-char string to a (lsb_delta, rsb_delta)
@@ -88,18 +154,19 @@ FAMILIES = {
         # tighten. Populate when a specific glyph needs a manual margin
         # nudge that palt + tracking alone can't reach.
         "glyphSpacing": {
+            **NORMAL_PALT_SPACE_ADJUSTMENTS,
             "く": (30, 0),
         },
     },
     "display": {
         "familyName": "Gen Interface JP Display",
         "interPrefix": "InterDisplay",
-        "tracking": 0,
-        "trackingKana": 0,
+        "tracking": DISPLAY_TRACKING,
+        "trackingKana": DISPLAY_TRACKING_KANA,
         "trackingIgnore": TRACKING_IGNORE_CODEPOINTS,
-        "halfPaltPunct": True,
         "folderPrefix": "GenInterfaceJPDisplay",
         "glyphSpacing": {
+            **DISPLAY_PALT_SPACE_ADJUSTMENTS,
             "く": (30, 0),
         },
     },
@@ -300,12 +367,46 @@ def _get_cjk_glyphs(font: TTFont) -> set[str]:
     return {gname for cp, gname in cmap.items() if _is_cjk_codepoint(cp)}
 
 
+def _split_cmap_codepoint_glyph(
+    font: TTFont,
+    codepoint: int,
+    new_glyph_name: str,
+) -> str | None:
+    """Give one cmap codepoint its own glyph copy when it shares a glyph.
+
+    Noto maps both U+2027 (‧) and U+30FB (・) to ``uni2027``. The spacing
+    policy treats them differently, so U+30FB needs an independent hmtx/glyf
+    record before palt and manual spacing are applied. The source glyph name
+    is returned so callers can copy palt override data when needed.
+    """
+    cmap = font.getBestCmap() or {}
+    source_glyph = cmap.get(codepoint)
+    if source_glyph is None:
+        return None
+    if source_glyph == new_glyph_name:
+        return source_glyph
+
+    glyph_order = font.getGlyphOrder()
+    if new_glyph_name not in glyph_order:
+        font.setGlyphOrder([*glyph_order, new_glyph_name])
+        font["glyf"][new_glyph_name] = copy.deepcopy(font["glyf"][source_glyph])
+        font["hmtx"].metrics[new_glyph_name] = font["hmtx"].metrics[source_glyph]
+        if "vmtx" in font and source_glyph in font["vmtx"].metrics:
+            font["vmtx"].metrics[new_glyph_name] = font["vmtx"].metrics[source_glyph]
+
+    for table in font["cmap"].tables:
+        if table.cmap.get(codepoint) == source_glyph:
+            table.cmap[codepoint] = new_glyph_name
+
+    return source_glyph
+
+
 def _is_kana_letter(glyph_name: str) -> bool:
     """Return True for hiragana / katakana *letters*, excluding punctuation.
 
-    Stricter than :func:`_is_kana_or_punct`: the kana proportional pass
-    keeps full palt shrink on letters (where palt's optical kerning is
-    designed to apply) and applies a reduced palt to punctuation.
+    Stricter than :func:`_is_kana_or_punct`: this helper answers whether a
+    glyph is an actual kana letter rather than CJK punctuation or fullwidth
+    symbols.
     Notable exclusion: U+30FB (・) is punctuation, not a letter.
     """
     cp = _glyph_codepoint(glyph_name)
@@ -448,7 +549,7 @@ def _strip_extreme_glyphs(font: TTFont) -> None:
     head.yMax/yMin, and the upper/lower-half remnants can confuse Adobe's
     Japanese composer when pasted into horizontal text. Acceptable trade-off
     for a horizontal-only UI font: vertical typesetting is out of scope
-    (see CLAUDE.md).
+    (see docs/ARCHITECTURE.md).
 
     Removing the glyph slots outright would shift every later index in
     GSUB / GPOS lookups. Instead we keep the slot in place and only
@@ -508,21 +609,29 @@ def _strip_extreme_glyphs(font: TTFont) -> None:
 # Tracking
 # ---------------------------------------------------------------------------
 
+def _glyphs_for_codepoints(
+    font: TTFont,
+    codepoint_entries: list | tuple | set | None,
+) -> set[str]:
+    """Resolve codepoint entries to glyph names via cmap."""
+    if not codepoint_entries:
+        return set()
+    entries = (
+        tuple(codepoint_entries)
+        if isinstance(codepoint_entries, set)
+        else codepoint_entries
+    )
+    codepoints = parse_codepoint_list(entries)
+    cmap = font.getBestCmap() or {}
+    return {glyph_name for cp, glyph_name in cmap.items() if cp in codepoints}
+
+
 def _tracking_ignore_glyphs(
     font: TTFont,
     tracking_ignore: list | tuple | set | None,
 ) -> set[str]:
     """Resolve tracking-ignore codepoints to glyph names via cmap."""
-    if not tracking_ignore:
-        return set()
-    entries = (
-        tuple(tracking_ignore)
-        if isinstance(tracking_ignore, set)
-        else tracking_ignore
-    )
-    codepoints = parse_codepoint_list(entries)
-    cmap = font.getBestCmap() or {}
-    return {glyph_name for cp, glyph_name in cmap.items() if cp in codepoints}
+    return _glyphs_for_codepoints(font, tracking_ignore)
 
 
 def _apply_tracking(
@@ -701,46 +810,32 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     tracking = family["tracking"]
     tracking_kana = family["trackingKana"]
     tracking_ignore = family.get("trackingIgnore")
-    half_palt_punct = family.get("halfPaltPunct", False)
 
     desc = f"tracking +{tracking}"
     if tracking_kana is not None:
         desc += f" (kana/punct +{tracking_kana})"
-    if half_palt_punct:
-        desc += " (punct half-palt)"
     print(f"    [2/3] Proportional (palt) + {desc}...")
 
     font = TTFont(inst_path)
+
+    # Split U+30FB from U+2027 before metrics work. Noto maps both to
+    # ``uni2027``, but U+30FB has an explicit spacing adjustment while
+    # U+2027 only needs palt + tracking.
+    split_source = _split_cmap_codepoint_glyph(font, 0x30FB, "uni30FB")
 
     # Read palt from the variable source rather than the freshly-baked inst:
     # variable instantiation can leave palt ValueRecords with zeroed or
     # otherwise stale XPlacement/XAdvance pairs. The cached variable read
     # is canonical across all weights.
-    palt_data = _get_variable_palt()
+    palt_data = dict(_get_variable_palt())
+    if split_source in palt_data:
+        palt_data["uni30FB"] = palt_data[split_source]
 
-    # Two-bucket policy for proportional metrics, only active when
-    # ``halfPaltPunct`` is set on the family:
-    #   - kana letters: keep the full palt shrink (unchanged below)
-    #   - reduced_palt: glyphs that have palt entries but aren't kana
-    #     letters — typically punctuation. These get a fraction of the
-    #     full palt shift so punctuation doesn't pull as tight as kana.
-    # Glyphs without palt entries keep their original hmtx. CJK ideographs
-    # and vertical-only glyphs are excluded from reduced_palt — they keep
-    # full-width metrics (see CLAUDE.md).
-    reduced_palt_glyphs = None
-    if half_palt_punct:
-        palt_glyphs = set(palt_data.keys())
-        vert_glyphs = _get_vert_alternates(font)
-        cjk_glyphs = _get_cjk_glyphs(font)
-        exclude = vert_glyphs | cjk_glyphs
-        reduced_palt_glyphs = {
-            g for g in palt_glyphs
-            if not _is_kana_letter(g) and g not in exclude
-        }
-
+    # Bake every Noto palt entry at full strength. Glyphs without palt keep
+    # their original hmtx; selected punctuation is adjusted later by
+    # glyphSpacing.
     make_proportional(
         font,
-        reduced_palt=reduced_palt_glyphs,
         palt_override=palt_data,
     )
     _apply_tracking(font, tracking, tracking_kana, tracking_ignore)

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -19,11 +19,16 @@ from font.build import (
     _get_cjk_glyphs,
     _get_variable_palt,
     _get_vert_alternates,
+    _glyphs_for_codepoints,
     _glyph_codepoint,
     _is_cjk_codepoint,
     _is_kana_letter,
     _is_kana_or_punct,
+    _split_cmap_codepoint_glyph,
     _strip_extreme_glyphs,
+    DISPLAY_PALT_SPACE_ADJUSTMENTS,
+    NORMAL_PALT_SPACE_ADJUSTMENTS,
+    PALT_SPACE_ADJUSTMENTS,
     SUB_EXCLUDE_CODEPOINTS,
     TRACKING_IGNORE_CODEPOINTS,
 )
@@ -504,7 +509,6 @@ class TestApplyTracking:
         assert 0x259F in codepoints  # ▟
         assert 0x2025 in codepoints  # ‥
         assert 0x22EF in codepoints  # ⋯
-        assert 0x30FB in codepoints  # ・
         assert 0x3030 in codepoints  # 〰
         assert 0xFE30 in codepoints  # ︰
         assert 0xFE4F in codepoints  # ﹏
@@ -514,11 +518,81 @@ class TestApplyTracking:
         assert 0xFF3F in codepoints  # ＿
         assert 0xFFE3 in codepoints  # ￣
 
+        # U+30FB belongs to the palt + spacing group, so it receives tracking
+        # and is corrected later by glyphSpacing.
+        assert 0x30FB not in codepoints  # ・
+
         # From the earlier "confirm visually" group, only U+3030 is opted in.
         assert 0x301C not in codepoints  # 〜
         assert 0x30FC not in codepoints  # ー
         assert 0xFF0D not in codepoints  # －
         assert 0xFF1D not in codepoints  # ＝
+
+
+# ---------------------------------------------------------------------------
+# palt symbol policy
+# ---------------------------------------------------------------------------
+
+class TestPaltSymbolPolicy:
+    """Full palt is the default; spacing values mark the adjusted symbols."""
+
+    def test_tracking_only_symbols_are_implicit_palt_entries(self):
+        palt = _get_variable_palt()
+
+        for glyph_name in (
+            "uni3012", "uni3005", "uni3006",
+            "uniFF10", "uniFF19", "uniFF21", "uniFF2C",
+            "uniFF2E", "uniFF3A", "uniFF41", "uniFF56",
+            "uniFF58", "uniFF5A", "uniFF3E",
+            "uniFFE5", "uni2027", "uni2035",
+        ):
+            assert glyph_name in palt
+
+        assert "〒" not in PALT_SPACE_ADJUSTMENTS
+        assert "０" not in PALT_SPACE_ADJUSTMENTS
+        assert "Ａ" not in PALT_SPACE_ADJUSTMENTS
+        assert "‧" not in PALT_SPACE_ADJUSTMENTS
+
+        assert "uniFF2D" not in palt  # Ｍ
+        assert "uniFF57" not in palt  # ｗ
+        assert "uniFF40" not in palt  # ｀
+
+    def test_palt_spacing_adjustments_preserve_previous_metrics(self):
+        assert PALT_SPACE_ADJUSTMENTS["、"] == (6, 327)
+        assert PALT_SPACE_ADJUSTMENTS["〈"] == (317, 16)
+        assert PALT_SPACE_ADJUSTMENTS["！"] == (167, 166)
+        assert PALT_SPACE_ADJUSTMENTS["？"] == (89, 100)
+        assert PALT_SPACE_ADJUSTMENTS["・"] == (167, 166)
+
+    def test_family_spacing_adjustments_handle_middle_dot_tracking(self):
+        assert DISPLAY_PALT_SPACE_ADJUSTMENTS["・"] == (167, 166)
+        assert NORMAL_PALT_SPACE_ADJUSTMENTS["・"] == (147, 146)
+
+    def test_codepoint_entries_resolve_to_glyphs(self, synthetic_ttf):
+        glyphs = _glyphs_for_codepoints(
+            synthetic_ttf,
+            (0x2500, "U+3033-U+3035"),
+        )
+
+        assert glyphs == {"uni2500", "uni3033", "uni3034", "uni3035"}
+
+    def test_middle_dot_can_split_from_shared_noto_glyph(self, synthetic_ttf):
+        synthetic_ttf.setGlyphOrder([*synthetic_ttf.getGlyphOrder(), "uni2027"])
+        synthetic_ttf["glyf"]["uni2027"] = copy.deepcopy(synthetic_ttf["glyf"]["uni30FB"])
+        synthetic_ttf["hmtx"].metrics["uni2027"] = synthetic_ttf["hmtx"]["uni30FB"]
+        for table in synthetic_ttf["cmap"].tables:
+            table.cmap[0x2027] = "uni2027"
+            table.cmap[0x30FB] = "uni2027"
+        before_hmtx = synthetic_ttf["hmtx"]["uni2027"]
+
+        split_source = _split_cmap_codepoint_glyph(synthetic_ttf, 0x30FB, "uni30FB")
+
+        cmap = synthetic_ttf.getBestCmap()
+        assert split_source == "uni2027"
+        assert cmap[0x2027] == "uni2027"
+        assert cmap[0x30FB] == "uni30FB"
+        assert synthetic_ttf["hmtx"]["uni30FB"] == before_hmtx
+        assert synthetic_ttf["hmtx"]["uni2027"] == before_hmtx
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- simplify the proportionalization policy so every Noto `palt` entry is baked at full strength
- keep only the explicit `glyphSpacing` adjustment table for punctuation that needs post-tracking spacing compensation
- preserve the `・` / `‧` glyph split while removing the separate B/full-palt symbol lists and reduced-palt branch
- update architecture docs and tests to match the simplified policy

## Validation

- `PYTHONPATH=src python3 -m pytest -q` -> 145 passed
- `PYTHONPATH=src python3 -m font.build normal Regular` -> passed
- `PYTHONPATH=src python3 -m font.build display Regular` -> passed
- Compared previous explicit/reduced policy against the new full-palt policy: no encoded cmap glyph geometry differences; only 23 unmapped internal glyphs differed.
