### PR TITLE
[codex] Add runtime palt and vpal features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ venv/
 # Build output
 dist/
 
+# Scratch verification pages
+scratch.*.html
+
 # Node
 node_modules/
 site/node_modules/

--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -23,7 +23,7 @@ Gen Interface JP はフォントビルドパイプライン (アプリ/UI なし
         │         metadataMode=inheritBase                │
         │             ↓                                   │
         │   [2/3] Proportionalise — proportional.py       │
-        │         palt → hmtx (グループ別 palt 方針)        │
+        │      palt → hmtx + runtime 役物 palt/vpal       │
         │         tracking (連続記号は除外)              │
         │         + 極端な bbox の除去                    │
         │             ↓                                   │
@@ -32,6 +32,7 @@ Gen Interface JP はフォントビルドパイプライン (アプリ/UI なし
         │         subFont.excludeCodepoints で日本語慣習    │
         │         記号は Noto を維持                        │
         │         metricsSource=sub, manufacturer 刻印     │
+        │         GSUB/GPOS coverage order 正規化          │
         │             ↓                                   │
         │   dist/ttf/  (ファミリー × ウェイトごとに TTF)    │
         │                                                  │
@@ -67,11 +68,11 @@ FAMILIES × WEIGHTS の各組合せに対して:
   → font-baker bake: variable Noto → static TTF
                     inheritBase で designer/OFL/version を継承
                     weight だけを上書き
-  → inst を再読込し、キャッシュした variable から palt 取得
-  → Noto の palt エントリを全量で焼き込み
+  → inst を再読込し、キャッシュした variable から palt/vpal 取得
+  → runtime 役物を除き Noto の palt エントリを全量で焼き込み
     (palt なしグリフはメトリクス維持)
   → make_proportional で palt → hmtx に焼き込み
-    palt/vpal/halt/vhal 削除
+    vpal/halt/vhal を削除し、役物だけの palt/vpal feature を再生成
   → _apply_tracking で advance を広げ LSB を半分シフト
     ただし family["trackingIgnore"] の連続・隙間なし記号は除外
   → _apply_glyph_spacing で family["glyphSpacing"] の個別調整を適用
@@ -85,6 +86,10 @@ FAMILIES × WEIGHTS の各組合せに対して:
                      family/weight を「Gen Interface JP …」に刻印
                      metricsSource=sub で Inter 基準の hhea を採用
                      manufacturer / manufacturerURL を刻印
+  → final TTF を一度 reload/save し、GSUB/GPOS coverage を
+    merge 後の glyph ID 順に正規化
+  → merge 時の glyph rename 後も encoded glyph に live 役物 feature が
+    残るよう、final cmap に対して runtime palt/vpal を再生成
 ```
 
 ### 2. Web 用サブセット化 (`webfont.build`)
@@ -132,16 +137,23 @@ Stage 2 に渡る。
 
 inst に対して 4 つのサブパスを in-place で実行:
 
-1. **palt のベイク** (`proportional.make_proportional`) — palt 値は
+1. **palt のベイク / runtime vpal** (`proportional.make_proportional`) — palt 値は
    キャッシュ済みの variable から読む (instantiation で非デフォルト軸位置の
    palt ValueRecord が壊れることがあるため)。XPlacement / XAdvance を
    LSB / advance に加算しアウトラインをシフト。Noto の palt エントリは
-   すべて全量で焼き込む; tracking-only / full-palt 記号リストのような
-   別分類は持たない。palt なしグリフは自動的に sidebearing を詰めない;
-   後続の明示的な spacing ルールが触らない限り元の `hmtx` を維持する。
+   原則として全量で焼き込むが、`PALT_FEATURE_CHARS` の役物は焼き込まず、
+   live `palt` GPOS feature として再生成する。Noto の `vpal` も同じ
+   variable から読み、`VPAL_FEATURE_CHARS` に列挙した Unicode-mapped
+   役物 33 glyph (縦組み presentation form と全角パーセントを含む) を
+   live `vpal` として再生成する。全角コロン / セミコロンは Noto に palt は
+   あるが vpal がなく、縦組みコロンは unmapped の `glyph17071` に
+   置換されるため、小さな合成 fallback を `SYNTHETIC_VPAL_ADJUSTMENTS` で
+   足す。`vpal` は `hmtx` には焼き込まない。palt なしグリフは自動的に
+   sidebearing を詰めない; 後続の明示的な spacing ルールが触らない限り
+   元の `hmtx` を維持する。
    `U+30FB` (・) は Noto では `U+2027` (‧) と同じ `uni2027` を共有して
-   いるため、palt ベイク前に `uni30FB` として分離する。これにより `‧` は
-   palt + tracking のみ、`・` は明示的な spacing 補正ありとして扱える。
+   いるため、palt ベイク前に `uni30FB` として分離する。これにより `‧` と
+   `・` は必要に応じて別々の live palt record を持てる。
 2. **トラッキング** (`_apply_tracking`) — advance を `tracking` 分広げ、
    `tracking // 2` を LSB に加算してアウトラインを広がった枠の中央に
    配置。kana / 句読点はファミリー設定の `trackingKana` で別値。
@@ -164,9 +176,9 @@ inst に対して 4 つのサブパスを in-place で実行:
    palt 後に詰まり気味に見えるため、このレイヤーで左右に明示的な余白を
    足す。大半の小書き仮名は左右 15 units を基準にしつつ、カタカナの
    小書き「ィ」「ャ」や、ひらがなの小書き「ょ」などは見え方に合わせて
-   個別値を持つ。`U+30FB` (・) は `trackingIgnore` ではなくここで
-   扱う: 他の調整対象の句読点と同じく tracking を通し、Normal family では
-   family-specific な spacing 値で最終 hmtx を従来の目標に合わせる。
+   個別値を持つ。`U+30FB` (・) を含む役物はここでは扱わない: tracking は
+   通常どおり通し、横方向の詰めは live `palt` feature に任せる。縦方向の
+   proportional spacing は別集合の `VPAL_FEATURE_CHARS` で制御する。
 4. **bbox 除去** (`_strip_extreme_glyphs`) — 下記 [垂直メトリクス] 参照。
 
 オプションの **横スケール** (`xScale` 設定、現在未使用) は上記の後に
@@ -193,6 +205,12 @@ font-baker は sub のほうを `uni25CE.sub` にリネームし、base のグ�
 
 `output.manufacturer = "Yamato Iizuka"`、`output.manufacturerURL =
 "https://yamatoiizuka.com"` でリリース TTF の nameID 8 / 11 を刻印。
+merge 後は final TTF を一度 fontTools で reload/save し、GSUB/GPOS coverage を
+最終 glyph order に合わせて正規化する。その後、merge 前に codepoint keyed で
+保持した最小 runtime `palt` / `vpal` を final cmap に対して再生成する。
+これは `U+FF40` (｀) のように、Noto では `U+2035` と同じ `uni2035`
+を共有するが、Inter 側の `U+2035` と衝突して merge 後に
+`uni2035.orig` へ rename される glyph で必要になる。
 
 ## プロポーショナルメトリクス (`font/proportional.py`)
 
@@ -202,17 +220,31 @@ em-square を占有し、`palt` GPOS が runtime に kana / Latin を光学的�
 フォールバック、CJK を等幅扱いするレイアウトエンジン) ではこの調整が
 効かず、全角ピッチで組まれてしまう。
 
-`make_proportional` は `palt` を static の `hmtx` に焼き込み、その上で
-`palt` / `vpal` / `halt` / `vhal` を削除する — `palt` を効かせるアプリで
-二重適用されるのを防ぐため。TrueType アウトラインのみ対応 (palt のベイクは
-`glyf` に書き戻すので CFF は対象外)。
+`make_proportional` は多くの `palt` 値を static の `hmtx` に焼き込む。
+`runtime_palt` が指定されたグリフはベイク対象から外し、いったん
+`palt` / `vpal` / `halt` / `vhal` を削除した後、そのグリフ集合だけの
+新しい `palt` feature を追加する。`runtime_vpal` が指定された場合は、
+一致する Noto `vpal` record も水平メトリクスに触らず新しい `vpal`
+feature として戻す。ビルドでは runtime `palt` に `PALT_FEATURE_CHARS`
+(48 文字)、runtime `vpal` に `VPAL_FEATURE_CHARS` (33 文字) を使う。
+Noto の vpal には縦組み presentation form と `％` が含まれるため、
+この 2 つの集合は意図的に一致させない。`SYNTHETIC_VPAL_ADJUSTMENTS` は
+Noto が持たない全角コロン / セミコロンの縦方向 proportional record を補う。
+これにより、焼き込み済みの kana / Latin に palt が二重適用されることを
+避けながら、選択した役物だけ runtime palt/vpal を公開できる。
+TrueType アウトラインのみ対応 (palt のベイクは `glyf` に書き戻すので
+CFF は対象外)。
+Inter との merge では base 側 glyph が rename されることがあるため、
+ビルドは merge 前に runtime palt/vpal 値を codepoint 単位で保持し、
+merge 後の final cmap に対して再インストールする。
 
 `_remove_prop_features` は GPOS を 2 段で歩く: FeatureRecord の削除と、
 それに対応する LangSys インデックスの再マップ。レコード削除は後ろの全
 レコードのインデックスを動かすので、各 LangSys の `FeatureIndex` 配列を
-生き残ったレコードに対して再キーする必要がある。Lookup テーブル本体は
-触らない — palt の lookup は他の残す機能からも参照される可能性があり、
-孤立した lookup は無害なのでそのまま。
+生き残ったレコードに対して再キーする必要がある。feature 削除後は、どの
+生存 feature からも参照されない lookup だけを pruning する; 共有 lookup は
+残す。再生成した runtime-palt/vpal lookup は削除後に追加し、既存の各
+LangSys から参照させる。`kern` は GPOS に残る。
 
 ## 垂直メトリクスと Illustrator のテキストボックス問題
 
@@ -358,7 +390,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
 
 テストは表面ごとに `tests/` 直下に分割:
 
-- **`tests/conftest.py`** — 共有フィクスチャ: 実 palt / vert / cmap データ
+- **`tests/conftest.py`** — 共有フィクスチャ: 実 palt / vpal / vert / cmap データ
   が必要なテスト用に Noto Variable のサブセットをセッション単位でキャッシュ;
   全グリフ走査が必要な mutation テスト用には `FontBuilder` で組み立てた
   最小 TrueType (Noto 17000 グリフを毎回触るのは無駄)。
@@ -366,13 +398,13 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
   `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
   `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
   `_apply_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
-  `_split_cmap_codepoint_glyph`, `_get_variable_palt`、明示的な palt
-  spacing 方針。
-- **`tests/test_proportional.py`** — `_read_palt`, `_shift_glyph_x`,
-  `_remove_prop_features`, `make_proportional` (palt ベイク、reduced palt
-  scale、palt なしグリフのメトリクス維持、オプションの squeeze SB
-  sidebearing 計算、palt_override の優先、CFF 拒否、feature 削除後の
-  LangSys index 整合性)。
+  `_split_cmap_codepoint_glyph`, `_get_variable_palt`, `_get_variable_vpal`、
+  明示的な palt/vpal spacing 方針。
+- **`tests/test_proportional.py`** — `_read_palt`, `_read_vpal`,
+  `_shift_glyph_x`, `_remove_prop_features`, `make_proportional` (palt
+  ベイク、runtime-palt/vpal 再生成、reduced palt scale、palt なしグリフの
+  メトリクス維持、オプションの squeeze SB sidebearing 計算、
+  palt_override の優先、CFF 拒否、feature 削除後の LangSys index 整合性)。
 - **`tests/test_release.py`** — 公開配布の契約: GitHub アセット URL の形
   (サイトのダウンロードボタンが参照)、npm パッケージのレイアウト
   (`files` glob、生成 README、`cdn/*.css` エントリポイント、`license`
@@ -384,8 +416,8 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 81 | グリフ名パース、kana / CJK 分類、GSUB 走査、x-scale、bbox 除去、tracking |
-| `test_proportional.py` | 20 | palt 抽出、グリフ平行移動、GPOS feature 削除、reduced-palt 方針 + optional squeeze helper |
+| `test_font_build.py` | 90 | グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、runtime feature の retarget |
+| `test_proportional.py` | 28 | palt/vpal 抽出、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal 再生成 + optional squeeze helper |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,7 @@ consumes the published webfont package.
         │         metadataMode=inheritBase                │
         │             ↓                                   │
         │   [2/3] Proportionalise — proportional.py       │
-        │         palt → hmtx (grouped palt policy)       │
+        │      palt → hmtx + runtime yakumono palt/vpal   │
         │         tracking (with repeatable skips)        │
         │         + strip extreme bbox                    │
         │             ↓                                   │
@@ -32,6 +32,7 @@ consumes the published webfont package.
         │         subFont.excludeCodepoints keeps         │
         │         CJK-conventional symbols on Noto        │
         │         metricsSource=sub, manufacturer stamp   │
+        │         normalize GSUB/GPOS coverage order      │
         │             ↓                                   │
         │   dist/ttf/  (one TTF per family × weight)      │
         │                                                  │
@@ -67,10 +68,11 @@ For each (family, weight) in FAMILIES × WEIGHTS:
   → font-baker bake: variable Noto → static TTF
                     inheritBase passes designer/OFL/version
                     through; only weight is stamped
-  → reload inst, read palt from cached variable font
-  → bake every Noto palt entry at full strength
+  → reload inst, read palt/vpal from cached variable font
+  → bake Noto palt at full strength except runtime yakumono
     (glyphs without palt keep metrics)
-  → make_proportional bakes palt → hmtx, strips palt/vpal/halt/vhal
+  → make_proportional bakes palt → hmtx, removes vpal/halt/vhal,
+    and reinstalls yakumono-only palt/vpal features
   → _apply_tracking widens advances + half-balances LSB
     except repeatable no-gap symbols in family["trackingIgnore"]
   → _apply_glyph_spacing applies family["glyphSpacing"] sidebearing tweaks
@@ -84,6 +86,10 @@ For each (family, weight) in FAMILIES × WEIGHTS:
                      family/weight stamped to "Gen Interface JP …"
                      metricsSource=sub anchors hhea on Inter
                      manufacturer / manufacturerURL stamped
+  → reload/save final TTF once so GSUB/GPOS coverage tables are ordered
+    by the final merged glyph IDs
+  → reinstall runtime palt/vpal against the final cmap so merge-time
+    glyph renames keep the live yakumono features on the encoded glyphs
 ```
 
 ### 2. Subset for the Web (`webfont.build`)
@@ -130,17 +136,23 @@ save/restore.
 
 Four sub-passes, all in-place on the inst:
 
-1. **palt baking** (`proportional.make_proportional`) — palt values are
+1. **palt baking / runtime vpal** (`proportional.make_proportional`) — palt values are
    read from the cached variable font (instantiation can corrupt palt's
    ValueRecords at non-default axis positions). XPlacement/XAdvance pairs
-   are added to LSB / advance, outlines shifted. Every Noto palt entry is
-   baked at full strength; there is no separate tracking-only or full-palt
-   symbol list. Glyphs without palt entries are not automatically
-   sidebearing-squeezed; they keep their original `hmtx` unless a later
-   explicit spacing rule touches them.
+   are added to LSB / advance, outlines shifted. Most Noto palt entries are
+   baked at full strength, but yakumono listed in `PALT_FEATURE_CHARS`
+   is left unbaked and reinstalled as a live `palt` GPOS feature. Noto
+   `vpal` is read from the same variable source and reinstalled for the
+   Unicode-mapped yakumono listed in `VPAL_FEATURE_CHARS` (33 glyphs,
+   including vertical presentation forms and fullwidth percent). Fullwidth
+   colon / semicolon need a small synthesized fallback because Noto has palt
+   for them but no vpal, and vertical colon is substituted to the unmapped
+   `glyph17071`. `vpal` is not baked into `hmtx`. Glyphs without palt entries
+   are not automatically sidebearing-squeezed; they keep their original
+   `hmtx` unless a later explicit spacing rule touches them.
    `U+30FB` (・) is split from Noto's shared `uni2027` glyph before palt
-   baking so `U+2027` (‧) can remain palt + tracking only while `U+30FB`
-   receives explicit spacing compensation.
+   baking so `U+2027` (‧) and `U+30FB` (・) can carry separate live palt
+   records when needed.
 2. **Tracking** (`_apply_tracking`) — advance grows by `tracking`;
    `tracking // 2` is added to LSB so the outline sits centred in the
    wider slot. Kana / punctuation get a separate `trackingKana` value
@@ -165,11 +177,11 @@ Four sub-passes, all in-place on the inst:
    add explicit margin on both sides after palt, because the small forms
    otherwise read too tight in UI text; most small kana use 15 units per
    side, with a few optical exceptions such as small katakana i (`ィ`),
-   small katakana ya (`ャ`), and small hiragana yo (`ょ`). `U+30FB` (・) is
-   intentionally handled here instead of `trackingIgnore`: it passes
-   through tracking like other adjusted punctuation, and Normal uses a
-   family-specific spacing value so the final hmtx matches the previous
-   target.
+   small katakana ya (`ャ`), and small hiragana yo (`ょ`). Punctuation,
+   including `U+30FB` (・), is intentionally not handled here: it passes
+   through tracking and tightens only through the live `palt` feature.
+   Vertical proportional spacing is controlled by the separate
+   `VPAL_FEATURE_CHARS` set.
 4. **Bbox strip** (`_strip_extreme_glyphs`) — see [Vertical metrics]
    below.
 
@@ -198,6 +210,13 @@ to feel proportionate.
 
 `output.manufacturer = "Yamato Iizuka"`, `output.manufacturerURL =
 "https://yamatoiizuka.com"` stamp nameID 8 / 11 on every released TTF.
+After the merge, the TTF is reloaded and saved once with fontTools so
+GSUB/GPOS coverage tables are sorted against the final merged glyph order.
+Then the minimal runtime `palt` / `vpal` features are rebuilt one final
+time from codepoint-keyed records captured before the merge. This matters
+for shared Noto glyphs such as `U+FF40` (｀), which uses Noto's `uni2035`
+before merge but may be renamed to `uni2035.orig` when Inter also provides
+`U+2035`.
 
 ## Proportional Metrics (`font/proportional.py`)
 
@@ -207,17 +226,33 @@ optically at runtime. Apps that don't enable `palt` (Adobe's Japanese
 composer, browser fallbacks, anything treating CJK as monospaced for
 layout) miss those adjustments and lay out at full-width spacing.
 
-`make_proportional` bakes `palt` into the static `hmtx` so the font reads
-proportional everywhere, then strips `palt` / `vpal` / `halt` / `vhal` to
-prevent apps that *do* honour them from double-applying. Only TrueType
-outlines are supported — palt baking writes back to `glyf`, not CFF.
+`make_proportional` bakes most `palt` values into the static `hmtx` so the
+font reads proportional everywhere. When `runtime_palt` is provided, those
+glyphs are skipped during baking; after `palt` / `vpal` / `halt` / `vhal`
+are stripped, a fresh `palt` feature is installed for just that glyph set.
+When `runtime_vpal` is provided, matching Noto `vpal` records are also
+reinstalled as a fresh `vpal` feature without affecting horizontal metrics.
+The build uses `PALT_FEATURE_CHARS` (48 chars) for runtime `palt` and
+`VPAL_FEATURE_CHARS` (33 chars) for runtime `vpal`; these sets intentionally
+differ because Noto's vertical proportional feature contains vertical
+presentation forms and `％` that are not horizontal palt targets.
+`SYNTHETIC_VPAL_ADJUSTMENTS` adds the missing vertical proportional records
+for fullwidth colon / semicolon that Noto omits.
+This avoids double-applying palt to baked kana / Latin while still exposing
+runtime palt/vpal for selected yakumono. Only TrueType outlines are supported
+— palt baking writes back to `glyf`, not CFF.
+Because the Inter merge can rename colliding base glyphs, the build captures
+runtime palt/vpal values by codepoint before the merge and reinstalls them
+against the final cmap afterward.
 
 `_remove_prop_features` walks GPOS in two coordinated passes:
 FeatureRecord deletions and the corresponding LangSys index remap.
 Removing a record changes the indices of every later record, so each
 LangSys's `FeatureIndex` array is re-keyed against the surviving records.
-Lookup tables themselves are untouched — palt's lookups may also be
-referenced by other features we keep, and orphaned lookups are harmless.
+After feature removal, lookup indices are pruned only when no surviving
+feature references them; shared lookups stay intact. The regenerated
+runtime-palt/vpal lookups are appended after removal and referenced from
+every existing LangSys. `kern` remains in GPOS.
 
 ## Vertical Metrics & the Illustrator Box Problem
 
@@ -367,20 +402,20 @@ PYTHONPATH=src python3 -m pytest        # full suite (~0.6s)
 Tests live under `tests/`, split by surface:
 
 - **`tests/conftest.py`** — shared fixtures: a session-cached subset of
-  Noto Variable for tests that need real palt / vert / cmap data, and a
+  Noto Variable for tests that need real palt / vpal / vert / cmap data, and a
   hand-built minimal TrueType (`FontBuilder`) for whole-font mutation
   tests where 17 000 Noto glyphs would be wasteful.
 - **`tests/test_font_build.py`** — `_glyph_codepoint`, `_is_kana_or_punct`,
   `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
   `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
   `_apply_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
-  `_split_cmap_codepoint_glyph`, `_get_variable_palt`, and the explicit
-  palt spacing policy.
-- **`tests/test_proportional.py`** — `_read_palt`, `_shift_glyph_x`,
-  `_remove_prop_features`, `make_proportional` (palt baking, reduced
-  palt scaling, non-palt metric preservation, optional squeeze SB
-  sidebearing math, palt_override precedence, CFF rejection, LangSys
-  index validity post-removal).
+  `_split_cmap_codepoint_glyph`, `_get_variable_palt`, `_get_variable_vpal`,
+  and the explicit palt/vpal spacing policy.
+- **`tests/test_proportional.py`** — `_read_palt`, `_read_vpal`,
+  `_shift_glyph_x`, `_remove_prop_features`, `make_proportional` (palt
+  baking, runtime-palt/vpal reinstall, reduced palt scaling, non-palt metric
+  preservation, optional squeeze SB sidebearing math, palt_override
+  precedence, CFF rejection, LangSys index validity post-removal).
 - **`tests/test_release.py`** — public distribution contracts: GitHub
   asset URL shape (referenced by the site download button), npm package
   layout including `files` glob, generated README, `cdn/*.css` entrypoints,
@@ -392,8 +427,8 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 81 | Glyph-name parsing, kana / CJK classification, GSUB walk, x-scale, bbox strip, tracking |
-| `test_proportional.py` | 20 | palt extraction, glyph translation, GPOS feature removal, reduced-palt policy + optional squeeze helper |
+| `test_font_build.py` | 90 | Glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, runtime feature retargeting |
+| `test_proportional.py` | 28 | palt/vpal extraction, glyph translation, GPOS feature removal, runtime-palt/vpal reinstall + optional squeeze helper |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-interface-jp"
-version = "0.1.9"
+version = "0.1.10"
 description = "Typeface harmonizing Latin and Japanese for digital interfaces."
 license = "MIT"
 license-files = ["LICENSE"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-interface-jp"
-version = "0.1.10"
+version = "0.2.0"
 description = "Typeface harmonizing Latin and Japanese for digital interfaces."
 license = "MIT"
 license-files = ["LICENSE"]

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -12,8 +12,8 @@ Shared pipeline per weight:
      subFont.excludeCodepoints to keep CJK-conventional symbols on Noto)
 
 Families:
-  - Gen Interface JP         : Inter       + proportional Noto, tracking +50 (kana/punct +60)
-  - Gen Interface JP Display : InterDisplay + proportional Noto, tracking +20
+  - Gen Interface JP         : Inter       + proportional Noto, tracking +30 (kana/punct +40)
+  - Gen Interface JP Display : InterDisplay + proportional Noto, tracking +0
 
 Outputs TTF into dist/ttf/. Web delivery (subset WOFF2 chunks served via
 unicode-range) is generated separately by the webfont module from these
@@ -23,12 +23,20 @@ TTF outputs — see src/webfont/.
 from __future__ import annotations
 
 import copy
+from contextlib import contextmanager
+import logging
 import os
 import sys
 
 from fontTools.ttLib import TTFont
+from fontTools.ttLib.reorderGlyphs import reorderGlyphs
 from merge_fonts import merge_fonts, parse_codepoint_list
-from .proportional import make_proportional
+from .proportional import (
+    _install_palt_feature,
+    _install_vpal_feature,
+    _remove_prop_features,
+    make_proportional,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -73,56 +81,52 @@ TRACKING_IGNORE_CODEPOINTS = (
     "U+FFE3",          # ￣ FULLWIDTH MACRON
 )
 
-# Glyphs listed here get full Noto palt like every other palt glyph, then
-# receive explicit hmtx spacing after tracking. The values are derived from
-# the canonical Noto palt records so that:
-#
-#   full palt + tracking + glyphSpacing == previous reduced-palt output
-#
-# for advance and hmtx LSB. This keeps the current visual rhythm for the
-# more spacing-sensitive punctuation while letting the pipeline express the
-# policy as "full palt, then explicit spacing compensation".
+# These yakumono punctuation/symbol glyphs keep a live palt feature instead
+# of receiving hand-tuned hmtx spacing. They still receive normal tracking;
+# palt is applied later by the shaper when the feature is enabled.
+PALT_FEATURE_CHARS = (
+    "、", "。", "，", "．",
+    "〈", "〉", "《", "》",
+    "「", "」", "『", "』",
+    "【", "】", "〔", "〕",
+    "〖", "〗", "〘", "〙",
+    "〚", "〛", "（", "）",
+    "｛", "｝", "｟", "｠",
+    "〝", "〞", "〟", "［", "］",
+    "！", "？", "・", "：", "；",
+    "〒", "＂", "＃", "＄", "＆",
+    "＇", "＊", "＾", "｀", "￥",
+)
+
+# Unicode-mapped Noto vpal yakumono records kept as a live vertical
+# proportional feature. This intentionally differs from PALT_FEATURE_CHARS:
+# Noto's vpal source contains vertical presentation forms and fullwidth
+# percent, so those remain available for vertical shaping even though they
+# are not horizontal palt targets.
+VPAL_FEATURE_CHARS = (
+    "〒", "・",
+    "︐", "︑", "︒", "︗", "︘",
+    "︵", "︶", "︷", "︸", "︹", "︺",
+    "︻", "︼", "︽", "︾", "︿", "﹀",
+    "﹁", "﹂", "﹃", "﹄", "﹇", "﹈",
+    "！", "＃", "＄", "％", "＆", "＊", "？", "￥",
+)
+
+# Noto has palt for fullwidth colon/semicolon but no matching vpal. In
+# vertical layout U+FF1A (：) is GSUB-vert substituted to the unmapped
+# glyph17071, so a Unicode-driven VPAL_FEATURE_CHARS pass cannot reach it.
+# Synthesize the vertical analogue of Noto's palt (-250, -500): shift down
+# into the half-height slot and reduce vertical advance by 500.
+SYNTHETIC_VPAL_ADJUSTMENTS = {
+    "glyph17071": (250, -500),  # vertical alternate for U+FF1A ：
+    "uniFF1B": (250, -500),     # U+FF1B ； has no vert substitution
+}
+
+# Glyphs listed here get full Noto palt baked like every other non-runtime
+# palt glyph, then receive explicit hmtx spacing after tracking. Keep this
+# list limited to small kana that need breathing room after palt; yakumono
+# belongs in PALT_FEATURE_CHARS so it can tighten via the live palt feature.
 PALT_SPACE_ADJUSTMENTS = {
-    "、": (0, 327),
-    "。": (0, 340),
-    "，": (43, 290),
-    "．": (53, 280),
-    "〈": (317, 16),
-    "〉": (17, 316),
-    "《": (320, 13),
-    "》": (13, 320),
-    "「": (321, 12),
-    "」": (13, 320),
-    "『": (321, 12),
-    "』": (13, 320),
-    "【": (317, 16),
-    "】": (16, 317),
-    "〔": (314, 19),
-    "〕": (19, 314),
-    "〖": (333, 0),
-    "〗": (0, 333),
-    "〘": (320, 13),
-    "〙": (13, 320),
-    "〚": (333, 0),
-    "〛": (0, 333),
-    "（": (309, 24),
-    "）": (24, 309),
-    "｛": (320, 13),
-    "｝": (13, 320),
-    "｟": (315, 18),
-    "｠": (19, 314),
-    "〝": (312, 21),
-    "〞": (0, 333),
-    "〟": (21, 312),
-    "［": (321, 12),
-    "］": (13, 320),
-    "！": (167, 166),
-    "？": (89, 100),
-    "・": (167, 166),
-    "：": (167, 166),
-    "；": (167, 166),
-    # Small kana read too tight after full palt; give them explicit
-    # breathing room on both sides.
     "ぁ": (15, 15),
     "ぃ": (15, 15),
     "ぅ": (15, 15),
@@ -157,10 +161,6 @@ DISPLAY_TRACKING_KANA = 0
 
 NORMAL_PALT_SPACE_ADJUSTMENTS = {
     **PALT_SPACE_ADJUSTMENTS,
-    # U+30FB used to skip tracking in the legacy pipeline. It now passes
-    # through tracking like the other Group A symbols, so Normal uses a
-    # family-specific spacing value to keep the same final hmtx target.
-    "・": (147, 146),
 }
 
 DISPLAY_PALT_SPACE_ADJUSTMENTS = PALT_SPACE_ADJUSTMENTS
@@ -173,6 +173,8 @@ FAMILIES = {
         "tracking": NORMAL_TRACKING,
         "trackingKana": NORMAL_TRACKING_KANA,
         "trackingIgnore": TRACKING_IGNORE_CODEPOINTS,
+        "runtimePalt": PALT_FEATURE_CHARS,
+        "runtimeVpal": VPAL_FEATURE_CHARS,
         "folderPrefix": "GenInterfaceJP",
         # Per-glyph sidebearing tweaks applied after tracking. Map a
         # codepoint (int) or single-char string to a (lsb_delta, rsb_delta)
@@ -190,6 +192,8 @@ FAMILIES = {
         "tracking": DISPLAY_TRACKING,
         "trackingKana": DISPLAY_TRACKING_KANA,
         "trackingIgnore": TRACKING_IGNORE_CODEPOINTS,
+        "runtimePalt": PALT_FEATURE_CHARS,
+        "runtimeVpal": VPAL_FEATURE_CHARS,
         "folderPrefix": "GenInterfaceJPDisplay",
         "glyphSpacing": {
             **DISPLAY_PALT_SPACE_ADJUSTMENTS,
@@ -252,10 +256,11 @@ SCALE = 0.925
 
 
 # ---------------------------------------------------------------------------
-# Variable-font palt cache
+# Variable-font palt/vpal caches
 # ---------------------------------------------------------------------------
 
 _variable_palt_cache: dict | None = None
+_variable_vpal_cache: dict | None = None
 
 
 def _get_variable_palt() -> dict[str, tuple[int, int]]:
@@ -275,6 +280,22 @@ def _get_variable_palt() -> dict[str, tuple[int, int]]:
         font = TTFont(NOTO_VARIABLE)
         _variable_palt_cache = _read_palt(font)
     return _variable_palt_cache
+
+
+def _get_variable_vpal() -> dict[str, tuple[int, int]]:
+    """Read vpal adjustments from the original Noto variable font (cached).
+
+    Mirrors :func:`_get_variable_palt`; the final build only reinstalls the
+    subset that overlaps runtime yakumono glyphs, but the source of truth is
+    still the vendor variable font.
+    """
+    global _variable_vpal_cache
+    if _variable_vpal_cache is None:
+        from .proportional import _read_vpal
+
+        font = TTFont(NOTO_VARIABLE)
+        _variable_vpal_cache = _read_vpal(font)
+    return _variable_vpal_cache
 
 
 # ---------------------------------------------------------------------------
@@ -639,7 +660,14 @@ def _glyphs_for_codepoints(
     font: TTFont,
     codepoint_entries: list | tuple | set | None,
 ) -> set[str]:
-    """Resolve codepoint entries to glyph names via cmap."""
+    """Resolve codepoint / single-character entries to glyph names via cmap."""
+    codepoints = _codepoints_for_entries(codepoint_entries)
+    cmap = font.getBestCmap() or {}
+    return {glyph_name for cp, glyph_name in cmap.items() if cp in codepoints}
+
+
+def _codepoints_for_entries(codepoint_entries: list | tuple | set | None) -> set[int]:
+    """Resolve mixed codepoint entries into integer codepoints."""
     if not codepoint_entries:
         return set()
     entries = (
@@ -647,9 +675,107 @@ def _glyphs_for_codepoints(
         if isinstance(codepoint_entries, set)
         else codepoint_entries
     )
-    codepoints = parse_codepoint_list(entries)
+    codepoints = set()
+    parse_entries = []
+    for entry in entries:
+        if isinstance(entry, str) and len(entry) == 1:
+            codepoints.add(ord(entry))
+        else:
+            parse_entries.append(entry)
+    if parse_entries:
+        codepoints.update(parse_codepoint_list(parse_entries))
+    return codepoints
+
+
+def _feature_adjustments_for_codepoints(
+    font: TTFont,
+    codepoint_entries: list | tuple | set | None,
+    source_adjustments: dict[str, tuple[int, int]],
+) -> dict[int, tuple[int, int]]:
+    """Capture feature records by codepoint before merge-time glyph renames.
+
+    font-baker can rename base glyphs when Inter and Noto both contain the
+    same glyph name. Runtime palt/vpal targets must therefore survive by
+    Unicode scalar, then be retargeted to the final cmap glyph after merge.
+    """
+    if not source_adjustments:
+        return {}
+    codepoints = _codepoints_for_entries(codepoint_entries)
+    if not codepoints:
+        return {}
     cmap = font.getBestCmap() or {}
-    return {glyph_name for cp, glyph_name in cmap.items() if cp in codepoints}
+    return {
+        cp: source_adjustments[glyph_name]
+        for cp, glyph_name in cmap.items()
+        if cp in codepoints and glyph_name in source_adjustments
+    }
+
+
+def _retarget_feature_adjustments(
+    font: TTFont,
+    adjustments_by_codepoint: dict[int, tuple[int, int]],
+) -> dict[str, tuple[int, int]]:
+    """Map codepoint-keyed feature records onto the final font's glyph names."""
+    if not adjustments_by_codepoint:
+        return {}
+    cmap = font.getBestCmap() or {}
+    glyph_order = set(font.getGlyphOrder())
+    return {
+        glyph_name: value
+        for cp, value in adjustments_by_codepoint.items()
+        if (glyph_name := cmap.get(cp)) in glyph_order
+    }
+
+
+def _retarget_named_adjustments(
+    font: TTFont,
+    adjustments_by_glyph: dict[str, tuple[int, int]],
+) -> dict[str, tuple[int, int]]:
+    """Map glyph-name fallback records onto the final font when possible."""
+    if not adjustments_by_glyph:
+        return {}
+    cmap = font.getBestCmap() or {}
+    glyph_order = set(font.getGlyphOrder())
+    retargeted = {}
+    for glyph_name, value in adjustments_by_glyph.items():
+        if glyph_name in glyph_order:
+            retargeted[glyph_name] = value
+            continue
+        cp = _glyph_codepoint(glyph_name)
+        if cp is not None and (target_glyph := cmap.get(cp)) in glyph_order:
+            retargeted[target_glyph] = value
+    return retargeted
+
+
+def _refresh_runtime_prop_features_after_merge(
+    final_path: str,
+    runtime_palt_by_codepoint: dict[int, tuple[int, int]],
+    runtime_vpal_by_codepoint: dict[int, tuple[int, int]],
+    runtime_vpal_by_glyph: dict[str, tuple[int, int]],
+) -> None:
+    """Reinstall live palt/vpal after Inter+Noto merge glyph renaming.
+
+    The pre-merge proportional Noto already has minimal runtime palt/vpal,
+    but font-baker may rename colliding base glyphs in the final font. Rebuild
+    those features once more against the final cmap so characters such as
+    U+FF40 (｀), which shares Noto's ``uni2035`` glyph before merge, keep their
+    live palt on the renamed final glyph.
+    """
+    font = TTFont(final_path)
+    palt_adjustments = _retarget_feature_adjustments(
+        font,
+        runtime_palt_by_codepoint,
+    )
+    vpal_adjustments = _retarget_feature_adjustments(
+        font,
+        runtime_vpal_by_codepoint,
+    )
+    vpal_adjustments.update(_retarget_named_adjustments(font, runtime_vpal_by_glyph))
+
+    _remove_prop_features(font)
+    _install_palt_feature(font, palt_adjustments)
+    _install_vpal_feature(font, vpal_adjustments)
+    font.save(final_path)
 
 
 def _tracking_ignore_glyphs(
@@ -772,6 +898,31 @@ def _apply_glyph_spacing(font: TTFont, spacing: dict | None) -> int:
     return adjusted
 
 
+@contextmanager
+def _suppress_fonttools_coverage_warnings():
+    """Suppress known coverage-order warnings around font-baker merge output.
+
+    font-baker can reorder glyphs while carrying layout lookups through the
+    merge. fontTools warns while writing that intermediate final font, then a
+    normal TTFont load/save sorts the coverage tables by the final glyph IDs.
+    """
+    logger = logging.getLogger("fontTools.ttLib.tables.otTables")
+    old_level = logger.level
+    logger.setLevel(logging.ERROR)
+    try:
+        yield
+    finally:
+        logger.setLevel(old_level)
+
+
+def _normalize_layout_coverage_order(font_path: str) -> None:
+    """Rewrite a TTF so GSUB/GPOS coverage tables follow final glyph order."""
+    with _suppress_fonttools_coverage_warnings():
+        font = TTFont(font_path)
+        reorderGlyphs(font, font.getGlyphOrder())
+        font.save(font_path)
+
+
 # ---------------------------------------------------------------------------
 # Pipeline
 # ---------------------------------------------------------------------------
@@ -786,9 +937,9 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
        Noto identity records survive into the inst.
     2. **Proportionalise** the inst — read palt from the variable cache
        (variable instantiation can corrupt palt), bake those adjustments
-       into hmtx, apply tracking, apply per-glyph sidebearing tweaks
-       from ``family["glyphSpacing"]``, strip extreme bbox glyphs,
-       optionally apply x-scale.
+       into hmtx except selected runtime-palt yakumono, apply tracking,
+       apply per-glyph sidebearing tweaks from ``family["glyphSpacing"]``,
+       strip extreme bbox glyphs, optionally apply x-scale.
     3. **Merge** the proportional Noto with the matching Inter master via
        font-baker. ``subFont.excludeCodepoints`` keeps CJK-conventional
        symbols (※, ◯, ①, Ⓐ, …) on the Noto outline, and font-baker's
@@ -836,6 +987,8 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     tracking = family["tracking"]
     tracking_kana = family["trackingKana"]
     tracking_ignore = family.get("trackingIgnore")
+    runtime_palt_chars = family.get("runtimePalt")
+    runtime_vpal_chars = family.get("runtimeVpal")
 
     desc = f"tracking +{tracking}"
     if tracking_kana is not None:
@@ -845,24 +998,46 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     font = TTFont(inst_path)
 
     # Split U+30FB from U+2027 before metrics work. Noto maps both to
-    # ``uni2027``, but U+30FB has an explicit spacing adjustment while
-    # U+2027 only needs palt + tracking.
+    # ``uni2027``, but U+30FB is one of the yakumono glyphs that should
+    # keep a live palt record while U+2027 stays on its own palt data.
     split_source = _split_cmap_codepoint_glyph(font, 0x30FB, "uni30FB")
+    runtime_palt_glyphs = _glyphs_for_codepoints(font, runtime_palt_chars)
+    runtime_vpal_glyphs = _glyphs_for_codepoints(font, runtime_vpal_chars)
 
-    # Read palt from the variable source rather than the freshly-baked inst:
-    # variable instantiation can leave palt ValueRecords with zeroed or
-    # otherwise stale XPlacement/XAdvance pairs. The cached variable read
-    # is canonical across all weights.
+    # Read palt/vpal from the variable source rather than the freshly-baked inst:
+    # variable instantiation can leave proportional ValueRecords with zeroed
+    # or otherwise stale placement/advance pairs. The cached variable read is
+    # canonical across all weights.
     palt_data = dict(_get_variable_palt())
     if split_source in palt_data:
         palt_data["uni30FB"] = palt_data[split_source]
+    vpal_data = dict(_get_variable_vpal())
+    if split_source in vpal_data:
+        vpal_data["uni30FB"] = vpal_data[split_source]
+    for glyph_name, value in SYNTHETIC_VPAL_ADJUSTMENTS.items():
+        if glyph_name in font.getGlyphOrder():
+            vpal_data[glyph_name] = value
+            runtime_vpal_glyphs.add(glyph_name)
+    runtime_palt_by_codepoint = _feature_adjustments_for_codepoints(
+        font,
+        runtime_palt_chars,
+        palt_data,
+    )
+    runtime_vpal_by_codepoint = _feature_adjustments_for_codepoints(
+        font,
+        runtime_vpal_chars,
+        vpal_data,
+    )
 
-    # Bake every Noto palt entry at full strength. Glyphs without palt keep
-    # their original hmtx; selected punctuation is adjusted later by
-    # glyphSpacing.
+    # Bake Noto palt entries at full strength except yakumono that should
+    # remain live palt/vpal features. Glyphs without palt keep their
+    # original hmtx.
     make_proportional(
         font,
         palt_override=palt_data,
+        runtime_palt=runtime_palt_glyphs,
+        vpal_override=vpal_data,
+        runtime_vpal=runtime_vpal_glyphs,
     )
     _apply_tracking(font, tracking, tracking_kana, tracking_ignore)
     spacing_adjusted = _apply_glyph_spacing(font, family.get("glyphSpacing"))
@@ -878,6 +1053,7 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     family_name = family["familyName"]
     file_name = f"{family['folderPrefix']}-{weight_name}"
     ttf_dir = os.path.join(DIST_TTF, family_name)
+    final_path = os.path.join(ttf_dir, f"{file_name}.ttf")
     print(f"    [3/3] Merging {family['interPrefix']} + proportional Noto...")
     merge_config = {
         "subFont": {
@@ -904,13 +1080,21 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
         },
         "export": {
             "path": {
-                "font": os.path.join(ttf_dir, f"{file_name}.ttf"),
+                "font": final_path,
             },
         },
     }
-    merge_fonts(merge_config)
+    with _suppress_fonttools_coverage_warnings():
+        merge_fonts(merge_config)
+    _normalize_layout_coverage_order(final_path)
+    _refresh_runtime_prop_features_after_merge(
+        final_path,
+        runtime_palt_by_codepoint,
+        runtime_vpal_by_codepoint,
+        SYNTHETIC_VPAL_ADJUSTMENTS,
+    )
     return {
-        "fontPath": os.path.join(ttf_dir, f"{file_name}.ttf"),
+        "fontPath": final_path,
     }
 
 

--- a/src/font/proportional.py
+++ b/src/font/proportional.py
@@ -10,10 +10,11 @@ Japanese composer, browser fallbacks, anything that treats CJK as
 monospaced for layout) miss those adjustments and lay the text out at
 full-width spacing.
 
-This module bakes ``palt`` into the static hmtx so the font reads as
-proportional everywhere, then removes the now-redundant ``palt``/``vpal``/
-``halt``/``vhal`` features to prevent apps that *do* honor them from
-double-applying. Glyphs not covered by ``palt`` keep their original
+This module bakes most ``palt`` values into the static hmtx so the font
+reads as proportional everywhere. A caller may keep a small glyph set as a
+live runtime ``palt`` / ``vpal`` feature; those glyphs are not baked, and
+fresh lookups are installed for them after the redundant proportional
+features are removed. Glyphs not covered by ``palt`` keep their original
 metrics — nothing is forced.
 
 Usage:
@@ -24,6 +25,7 @@ from __future__ import annotations
 
 import sys
 from fontTools.ttLib import TTFont
+from fontTools.ttLib.tables import otTables
 
 
 # GPOS features that provide proportional metric adjustments.
@@ -47,6 +49,9 @@ def make_proportional(
     squeeze_sb: set[str] | None = None,
     squeeze_sb_scale: float | None = None,
     palt_override: dict[str, tuple[int, int]] | None = None,
+    runtime_palt: set[str] | None = None,
+    vpal_override: dict[str, tuple[int, int]] | None = None,
+    runtime_vpal: set[str] | None = None,
 ) -> None:
     """Bake palt adjustments into hmtx in place, then strip prop features.
 
@@ -70,6 +75,17 @@ def make_proportional(
     been corrupted by variable instantiation. Variable→static baking can
     leave palt ValueRecords with zeroed XPlacement/XAdvance pairs.
 
+    ``runtime_palt`` leaves selected palt-covered glyphs unbaked and
+    reinstalls only those glyphs as a live ``palt`` feature. This lets a
+    final font expose palt for a narrow target set (e.g. yakumono)
+    without double-applying palt to kana / Latin glyphs that were already
+    baked into hmtx.
+
+    ``vpal_override`` / ``runtime_vpal`` mirror that runtime feature path
+    for vertical proportional metrics. ``vpal`` is not baked into hmtx; when
+    requested, selected records are preserved as a live GPOS feature after
+    the original proportional features are stripped.
+
     Only TrueType-outlined fonts are supported — palt baking writes back
     to ``glyf``, not to CFF.
     """
@@ -79,14 +95,30 @@ def make_proportional(
     if squeeze_sb_scale is None:
         squeeze_sb_scale = reduced_palt_scale
 
+    runtime_palt = runtime_palt or set()
+    runtime_vpal = runtime_vpal or set()
+
     # Extract palt adjustments before removing features
     palt_adjustments = palt_override if palt_override is not None else _read_palt(font)
+    runtime_palt_adjustments = {
+        glyph_name: value
+        for glyph_name, value in palt_adjustments.items()
+        if glyph_name in runtime_palt
+    }
+    vpal_adjustments = vpal_override if vpal_override is not None else _read_vpal(font)
+    runtime_vpal_adjustments = {
+        glyph_name: value
+        for glyph_name, value in vpal_adjustments.items()
+        if glyph_name in runtime_vpal
+    }
 
     glyf = font["glyf"]
     hmtx = font["hmtx"]
 
     # ── Apply palt adjustments ──
     for glyph_name, (x_placement, x_advance) in palt_adjustments.items():
+        if glyph_name in runtime_palt:
+            continue
         if glyph_name not in hmtx.metrics:
             continue
 
@@ -146,12 +178,17 @@ def make_proportional(
             new_aw = aw - lsb_remove - rsb_remove
             hmtx[glyph_name] = (new_aw, new_lsb)
 
-    # Remove proportional-metric GPOS features
+    # Remove proportional-metric GPOS features, then install minimal live
+    # palt/vpal lookups for glyphs intentionally kept at runtime.
     _remove_prop_features(font)
+    if runtime_palt_adjustments:
+        _install_palt_feature(font, runtime_palt_adjustments)
+    if runtime_vpal_adjustments:
+        _install_vpal_feature(font, runtime_vpal_adjustments)
 
 
 # ---------------------------------------------------------------------------
-# GPOS palt extraction
+# GPOS palt/vpal extraction
 # ---------------------------------------------------------------------------
 
 def _read_palt(font: TTFont) -> dict[str, tuple[int, int]]:
@@ -165,24 +202,43 @@ def _read_palt(font: TTFont) -> dict[str, tuple[int, int]]:
     Missing GPOS, missing FeatureList, or no palt records all return an
     empty dict — callers treat the absence of palt as "leave hmtx alone".
     """
+    return _read_single_pos_feature(font, "palt", "XPlacement", "XAdvance")
+
+
+def _read_vpal(font: TTFont) -> dict[str, tuple[int, int]]:
+    """Walk GPOS vpal lookups and return ``{glyph_name: (YPlacement, YAdvance)}``.
+
+    Mirrors :func:`_read_palt`, but reads vertical placement / advance
+    records. Missing GPOS, missing FeatureList, or no vpal records all
+    return an empty dict.
+    """
+    return _read_single_pos_feature(font, "vpal", "YPlacement", "YAdvance")
+
+
+def _read_single_pos_feature(
+    font: TTFont,
+    feature_tag: str,
+    placement_attr: str,
+    advance_attr: str,
+) -> dict[str, tuple[int, int]]:
+    """Read a SinglePos feature as ``{glyph_name: (placement, advance)}``."""
     gpos = font.get("GPOS")
     if gpos is None or gpos.table is None:
         return {}
     if gpos.table.FeatureList is None:
         return {}
 
-    # Find palt feature
-    palt_lookup_indices = []
+    lookup_indices = []
     for fr in gpos.table.FeatureList.FeatureRecord:
-        if fr.FeatureTag == "palt":
-            palt_lookup_indices.extend(fr.Feature.LookupListIndex)
+        if fr.FeatureTag == feature_tag:
+            lookup_indices.extend(fr.Feature.LookupListIndex)
 
-    if not palt_lookup_indices:
+    if not lookup_indices:
         return {}
 
     adjustments: dict[str, tuple[int, int]] = {}
 
-    for li in palt_lookup_indices:
+    for li in lookup_indices:
         lookup = gpos.table.LookupList.Lookup[li]
         lookup_type = lookup.LookupType
 
@@ -190,8 +246,12 @@ def _read_palt(font: TTFont) -> dict[str, tuple[int, int]]:
         # Unwrap Extension lookups (type 9)
         if lookup_type == 9:
             subtables = [st.ExtSubTable for st in subtables]
+        elif lookup_type != 1:
+            continue
 
         for subtable in subtables:
+            if not hasattr(subtable, "Coverage") or subtable.Coverage is None:
+                continue
             glyphs = subtable.Coverage.glyphs
             for j, glyph_name in enumerate(glyphs):
                 if subtable.Format == 1:
@@ -203,9 +263,9 @@ def _read_palt(font: TTFont) -> dict[str, tuple[int, int]]:
                 else:
                     continue
 
-                xp = getattr(v, "XPlacement", 0) or 0
-                xa = getattr(v, "XAdvance", 0) or 0
-                adjustments[glyph_name] = (xp, xa)
+                placement = getattr(v, placement_attr, 0) or 0
+                advance = getattr(v, advance_attr, 0) or 0
+                adjustments[glyph_name] = (placement, advance)
 
     return adjustments
 
@@ -254,9 +314,9 @@ def _remove_prop_features(font: TTFont) -> None:
     remapped — the helpers ``_filter_feature_indices`` and
     ``_remap_feature_indices`` handle the two halves of that update.
 
-    Lookup tables aren't touched: the lookups behind palt may also be
-    referenced by other features we want to keep, and orphaned lookups
-    are harmless. fontTools will write them out unchanged.
+    Lookup tables are pruned after feature removal, but only for lookups no
+    longer referenced by surviving features. If a palt lookup is shared by a
+    kept feature, it stays referenced and is not removed.
     """
     gpos = font.get("GPOS")
     if gpos is None or gpos.table is None:
@@ -304,6 +364,8 @@ def _remove_prop_features(font: TTFont) -> None:
                 for lsr in script.LangSysRecord:
                     _remap_feature_indices(lsr.LangSys, remap)
 
+    _prune_unreferenced_lookups(gpos.table)
+
 
 def _filter_feature_indices(langsys, indices_to_remove: set) -> None:
     """Remove feature indices from a LangSys."""
@@ -321,6 +383,162 @@ def _remap_feature_indices(langsys, remap: dict) -> None:
             remap[i] for i in langsys.FeatureIndex if i in remap
         ]
         langsys.FeatureCount = len(langsys.FeatureIndex)
+
+
+def _prune_unreferenced_lookups(table) -> None:
+    """Remove GPOS lookups not referenced by surviving features."""
+    if table.LookupList is None or table.FeatureList is None:
+        return
+
+    lookups = table.LookupList.Lookup
+    used = set()
+    for feature_record in table.FeatureList.FeatureRecord:
+        used.update(feature_record.Feature.LookupListIndex or [])
+
+    if used == set(range(len(lookups))):
+        return
+
+    kept = sorted(used)
+    remap = {old: new for new, old in enumerate(kept)}
+    table.LookupList.Lookup = [lookups[i] for i in kept]
+    table.LookupList.LookupCount = len(table.LookupList.Lookup)
+
+    for feature_record in table.FeatureList.FeatureRecord:
+        feature = feature_record.Feature
+        feature.LookupListIndex = [
+            remap[i] for i in feature.LookupListIndex if i in remap
+        ]
+        feature.LookupCount = len(feature.LookupListIndex)
+
+
+def _install_palt_feature(
+    font: TTFont,
+    adjustments: dict[str, tuple[int, int]],
+) -> None:
+    """Install a fresh SinglePos palt feature for ``adjustments``.
+
+    The build pipeline reads palt values from the original variable font
+    because instantiated statics can carry stale ValueRecords. Rebuilding the
+    palt feature from that canonical data is simpler and safer than trying to
+    preserve and prune the original lookup tree.
+    """
+    _install_single_pos_feature(
+        font,
+        "palt",
+        adjustments,
+        "XPlacement",
+        "XAdvance",
+        0x0001 | 0x0004,
+    )
+
+
+def _install_vpal_feature(
+    font: TTFont,
+    adjustments: dict[str, tuple[int, int]],
+) -> None:
+    """Install a fresh SinglePos vpal feature for ``adjustments``."""
+    _install_single_pos_feature(
+        font,
+        "vpal",
+        adjustments,
+        "YPlacement",
+        "YAdvance",
+        0x0002 | 0x0008,
+    )
+
+
+def _install_single_pos_feature(
+    font: TTFont,
+    feature_tag: str,
+    adjustments: dict[str, tuple[int, int]],
+    placement_attr: str,
+    advance_attr: str,
+    value_format: int,
+) -> None:
+    """Install a fresh SinglePos feature for ``adjustments``."""
+    if not adjustments:
+        return
+
+    gpos = font.get("GPOS")
+    if gpos is None or gpos.table is None:
+        return
+
+    table = gpos.table
+    if table.LookupList is None:
+        table.LookupList = otTables.LookupList()
+        table.LookupList.Lookup = []
+        table.LookupList.LookupCount = 0
+    if table.FeatureList is None:
+        table.FeatureList = otTables.FeatureList()
+        table.FeatureList.FeatureRecord = []
+        table.FeatureList.FeatureCount = 0
+
+    glyph_order = {glyph_name: i for i, glyph_name in enumerate(font.getGlyphOrder())}
+    glyphs = [
+        glyph_name for glyph_name in adjustments
+        if glyph_name in glyph_order
+    ]
+    glyphs.sort(key=glyph_order.__getitem__)
+    if not glyphs:
+        return
+
+    coverage = otTables.Coverage()
+    coverage.glyphs = glyphs
+
+    subtable = otTables.SinglePos()
+    subtable.Format = 2
+    subtable.Coverage = coverage
+    subtable.ValueFormat = value_format
+    subtable.Value = []
+    for glyph_name in glyphs:
+        placement, advance = adjustments[glyph_name]
+        value = otTables.ValueRecord()
+        setattr(value, placement_attr, placement)
+        setattr(value, advance_attr, advance)
+        subtable.Value.append(value)
+    subtable.ValueCount = len(subtable.Value)
+
+    lookup = otTables.Lookup()
+    lookup.LookupType = 1  # SinglePos
+    lookup.LookupFlag = 0
+    lookup.SubTable = [subtable]
+    lookup.SubTableCount = 1
+
+    lookup_list = table.LookupList
+    lookup_index = lookup_list.LookupCount
+    lookup_list.Lookup.append(lookup)
+    lookup_list.LookupCount += 1
+
+    feature = otTables.Feature()
+    feature.LookupListIndex = [lookup_index]
+    feature.LookupCount = 1
+
+    feature_record = otTables.FeatureRecord()
+    feature_record.FeatureTag = feature_tag
+    feature_record.Feature = feature
+
+    feature_list = table.FeatureList
+    feature_index = feature_list.FeatureCount
+    feature_list.FeatureRecord.append(feature_record)
+    feature_list.FeatureCount += 1
+
+    if table.ScriptList:
+        for script_record in table.ScriptList.ScriptRecord:
+            script = script_record.Script
+            if script.DefaultLangSys:
+                _append_feature_index(script.DefaultLangSys, feature_index)
+            if script.LangSysRecord:
+                for lsr in script.LangSysRecord:
+                    _append_feature_index(lsr.LangSys, feature_index)
+
+
+def _append_feature_index(langsys, feature_index: int) -> None:
+    """Append ``feature_index`` to a LangSys if it is not already present."""
+    feature_indices = list(langsys.FeatureIndex or [])
+    if feature_index not in feature_indices:
+        feature_indices.append(feature_index)
+    langsys.FeatureIndex = feature_indices
+    langsys.FeatureCount = len(feature_indices)
 
 
 def main():

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -16,21 +16,28 @@ from font.build import (
     _EXTREME_YMAX,
     _EXTREME_YMIN,
     _VERTICAL_REPEAT_MARK_CODEPOINTS,
+    _feature_adjustments_for_codepoints,
     _get_cjk_glyphs,
     _get_variable_palt,
+    _get_variable_vpal,
     _get_vert_alternates,
     _glyphs_for_codepoints,
     _glyph_codepoint,
     _is_cjk_codepoint,
     _is_kana_letter,
     _is_kana_or_punct,
+    _retarget_feature_adjustments,
+    _retarget_named_adjustments,
     _split_cmap_codepoint_glyph,
     _strip_extreme_glyphs,
     DISPLAY_PALT_SPACE_ADJUSTMENTS,
     NORMAL_PALT_SPACE_ADJUSTMENTS,
+    PALT_FEATURE_CHARS,
     PALT_SPACE_ADJUSTMENTS,
     SUB_EXCLUDE_CODEPOINTS,
+    SYNTHETIC_VPAL_ADJUSTMENTS,
     TRACKING_IGNORE_CODEPOINTS,
+    VPAL_FEATURE_CHARS,
 )
 from merge_fonts import parse_codepoint_list
 
@@ -534,13 +541,15 @@ class TestApplyTracking:
 # ---------------------------------------------------------------------------
 
 class TestPaltSymbolPolicy:
-    """Full palt is the default; spacing values mark the adjusted symbols."""
+    """Full palt is baked by default; selected yakumono remains runtime palt."""
 
     def test_tracking_only_symbols_are_implicit_palt_entries(self):
         palt = _get_variable_palt()
 
         for glyph_name in (
             "uni3012", "uni3005", "uni3006",
+            "uniFF02", "uniFF03", "uniFF04", "uniFF06",
+            "uniFF07", "uniFF0A",
             "uniFF10", "uniFF19", "uniFF21", "uniFF2C",
             "uniFF2E", "uniFF3A", "uniFF41", "uniFF56",
             "uniFF58", "uniFF5A", "uniFF3E",
@@ -557,13 +566,79 @@ class TestPaltSymbolPolicy:
         assert "uniFF57" not in palt  # ｗ
         assert "uniFF40" not in palt  # ｀
 
-    def test_palt_spacing_adjustments_include_punctuation_and_small_kana(self):
-        assert PALT_SPACE_ADJUSTMENTS["、"] == (0, 327)
-        assert PALT_SPACE_ADJUSTMENTS["。"] == (0, 340)
-        assert PALT_SPACE_ADJUSTMENTS["〈"] == (317, 16)
-        assert PALT_SPACE_ADJUSTMENTS["！"] == (167, 166)
-        assert PALT_SPACE_ADJUSTMENTS["？"] == (89, 100)
-        assert PALT_SPACE_ADJUSTMENTS["・"] == (167, 166)
+    def test_yakumono_uses_runtime_palt_not_spacing(self):
+        assert len(PALT_FEATURE_CHARS) == 48
+        for char in (
+            "、。，．〈〉《》「」『』【】〔〕〖〗〘〙〚〛"
+            "（）｛｝｟｠〝〞〟［］！？・：；"
+            "〒＂＃＄＆＇＊＾｀￥"
+        ):
+            assert char in PALT_FEATURE_CHARS
+            assert char not in PALT_SPACE_ADJUSTMENTS
+
+    def test_noto_vpal_yakumono_uses_separate_runtime_target_set(self):
+        vpal = _get_variable_vpal()
+        assert len(VPAL_FEATURE_CHARS) == 33
+
+        palt_overlap = set("！？・〒＃＄＆＊￥")
+        vpal_only = set("︐︑︒︗︘︵︶︷︸︹︺︻︼︽︾︿﹀﹁﹂﹃﹄﹇﹈％")
+
+        assert set(VPAL_FEATURE_CHARS) & set(PALT_FEATURE_CHARS) == palt_overlap
+        assert set(VPAL_FEATURE_CHARS) - set(PALT_FEATURE_CHARS) == vpal_only
+
+        expected_glyphs = {
+            "uni3012",  # 〒
+            "uni2027",  # ・ (Noto source glyph before U+30FB split)
+            "uniFF01",  # ！
+            "uniFF03",  # ＃
+            "uniFF04",  # ＄
+            "uniFF06",  # ＆
+            "uniFF0A",  # ＊
+            "uniFF1F",  # ？
+            "uniFFE5",  # ￥
+            "uniFE10",  # ︐
+            "uniFE11",  # ︑
+            "uniFE12",  # ︒
+            "uniFE17",  # ︗
+            "uniFE18",  # ︘
+            "uniFE35",  # ︵
+            "uniFE36",  # ︶
+            "uniFE37",  # ︷
+            "uniFE38",  # ︸
+            "uniFE39",  # ︹
+            "uniFE3A",  # ︺
+            "uniFE3B",  # ︻
+            "uniFE3C",  # ︼
+            "uniFE3D",  # ︽
+            "uniFE3E",  # ︾
+            "uniFE3F",  # ︿
+            "uniFE40",  # ﹀
+            "uniFE41",  # ﹁
+            "uniFE42",  # ﹂
+            "uniFE43",  # ﹃
+            "uniFE44",  # ﹄
+            "uniFE47",  # ﹇
+            "uniFE48",  # ﹈
+            "uniFF05",  # ％
+        }
+
+        assert expected_glyphs <= set(vpal)
+
+    def test_colon_vpal_is_synthesized_for_vertical_glyph(self):
+        assert SYNTHETIC_VPAL_ADJUSTMENTS == {
+            "glyph17071": (250, -500),
+            "uniFF1B": (250, -500),
+        }
+
+    def test_palt_spacing_adjustments_are_small_kana_only(self):
+        assert "、" not in PALT_SPACE_ADJUSTMENTS
+        assert "。" not in PALT_SPACE_ADJUSTMENTS
+        assert "〈" not in PALT_SPACE_ADJUSTMENTS
+        assert "！" not in PALT_SPACE_ADJUSTMENTS
+        assert "？" not in PALT_SPACE_ADJUSTMENTS
+        assert "・" not in PALT_SPACE_ADJUSTMENTS
+        assert "〒" not in PALT_SPACE_ADJUSTMENTS
+        assert "￥" not in PALT_SPACE_ADJUSTMENTS
 
         for char in "ぁぃぅぇぉっゃゅゎゕゖァゥェォッュョヮヵヶ":
             assert PALT_SPACE_ADJUSTMENTS[char] == (15, 15)
@@ -571,17 +646,18 @@ class TestPaltSymbolPolicy:
         assert PALT_SPACE_ADJUSTMENTS["ィ"] == (10, 10)
         assert PALT_SPACE_ADJUSTMENTS["ャ"] == (10, 15)
 
-    def test_family_spacing_adjustments_handle_middle_dot_tracking(self):
-        assert DISPLAY_PALT_SPACE_ADJUSTMENTS["・"] == (167, 166)
-        assert NORMAL_PALT_SPACE_ADJUSTMENTS["・"] == (147, 146)
+    def test_family_spacing_adjustments_do_not_override_middle_dot(self):
+        assert "・" in PALT_FEATURE_CHARS
+        assert "・" not in DISPLAY_PALT_SPACE_ADJUSTMENTS
+        assert "・" not in NORMAL_PALT_SPACE_ADJUSTMENTS
 
     def test_codepoint_entries_resolve_to_glyphs(self, synthetic_ttf):
         glyphs = _glyphs_for_codepoints(
             synthetic_ttf,
-            (0x2500, "U+3033-U+3035"),
+            (0x2500, "、", "U+3033-U+3035"),
         )
 
-        assert glyphs == {"uni2500", "uni3033", "uni3034", "uni3035"}
+        assert glyphs == {"uni2500", "uni3001", "uni3033", "uni3034", "uni3035"}
 
     def test_middle_dot_can_split_from_shared_noto_glyph(self, synthetic_ttf):
         synthetic_ttf.setGlyphOrder([*synthetic_ttf.getGlyphOrder(), "uni2027"])
@@ -600,6 +676,56 @@ class TestPaltSymbolPolicy:
         assert cmap[0x30FB] == "uni30FB"
         assert synthetic_ttf["hmtx"]["uni30FB"] == before_hmtx
         assert synthetic_ttf["hmtx"]["uni2027"] == before_hmtx
+
+    def test_runtime_feature_adjustments_survive_merge_renames(self, synthetic_ttf):
+        synthetic_ttf.setGlyphOrder([
+            *synthetic_ttf.getGlyphOrder(),
+            "uni2035",
+            "uni2035.orig",
+        ])
+        synthetic_ttf["glyf"]["uni2035"] = copy.deepcopy(synthetic_ttf["glyf"]["A"])
+        synthetic_ttf["glyf"]["uni2035.orig"] = copy.deepcopy(synthetic_ttf["glyf"]["A"])
+        synthetic_ttf["hmtx"].metrics["uni2035"] = synthetic_ttf["hmtx"]["A"]
+        synthetic_ttf["hmtx"].metrics["uni2035.orig"] = synthetic_ttf["hmtx"]["A"]
+        for table in synthetic_ttf["cmap"].tables:
+            table.cmap[0x2035] = "uni2035"
+            table.cmap[0xFF40] = "uni2035.orig"
+
+        retargeted = _retarget_feature_adjustments(
+            synthetic_ttf,
+            {0xFF40: (-199, -500)},
+        )
+
+        assert retargeted == {"uni2035.orig": (-199, -500)}
+
+    def test_runtime_feature_adjustments_capture_pre_merge_codepoints(self, synthetic_ttf):
+        for table in synthetic_ttf["cmap"].tables:
+            table.cmap[0xFF40] = "uni3030"
+
+        adjustments = _feature_adjustments_for_codepoints(
+            synthetic_ttf,
+            ("｀", "U+1234"),
+            {"uni3030": (-199, -500)},
+        )
+
+        assert adjustments == {0xFF40: (-199, -500)}
+
+    def test_named_fallback_adjustments_can_retarget_by_codepoint(self, synthetic_ttf):
+        synthetic_ttf.setGlyphOrder([
+            *synthetic_ttf.getGlyphOrder(),
+            "uniFF1B.orig",
+        ])
+        synthetic_ttf["glyf"]["uniFF1B.orig"] = copy.deepcopy(synthetic_ttf["glyf"]["A"])
+        synthetic_ttf["hmtx"].metrics["uniFF1B.orig"] = synthetic_ttf["hmtx"]["A"]
+        for table in synthetic_ttf["cmap"].tables:
+            table.cmap[0xFF1B] = "uniFF1B.orig"
+
+        retargeted = _retarget_named_adjustments(
+            synthetic_ttf,
+            {"uniFF1B": (250, -500), "glyph17071": (250, -500)},
+        )
+
+        assert retargeted == {"uniFF1B.orig": (250, -500)}
 
 
 # ---------------------------------------------------------------------------
@@ -755,4 +881,31 @@ class TestGetVariablePalt:
         # Two calls return the same cached dict — module-level cache.
         first = _get_variable_palt()
         second = _get_variable_palt()
+        assert first is second
+
+
+# ---------------------------------------------------------------------------
+# _get_variable_vpal
+# ---------------------------------------------------------------------------
+
+class TestGetVariableVpal:
+    """Cached read of vpal from the vendor Noto Variable."""
+
+    def test_returns_dict(self):
+        vpal = _get_variable_vpal()
+        assert isinstance(vpal, dict)
+        assert len(vpal) > 0
+
+    def test_returns_yplacement_yadvance_tuples(self):
+        vpal = _get_variable_vpal()
+        for gname, value in list(vpal.items())[:5]:
+            assert isinstance(gname, str)
+            assert isinstance(value, tuple)
+            assert len(value) == 2
+            assert all(isinstance(v, int) for v in value)
+
+    def test_cached_returns_same_instance(self):
+        # Two calls return the same cached dict — module-level cache.
+        first = _get_variable_vpal()
+        second = _get_variable_vpal()
         assert first is second

--- a/tests/test_proportional.py
+++ b/tests/test_proportional.py
@@ -7,6 +7,7 @@ Covers palt extraction, glyph translation, GPOS feature removal, and the
 from font.proportional import (
     PROP_FEATURES,
     _read_palt,
+    _read_vpal,
     _remove_prop_features,
     _shift_glyph_x,
     make_proportional,
@@ -49,6 +50,41 @@ class TestReadPalt:
     def test_empty_when_no_gsub_palt(self, synthetic_ttf):
         # synthetic_ttf has no GPOS at all
         assert _read_palt(synthetic_ttf) == {}
+
+
+# ---------------------------------------------------------------------------
+# _read_vpal
+# ---------------------------------------------------------------------------
+
+class TestReadVpal:
+    """GPOS vpal extraction."""
+
+    def test_returns_dict_for_noto(self, noto_subset):
+        vpal = _read_vpal(noto_subset)
+        assert isinstance(vpal, dict)
+        assert len(vpal) > 0
+
+    def test_values_are_yplacement_yadvance_pairs(self, noto_subset):
+        vpal = _read_vpal(noto_subset)
+        for gname, value in vpal.items():
+            assert isinstance(gname, str)
+            assert isinstance(value, tuple)
+            assert len(value) == 2
+            yp, ya = value
+            assert isinstance(yp, int)
+            assert isinstance(ya, int)
+
+    def test_middle_dot_has_negative_y_advance(self, noto_subset):
+        vpal = _read_vpal(noto_subset)
+        cmap = noto_subset.getBestCmap()
+        middle_dot_glyph = cmap.get(0x30FB)  # ・
+        if middle_dot_glyph in vpal:
+            yp, ya = vpal[middle_dot_glyph]
+            assert ya < 0, f"Expected negative YAdvance for ・, got {ya}"
+
+    def test_empty_when_no_gpos_vpal(self, synthetic_ttf):
+        # synthetic_ttf has no GPOS at all
+        assert _read_vpal(synthetic_ttf) == {}
 
 
 # ---------------------------------------------------------------------------
@@ -149,6 +185,19 @@ class TestRemovePropFeatures:
                     assert 0 <= idx < n_features, \
                         f"Stale FeatureIndex {idx} (n_features={n_features})"
 
+    def test_unreferenced_lookups_are_pruned(self, noto_subset):
+        _remove_prop_features(noto_subset)
+        gpos = noto_subset["GPOS"]
+        if not gpos.table.LookupList or not gpos.table.FeatureList:
+            return
+
+        n_lookups = gpos.table.LookupList.LookupCount
+        used = set()
+        for feature_record in gpos.table.FeatureList.FeatureRecord:
+            used.update(feature_record.Feature.LookupListIndex or [])
+
+        assert used == set(range(n_lookups))
+
     def test_no_op_when_no_prop_features(self, synthetic_ttf):
         # Synthetic font has no GPOS at all — should not raise.
         _remove_prop_features(synthetic_ttf)
@@ -159,7 +208,7 @@ class TestRemovePropFeatures:
 # ---------------------------------------------------------------------------
 
 class TestMakeProportional:
-    """End-to-end: bake palt → hmtx, optionally squeeze sidebearings, strip features."""
+    """End-to-end: bake palt → hmtx, optionally keep runtime palt."""
 
     def test_advance_narrows_for_palt_glyph(self, noto_subset):
         cmap = noto_subset.getBestCmap()
@@ -183,6 +232,79 @@ class TestMakeProportional:
         if gpos and gpos.table and gpos.table.FeatureList:
             tags = {fr.FeatureTag for fr in gpos.table.FeatureList.FeatureRecord}
             assert not (PROP_FEATURES & tags)
+
+    def test_runtime_palt_skips_baking_and_reinstalls_palt(self, noto_subset):
+        cmap = noto_subset.getBestCmap()
+        punct_glyph = cmap.get(0x3001)  # 、
+        palt = _read_palt(noto_subset)
+        if punct_glyph not in palt:
+            import pytest
+            pytest.skip("subset palt does not cover U+3001")
+
+        before_hmtx = noto_subset["hmtx"][punct_glyph]
+        expected_palt = palt[punct_glyph]
+
+        make_proportional(noto_subset, runtime_palt={punct_glyph})
+
+        after_hmtx = noto_subset["hmtx"][punct_glyph]
+        assert after_hmtx == before_hmtx
+        assert _read_palt(noto_subset) == {punct_glyph: expected_palt}
+
+        tags = {
+            fr.FeatureTag
+            for fr in noto_subset["GPOS"].table.FeatureList.FeatureRecord
+        }
+        assert "palt" in tags
+        assert not ({"vpal", "halt", "vhal"} & tags)
+
+    def test_runtime_palt_and_vpal_can_be_reinstalled_together(self, noto_subset):
+        cmap = noto_subset.getBestCmap()
+        punct_glyph = cmap.get(0x30FB)  # ・
+        palt = _read_palt(noto_subset)
+        vpal = _read_vpal(noto_subset)
+        if punct_glyph not in palt or punct_glyph not in vpal:
+            import pytest
+            pytest.skip("subset does not cover U+30FB palt/vpal")
+
+        before_hmtx = noto_subset["hmtx"][punct_glyph]
+        expected_palt = palt[punct_glyph]
+        expected_vpal = vpal[punct_glyph]
+
+        make_proportional(
+            noto_subset,
+            runtime_palt={punct_glyph},
+            runtime_vpal={punct_glyph},
+        )
+
+        assert noto_subset["hmtx"][punct_glyph] == before_hmtx
+        assert _read_palt(noto_subset) == {punct_glyph: expected_palt}
+        assert _read_vpal(noto_subset) == {punct_glyph: expected_vpal}
+
+        tags = {
+            fr.FeatureTag
+            for fr in noto_subset["GPOS"].table.FeatureList.FeatureRecord
+        }
+        assert {"palt", "vpal"} <= tags
+        assert not ({"halt", "vhal"} & tags)
+
+    def test_runtime_palt_does_not_keep_baked_glyphs_in_feature(self, noto_subset):
+        cmap = noto_subset.getBestCmap()
+        runtime_glyph = cmap.get(0x3001)  # 、
+        baked_glyph = cmap.get(0x3042)  # あ
+        palt = _read_palt(noto_subset)
+        if runtime_glyph not in palt or baked_glyph not in palt:
+            import pytest
+            pytest.skip("subset palt does not cover runtime and baked glyphs")
+
+        before_baked_aw = noto_subset["hmtx"][baked_glyph][0]
+        _, baked_xa = palt[baked_glyph]
+
+        make_proportional(noto_subset, runtime_palt={runtime_glyph})
+
+        assert noto_subset["hmtx"][baked_glyph][0] == before_baked_aw + baked_xa
+        after_palt = _read_palt(noto_subset)
+        assert runtime_glyph in after_palt
+        assert baked_glyph not in after_palt
 
     def test_palt_override_takes_precedence(self, noto_subset):
         cmap = noto_subset.getBestCmap()


### PR DESCRIPTION
## Summary

- restore live runtime `palt` records for the selected Japanese punctuation / symbol set while keeping small-kana compensation explicit
- add matching live `vpal` support for Noto's Unicode-mapped yakumono records, plus synthesized vertical records for fullwidth colon / semicolon
- rebuild runtime `palt` / `vpal` after the Inter + Noto merge so final encoded glyph names keep their feature records
- document the updated proportionalization policy and ignore local `scratch.*.html` verification pages
- bump the package version to `0.2.0`

## Related

Fixes #6.

Draft release: https://github.com/yamatoiizuka/gen-interface-jp/releases/tag/untagged-7ef509a4558bac68937c

## Validation

- `PYTHONPATH=src python3 -m pytest -q` -> 162 passed
- `make font` -> rebuilt 16 TTFs
- TTF inspection -> 16 TTFs contain `palt=48`, `vpal=35`, retargeted `U+FF40` palt, unadjusted `U+2035`, and fullwidth semicolon vpal
- `PYTHONPATH=src python3 -m webfont.build --all --clean --strategy google-japanese --jobs 8` -> rebuilt 2048 WOFF2 subsets
- `PYTHONPATH=src python3 -m release.build` -> wrote `GenInterfaceJP-0.2.0.zip`, npm package, webfont release, and manifest
- `npm --cache /private/tmp/gen-interface-jp-npm-cache pack --dry-run` -> passed for `gen-interface-jp@0.2.0`
