### PR TITLE
[codex] Bump version to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-interface-jp"
-version = "0.2.0"
+version = "0.2.1"
 description = "Typeface harmonizing Latin and Japanese for digital interfaces."
 license = "MIT"
 license-files = ["LICENSE"]


### PR DESCRIPTION
## Summary

- bump the project version from `0.2.0` to `0.2.1` after publishing `gen-interface-jp@0.2.0`

## Validation

- `PYTHONPATH=src python3 -m pytest -q` -> 162 passed
