### PR TITLE
[codex] Restore baked yakumono spacing with live palt

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -70,6 +70,7 @@ FAMILIES × WEIGHTS の各組合せに対して:
                     weight だけを上書き
   → inst を再読込し、キャッシュした variable から palt/vpal 取得
   → runtime 役物を除き Noto の palt エントリを全量で焼き込み
+    runtime 役物は 34% を base に焼き、66% を live feature に残す
     (palt なしグリフはメトリクス維持)
   → make_proportional で palt → hmtx に焼き込み
     vpal/halt/vhal を削除し、役物だけの palt/vpal feature を再生成
@@ -141,9 +142,13 @@ inst に対して 4 つのサブパスを in-place で実行:
    キャッシュ済みの variable から読む (instantiation で非デフォルト軸位置の
    palt ValueRecord が壊れることがあるため)。XPlacement / XAdvance を
    LSB / advance に加算しアウトラインをシフト。Noto の palt エントリは
-   原則として全量で焼き込むが、`PALT_FEATURE_CHARS` の役物は焼き込まず、
-   live `palt` GPOS feature として再生成する。Noto の `vpal` も同じ
-   variable から読み、`VPAL_FEATURE_CHARS` に列挙した Unicode-mapped
+   原則として全量で焼き込むが、`PALT_FEATURE_CHARS` の役物は分割する。
+   palt 調整量の 34% を `hmtx` に焼き込んで `palt` 無効時にもある程度
+   詰まる base metrics にし、残り 66% を live `palt` GPOS feature として
+   再生成する。Noto の典型的な `XAdvance=-500` の役物では、palt-off で
+   `-170` が base advance に焼かれ、palt-on で残り `-330` が適用される。
+   Noto の `vpal` も同じ variable から読み、
+   `VPAL_FEATURE_CHARS` に列挙した Unicode-mapped
    役物 33 glyph (縦組み presentation form と全角パーセントを含む) を
    live `vpal` として再生成する。全角コロン / セミコロンは Noto に palt は
    あるが vpal がなく、縦組みコロンは unmapped の `glyph17071` に
@@ -217,21 +222,27 @@ merge 後は final TTF を一度 fontTools で reload/save し、GSUB/GPOS cover
 CJK フォントは全角がデフォルト: 全グリフがアウトライン幅に関係なく同じ
 em-square を占有し、`palt` GPOS が runtime に kana / Latin を光学的に
 詰める。`palt` を有効にしないアプリ (Adobe の和文コンポーザー、ブラウザ
-フォールバック、CJK を等幅扱いするレイアウトエンジン) ではこの調整が
-効かず、全角ピッチで組まれてしまう。
+フォールバック、CJK を等幅扱いするレイアウトエンジン) では live の調整が
+効かない。Gen Interface JP では多くの palt を `hmtx` に焼き込み、runtime
+役物にも reduced palt 分を base に焼くことで、palt 無効時も完全な等幅
+フォールバックにならないようにする。
 
 `make_proportional` は多くの `palt` 値を static の `hmtx` に焼き込む。
-`runtime_palt` が指定されたグリフはベイク対象から外し、いったん
-`palt` / `vpal` / `halt` / `vhal` を削除した後、そのグリフ集合だけの
-新しい `palt` feature を追加する。`runtime_vpal` が指定された場合は、
-一致する Noto `vpal` record も水平メトリクスに触らず新しい `vpal`
-feature として戻す。ビルドでは runtime `palt` に `PALT_FEATURE_CHARS`
-(48 文字)、runtime `vpal` に `VPAL_FEATURE_CHARS` (33 文字) を使う。
-Noto の vpal には縦組み presentation form と `％` が含まれるため、
-この 2 つの集合は意図的に一致させない。`SYNTHETIC_VPAL_ADJUSTMENTS` は
-Noto が持たない全角コロン / セミコロンの縦方向 proportional record を補う。
-これにより、焼き込み済みの kana / Latin に palt が二重適用されることを
-避けながら、選択した役物だけ runtime palt/vpal を公開できる。
+`runtime_palt` と `runtime_palt_base_scale` が指定された場合は、その割合を
+base metrics に焼き込み、`palt` / `vpal` / `halt` / `vhal` を削除した後に
+残差だけを新しい `palt` feature として追加する。本プロジェクトでは
+`RUNTIME_PALT_BASE_SCALE = 0.34` を使うため、palt-off の役物はすでに部分的に
+詰まり (典型的な `-500` palt advance なら `-170`)、`palt` を有効にすると
+Noto の full palt 目標まで到達する。
+`runtime_vpal` が指定された場合は、一致する Noto `vpal` record も水平
+メトリクスに触らず新しい `vpal` feature として戻す。ビルドでは runtime
+`palt` に `PALT_FEATURE_CHARS` (48 文字)、runtime `vpal` に
+`VPAL_FEATURE_CHARS` (33 文字) を使う。Noto の vpal には縦組み presentation
+form と `％` が含まれるため、この 2 つの集合は意図的に一致させない。
+`SYNTHETIC_VPAL_ADJUSTMENTS` は Noto が持たない全角コロン / セミコロンの
+縦方向 proportional record を補う。これにより、焼き込み済みの kana /
+Latin に palt が二重適用されることを避けながら、選択した役物だけ
+runtime palt/vpal を公開できる。
 TrueType アウトラインのみ対応 (palt のベイクは `glyf` に書き戻すので
 CFF は対象外)。
 Inter との merge では base 側 glyph が rename されることがあるため、
@@ -402,8 +413,9 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
   明示的な palt/vpal spacing 方針。
 - **`tests/test_proportional.py`** — `_read_palt`, `_read_vpal`,
   `_shift_glyph_x`, `_remove_prop_features`, `make_proportional` (palt
-  ベイク、runtime-palt/vpal 再生成、reduced palt scale、palt なしグリフの
-  メトリクス維持、オプションの squeeze SB sidebearing 計算、
+  ベイク、runtime-palt/vpal 再生成、runtime-palt の base/residual 分割、
+  reduced palt scale、palt なしグリフのメトリクス維持、
+  オプションの squeeze SB sidebearing 計算、
   palt_override の優先、CFF 拒否、feature 削除後の LangSys index 整合性)。
 - **`tests/test_release.py`** — 公開配布の契約: GitHub アセット URL の形
   (サイトのダウンロードボタンが参照)、npm パッケージのレイアウト
@@ -416,8 +428,8 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 90 | グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、runtime feature の retarget |
-| `test_proportional.py` | 28 | palt/vpal 抽出、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal 再生成 + optional squeeze helper |
+| `test_font_build.py` | 91 | グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、runtime feature の retarget |
+| `test_proportional.py` | 29 | palt/vpal 抽出、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal 再生成 + base/residual 分割 + optional squeeze helper |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -69,7 +69,8 @@ For each (family, weight) in FAMILIES × WEIGHTS:
                     inheritBase passes designer/OFL/version
                     through; only weight is stamped
   → reload inst, read palt/vpal from cached variable font
-  → bake Noto palt at full strength except runtime yakumono
+  → bake Noto palt at full strength except runtime yakumono,
+    whose palt is split into a 34% baked base + 66% live feature
     (glyphs without palt keep metrics)
   → make_proportional bakes palt → hmtx, removes vpal/halt/vhal,
     and reinstalls yakumono-only palt/vpal features
@@ -141,7 +142,11 @@ Four sub-passes, all in-place on the inst:
    ValueRecords at non-default axis positions). XPlacement/XAdvance pairs
    are added to LSB / advance, outlines shifted. Most Noto palt entries are
    baked at full strength, but yakumono listed in `PALT_FEATURE_CHARS`
-   is left unbaked and reinstalled as a live `palt` GPOS feature. Noto
+   is split: 34% of the palt adjustment is baked into `hmtx` so the glyph is
+   still tightened when `palt` is disabled, and the remaining 66% is
+   reinstalled as a live `palt` GPOS feature. For Noto's common
+   `XAdvance=-500` yakumono records, that means palt-off gets `-170` baked
+   into the base advance and palt-on applies the remaining `-330`. Noto
    `vpal` is read from the same variable source and reinstalled for the
    Unicode-mapped yakumono listed in `VPAL_FEATURE_CHARS` (33 glyphs,
    including vertical presentation forms and fullwidth percent). Fullwidth
@@ -224,12 +229,18 @@ CJK fonts ship full-width: every glyph occupies the same em-square
 regardless of outline width, with `palt` GPOS narrowing kana / Latin
 optically at runtime. Apps that don't enable `palt` (Adobe's Japanese
 composer, browser fallbacks, anything treating CJK as monospaced for
-layout) miss those adjustments and lay out at full-width spacing.
+layout) miss those live adjustments. Gen Interface JP avoids a fully
+monospaced fallback by baking most palt values directly into `hmtx`, and by
+baking a reduced palt fraction for runtime yakumono.
 
 `make_proportional` bakes most `palt` values into the static `hmtx` so the
-font reads proportional everywhere. When `runtime_palt` is provided, those
-glyphs are skipped during baking; after `palt` / `vpal` / `halt` / `vhal`
-are stripped, a fresh `palt` feature is installed for just that glyph set.
+font reads proportional everywhere. When `runtime_palt` is provided together
+with `runtime_palt_base_scale`, the build bakes that fraction of each runtime
+record into the base metrics and installs only the residual delta as live
+`palt` after `palt` / `vpal` / `halt` / `vhal` are stripped. The project uses
+`RUNTIME_PALT_BASE_SCALE = 0.34`, so palt-off yakumono is already partially
+tightened (`-170` for the common `-500` palt advance) while enabling `palt`
+still reaches the full Noto palt target.
 When `runtime_vpal` is provided, matching Noto `vpal` records are also
 reinstalled as a fresh `vpal` feature without affecting horizontal metrics.
 The build uses `PALT_FEATURE_CHARS` (48 chars) for runtime `palt` and
@@ -413,8 +424,8 @@ Tests live under `tests/`, split by surface:
   and the explicit palt/vpal spacing policy.
 - **`tests/test_proportional.py`** — `_read_palt`, `_read_vpal`,
   `_shift_glyph_x`, `_remove_prop_features`, `make_proportional` (palt
-  baking, runtime-palt/vpal reinstall, reduced palt scaling, non-palt metric
-  preservation, optional squeeze SB sidebearing math, palt_override
+  baking, runtime-palt/vpal reinstall, runtime-palt base/residual splitting,
+  reduced palt scaling, non-palt metric preservation, optional squeeze SB sidebearing math, palt_override
   precedence, CFF rejection, LangSys index validity post-removal).
 - **`tests/test_release.py`** — public distribution contracts: GitHub
   asset URL shape (referenced by the site download button), npm package
@@ -427,8 +438,8 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 90 | Glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, runtime feature retargeting |
-| `test_proportional.py` | 28 | palt/vpal extraction, glyph translation, GPOS feature removal, runtime-palt/vpal reinstall + optional squeeze helper |
+| `test_font_build.py` | 91 | Glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, runtime feature retargeting |
+| `test_proportional.py` | 29 | palt/vpal extraction, glyph translation, GPOS feature removal, runtime-palt/vpal reinstall + base/residual split + optional squeeze helper |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-interface-jp"
-version = "0.2.1"
+version = "0.2.2"
 description = "Typeface harmonizing Latin and Japanese for digital interfaces."
 license = "MIT"
 license-files = ["LICENSE"]

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -35,6 +35,7 @@ from .proportional import (
     _install_palt_feature,
     _install_vpal_feature,
     _remove_prop_features,
+    _scale_position_adjustment,
     make_proportional,
 )
 
@@ -97,6 +98,11 @@ PALT_FEATURE_CHARS = (
     "〒", "＂", "＃", "＄", "＆",
     "＇", "＊", "＾", "｀", "￥",
 )
+
+# Runtime palt yakumono still need a reasonably tight default when callers do
+# not enable palt. Bake this fraction into hmtx, then expose only the remaining
+# palt delta as the live feature.
+RUNTIME_PALT_BASE_SCALE = 0.34
 
 # Unicode-mapped Noto vpal yakumono records kept as a live vertical
 # proportional feature. This intentionally differs from PALT_FEATURE_CHARS:
@@ -711,6 +717,28 @@ def _feature_adjustments_for_codepoints(
     }
 
 
+def _runtime_palt_residual_adjustment(
+    adjustment: tuple[int, int],
+) -> tuple[int, int]:
+    """Return the live palt delta after the default base fraction is baked."""
+    base_placement, base_advance = _scale_position_adjustment(
+        adjustment,
+        RUNTIME_PALT_BASE_SCALE,
+    )
+    placement, advance = adjustment
+    return (placement - base_placement, advance - base_advance)
+
+
+def _runtime_palt_residuals_by_codepoint(
+    adjustments: dict[int, tuple[int, int]],
+) -> dict[int, tuple[int, int]]:
+    """Convert full palt records to residual records for final reinstall."""
+    return {
+        cp: _runtime_palt_residual_adjustment(adjustment)
+        for cp, adjustment in adjustments.items()
+    }
+
+
 def _retarget_feature_adjustments(
     font: TTFont,
     adjustments_by_codepoint: dict[int, tuple[int, int]],
@@ -1018,10 +1046,12 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
         if glyph_name in font.getGlyphOrder():
             vpal_data[glyph_name] = value
             runtime_vpal_glyphs.add(glyph_name)
-    runtime_palt_by_codepoint = _feature_adjustments_for_codepoints(
-        font,
-        runtime_palt_chars,
-        palt_data,
+    runtime_palt_by_codepoint = _runtime_palt_residuals_by_codepoint(
+        _feature_adjustments_for_codepoints(
+            font,
+            runtime_palt_chars,
+            palt_data,
+        )
     )
     runtime_vpal_by_codepoint = _feature_adjustments_for_codepoints(
         font,
@@ -1029,13 +1059,14 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
         vpal_data,
     )
 
-    # Bake Noto palt entries at full strength except yakumono that should
-    # remain live palt/vpal features. Glyphs without palt keep their
-    # original hmtx.
+    # Bake Noto palt entries at full strength except runtime yakumono, which
+    # receive a reduced baked base plus a live residual palt feature. Glyphs
+    # without palt keep their original hmtx.
     make_proportional(
         font,
         palt_override=palt_data,
         runtime_palt=runtime_palt_glyphs,
+        runtime_palt_base_scale=RUNTIME_PALT_BASE_SCALE,
         vpal_override=vpal_data,
         runtime_vpal=runtime_vpal_glyphs,
     )

--- a/src/font/proportional.py
+++ b/src/font/proportional.py
@@ -12,10 +12,11 @@ full-width spacing.
 
 This module bakes most ``palt`` values into the static hmtx so the font
 reads as proportional everywhere. A caller may keep a small glyph set as a
-live runtime ``palt`` / ``vpal`` feature; those glyphs are not baked, and
-fresh lookups are installed for them after the redundant proportional
-features are removed. Glyphs not covered by ``palt`` keep their original
-metrics — nothing is forced.
+live runtime ``palt`` / ``vpal`` feature; palt glyphs can either stay
+unbaked or split into a baked base fraction plus a live residual feature.
+Fresh lookups are installed after the redundant proportional features are
+removed. Glyphs not covered by ``palt`` keep their original metrics —
+nothing is forced.
 
 Usage:
     python3 -m font.proportional INPUT.ttf OUTPUT.ttf
@@ -38,6 +39,15 @@ from fontTools.ttLib.tables import otTables
 PROP_FEATURES = {"palt", "vpal", "halt", "vhal"}
 
 
+def _scale_position_adjustment(
+    adjustment: tuple[int, int],
+    scale: float,
+) -> tuple[int, int]:
+    """Scale an OpenType placement/advance pair with design-unit rounding."""
+    placement, advance = adjustment
+    return (round(placement * scale), round(advance * scale))
+
+
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
@@ -50,6 +60,7 @@ def make_proportional(
     squeeze_sb_scale: float | None = None,
     palt_override: dict[str, tuple[int, int]] | None = None,
     runtime_palt: set[str] | None = None,
+    runtime_palt_base_scale: float = 0.0,
     vpal_override: dict[str, tuple[int, int]] | None = None,
     runtime_vpal: set[str] | None = None,
 ) -> None:
@@ -75,11 +86,12 @@ def make_proportional(
     been corrupted by variable instantiation. Variable→static baking can
     leave palt ValueRecords with zeroed XPlacement/XAdvance pairs.
 
-    ``runtime_palt`` leaves selected palt-covered glyphs unbaked and
-    reinstalls only those glyphs as a live ``palt`` feature. This lets a
-    final font expose palt for a narrow target set (e.g. yakumono)
-    without double-applying palt to kana / Latin glyphs that were already
-    baked into hmtx.
+    ``runtime_palt`` leaves selected palt-covered glyphs available as a live
+    ``palt`` feature. By default those glyphs are not baked. When
+    ``runtime_palt_base_scale`` is non-zero, that fraction is baked into the
+    base hmtx and only the remaining delta is reinstalled as live ``palt``.
+    This lets selected yakumono stay somewhat tight when ``palt`` is disabled
+    while preserving the full palt result when it is enabled.
 
     ``vpal_override`` / ``runtime_vpal`` mirror that runtime feature path
     for vertical proportional metrics. ``vpal`` is not baked into hmtx; when
@@ -94,17 +106,15 @@ def make_proportional(
 
     if squeeze_sb_scale is None:
         squeeze_sb_scale = reduced_palt_scale
+    if not 0 <= runtime_palt_base_scale <= 1:
+        raise ValueError("runtime_palt_base_scale must be between 0 and 1")
 
     runtime_palt = runtime_palt or set()
     runtime_vpal = runtime_vpal or set()
 
     # Extract palt adjustments before removing features
     palt_adjustments = palt_override if palt_override is not None else _read_palt(font)
-    runtime_palt_adjustments = {
-        glyph_name: value
-        for glyph_name, value in palt_adjustments.items()
-        if glyph_name in runtime_palt
-    }
+    runtime_palt_adjustments = {}
     vpal_adjustments = vpal_override if vpal_override is not None else _read_vpal(font)
     runtime_vpal_adjustments = {
         glyph_name: value
@@ -118,14 +128,31 @@ def make_proportional(
     # ── Apply palt adjustments ──
     for glyph_name, (x_placement, x_advance) in palt_adjustments.items():
         if glyph_name in runtime_palt:
-            continue
-        if glyph_name not in hmtx.metrics:
+            if runtime_palt_base_scale == 0:
+                runtime_palt_adjustments[glyph_name] = (x_placement, x_advance)
+                continue
+            if glyph_name not in hmtx.metrics:
+                runtime_palt_adjustments[glyph_name] = (x_placement, x_advance)
+                continue
+            base_x_placement, base_x_advance = _scale_position_adjustment(
+                (x_placement, x_advance),
+                runtime_palt_base_scale,
+            )
+            runtime_palt_adjustments[glyph_name] = (
+                x_placement - base_x_placement,
+                x_advance - base_x_advance,
+            )
+            x_placement = base_x_placement
+            x_advance = base_x_advance
+        elif glyph_name not in hmtx.metrics:
             continue
 
         # Reduced palt: apply a fraction of the adjustment
-        if reduced_palt and glyph_name in reduced_palt:
-            x_placement = round(x_placement * reduced_palt_scale)
-            x_advance = round(x_advance * reduced_palt_scale)
+        if glyph_name not in runtime_palt and reduced_palt and glyph_name in reduced_palt:
+            x_placement, x_advance = _scale_position_adjustment(
+                (x_placement, x_advance),
+                reduced_palt_scale,
+            )
 
         aw, lsb = hmtx[glyph_name]
 

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -28,12 +28,14 @@ from font.build import (
     _is_kana_or_punct,
     _retarget_feature_adjustments,
     _retarget_named_adjustments,
+    _runtime_palt_residual_adjustment,
     _split_cmap_codepoint_glyph,
     _strip_extreme_glyphs,
     DISPLAY_PALT_SPACE_ADJUSTMENTS,
     NORMAL_PALT_SPACE_ADJUSTMENTS,
     PALT_FEATURE_CHARS,
     PALT_SPACE_ADJUSTMENTS,
+    RUNTIME_PALT_BASE_SCALE,
     SUB_EXCLUDE_CODEPOINTS,
     SYNTHETIC_VPAL_ADJUSTMENTS,
     TRACKING_IGNORE_CODEPOINTS,
@@ -541,7 +543,7 @@ class TestApplyTracking:
 # ---------------------------------------------------------------------------
 
 class TestPaltSymbolPolicy:
-    """Full palt is baked by default; selected yakumono remains runtime palt."""
+    """Full palt is baked by default; selected yakumono keeps split runtime palt."""
 
     def test_tracking_only_symbols_are_implicit_palt_entries(self):
         palt = _get_variable_palt()
@@ -575,6 +577,11 @@ class TestPaltSymbolPolicy:
         ):
             assert char in PALT_FEATURE_CHARS
             assert char not in PALT_SPACE_ADJUSTMENTS
+
+    def test_runtime_palt_keeps_reduced_base_metrics(self):
+        assert RUNTIME_PALT_BASE_SCALE == 0.34
+        assert _runtime_palt_residual_adjustment((-250, -500)) == (-165, -330)
+        assert _runtime_palt_residual_adjustment((-70, -140)) == (-46, -92)
 
     def test_noto_vpal_yakumono_uses_separate_runtime_target_set(self):
         vpal = _get_variable_vpal()

--- a/tests/test_proportional.py
+++ b/tests/test_proportional.py
@@ -257,6 +257,36 @@ class TestMakeProportional:
         assert "palt" in tags
         assert not ({"vpal", "halt", "vhal"} & tags)
 
+    def test_runtime_palt_can_bake_base_fraction_and_reinstall_residual(self, noto_subset):
+        cmap = noto_subset.getBestCmap()
+        punct_glyph = cmap.get(0x3001)  # 、
+        palt = _read_palt(noto_subset)
+        if punct_glyph not in palt:
+            import pytest
+            pytest.skip("subset palt does not cover U+3001")
+
+        before_aw, before_lsb = noto_subset["hmtx"][punct_glyph]
+        x_placement, x_advance = palt[punct_glyph]
+        base_x_placement = round(x_placement * 0.34)
+        base_x_advance = round(x_advance * 0.34)
+
+        make_proportional(
+            noto_subset,
+            runtime_palt={punct_glyph},
+            runtime_palt_base_scale=0.34,
+        )
+
+        assert noto_subset["hmtx"][punct_glyph] == (
+            before_aw + base_x_advance,
+            before_lsb + base_x_placement,
+        )
+        assert _read_palt(noto_subset) == {
+            punct_glyph: (
+                x_placement - base_x_placement,
+                x_advance - base_x_advance,
+            )
+        }
+
     def test_runtime_palt_and_vpal_can_be_reinstalled_together(self, noto_subset):
         cmap = noto_subset.getBestCmap()
         punct_glyph = cmap.get(0x30FB)  # ・


### PR DESCRIPTION
## Summary

- keep 34% of runtime yakumono palt baked into base horizontal advances so palt-off text no longer falls back to near-fullwidth punctuation
- leave the remaining palt adjustment live, preserving opt-in tighter punctuation spacing and existing kern/tracking behavior
- document the split and add regression coverage for base advances plus residual palt records
- bump the release version to 0.2.2

## Validation

- PYTHONPATH=src python3 -m pytest -q -> 164 passed
- PYTHONPATH=src python3 -m font.build -> rebuilt 16 TTFs
- full TTF inspection -> palt=48, vpal=35, Normal Regular punctuation advance 805 with residual palt (-165, -330)
- PYTHONPATH=src python3 -m webfont.build --all --clean --strategy google-japanese --jobs 8 -> rebuilt 2048 WOFF2 subsets
- PYTHONPATH=src python3 -m release.build -> generated 0.2.2 GitHub/npm release artifacts
- npm --cache /private/tmp/gen-interface-jp-npm-cache pack --dry-run --json --silent -> gen-interface-jp@0.2.2, 2086 entries

## Release

Prepared for v0.2.2 as a patch release because v0.2.1 is already published.
