### PR TITLE
[codex] Build fonts at Inter-native 2048 UPM

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -21,6 +21,7 @@ Gen Interface JP はフォントビルドパイプライン (アプリ/UI なし
         │   [1/3] Bake — font-baker, base-only            │
         │         Noto wght → static TTF                  │
         │         metadataMode=inheritBase                │
+        │         output.upm=2048                         │
         │             ↓                                   │
         │   [2/3] Proportionalise — proportional.py       │
         │      palt → hmtx + runtime 役物 palt/vpal       │
@@ -31,7 +32,8 @@ Gen Interface JP はフォントビルドパイプライン (アプリ/UI なし
         │         Inter (sub) + proportional Noto (base)  │
         │         subFont.excludeCodepoints で日本語慣習    │
         │         記号は Noto を維持                        │
-        │         metricsSource=sub, manufacturer 刻印     │
+        │         output.upm=2048, metricsSource=sub      │
+        │         manufacturer 刻印                        │
         │         GSUB/GPOS coverage order 正規化          │
         │             ↓                                   │
         │   dist/ttf/  (ファミリー × ウェイトごとに TTF)    │
@@ -69,6 +71,7 @@ FAMILIES × WEIGHTS の各組合せに対して:
                     inheritBase で designer/OFL/version を継承
                     weight だけを上書き
   → inst を再読込し、キャッシュした variable から palt/vpal 取得
+    1000-UPM の record を 2048-UPM のビルドグリッドへ換算
   → runtime 役物を除き Noto の palt エントリを全量で焼き込み
     runtime 役物は 34% を base に焼き、66% を live feature に残す
     (palt なしグリフはメトリクス維持)
@@ -78,13 +81,14 @@ FAMILIES × WEIGHTS の各組合せに対して:
     ただし family["trackingIgnore"] の連続・隙間なし記号は除外
   → _apply_glyph_spacing で family["glyphSpacing"] の個別調整を適用
   → _strip_extreme_glyphs で縦組み用繰り返し記号 〱-〵 を無効化
-    (yMax > 1200 / yMin < -400)
+    (1000-UPM 設計値: yMax > 1200 / yMin < -400)
   → font-baker merge: Inter + proportional Noto
                      subFont.excludeCodepoints = SUB_EXCLUDE_CODEPOINTS で
                      日本語慣習記号 (① Ⓐ ※ ◯ …) は Noto を維持
                      glyph-name collision (Inter U+0298 と Noto U+25CE が
                      共に `uni25CE`) も font-baker が自動 rename
                      family/weight を「Gen Interface JP …」に刻印
+                     output.upm=2048 で Inter ネイティブグリッドを維持
                      metricsSource=sub で Inter 基準の hhea を採用
                      manufacturer / manufacturerURL を刻印
   → final TTF を一度 reload/save し、GSUB/GPOS coverage を
@@ -134,19 +138,29 @@ Noto の軸は非線形で、整数位置の太さでは Inter より細く見�
 inst TTF は手動 save/restore なしにクリーンな出元メタデータを持って
 Stage 2 に渡る。
 
+この最初の段階で `output.upm = 2048` を指定する。Noto のソースは 1000 UPM
+だが、Inter / Inter Display は 2048 UPM がネイティブなので、プロジェクト側の
+spacing 作業に入る前に Noto intermediate を Inter のグリッドへ移す。これにより
+final merge で Inter を 1000 UPM に丸め落とさずに済む。ここでは font-baker が
+glyph order 全体をスケールする前提で、縦組み代替のような unmapped glyph も
+palt record を持ちうるため対象に含める。
+
 ### Stage 2 — プロポーショナル化 + メトリクス調整
 
 inst に対して 4 つのサブパスを in-place で実行:
 
 1. **palt のベイク / runtime vpal** (`proportional.make_proportional`) — palt 値は
    キャッシュ済みの variable から読む (instantiation で非デフォルト軸位置の
-   palt ValueRecord が壊れることがあるため)。XPlacement / XAdvance を
-   LSB / advance に加算しアウトラインをシフト。Noto の palt エントリは
+   palt ValueRecord が壊れることがあるため)。その値は Noto の 1000-UPM
+   ソースグリッドから、実際の 2048-UPM ビルドグリッドへ換算する。
+   XPlacement / XAdvance を LSB / advance に加算しアウトラインをシフト。
+   Noto の palt エントリは
    原則として全量で焼き込むが、`PALT_FEATURE_CHARS` の役物は分割する。
    palt 調整量の 34% を `hmtx` に焼き込んで `palt` 無効時にもある程度
    詰まる base metrics にし、残り 66% を live `palt` GPOS feature として
    再生成する。Noto の典型的な `XAdvance=-500` の役物では、palt-off で
-   `-170` が base advance に焼かれ、palt-on で残り `-330` が適用される。
+   `-170` が base advance に焼かれ、palt-on で残り `-330` が適用される
+   (いずれも UPM 換算前の設計値)。
    Noto の `vpal` も同じ variable から読み、
    `VPAL_FEATURE_CHARS` に列挙した Unicode-mapped
    役物 33 glyph (縦組み presentation form と全角パーセントを含む) を
@@ -162,7 +176,8 @@ inst に対して 4 つのサブパスを in-place で実行:
 2. **トラッキング** (`_apply_tracking`) — advance を `tracking` 分広げ、
    `tracking // 2` を LSB に加算してアウトラインを広がった枠の中央に
    配置。kana / 句読点はファミリー設定の `trackingKana` で別値。
-   `trackingIgnore` はコードポイント / 範囲を受け取り、cmap で解決した
+   これらの値は 1000-UPM 設計値として持ち、normal family では `+30` / `+40`
+   を active UPM に換算して適用する。`trackingIgnore` はコードポイント / 範囲を受け取り、cmap で解決した
    グリフを完全にスキップする。デフォルトでは Noto の tracking stage で
    Box Drawing (`U+2500-U+257F`)、Block Elements (`U+2580-U+259F`)、
    2 点 / 中点 leader (`U+2025`, `U+22EF`)、半角中黒 (`U+FF65`)、`U+3030`、
@@ -173,7 +188,8 @@ inst に対して 4 つのサブパスを in-place で実行:
 3. **個別グリフのスペーシング** (`_apply_glyph_spacing`) — palt + 一律
    トラッキングだけでは追い込めない稀なグリフのための手動レイヤー。
    ファミリー設定の `glyphSpacing` がコードポイント (または 1 文字) を
-   `(lsb_delta, rsb_delta)` ペアにマップする: `lsb_delta` は hmtx LSB と
+   1000-UPM 設計値の `(lsb_delta, rsb_delta)` ペアにマップし、適用前に
+   active UPM へ換算する: `lsb_delta` は hmtx LSB と
    advance を同量増やし、`rsb_delta` は advance を右側だけ広げる。
    アウトライン座標は触らない。各エントリは特定グリフを特定の隣接リズムに
    対して個別チューニングする想定なので、慎重に追加すること。現在の調整値は
@@ -202,11 +218,14 @@ font-baker は sub のほうを `uni25CE.sub` にリネームし、base のグ�
 する。この 2 段で、直接重複と命名衝突の両方を、こちら側で cmap を手術せず
 にカバーできる。
 
+`output.upm = 2048` で final TTF でも Inter のネイティブ座標グリッドを維持し、
 `output.metricsSource = "sub"` で merged の hhea / OS/2 包絡線を Inter 側に
-揃え、欧文のメトリクスが行高を駆動する。`BASELINE_OFFSET = 25` で Noto を
-上に持ち上げ、CJK 漢字が Latin の caps と光学的に同じベースラインに乗るように
-調整。`SCALE = 0.925` で Noto を縮め、CJK 1 文字の幅が Inter の cap-height と
-揃う — 欧文/CJK 混植で CJK を少し小さくして釣り合いを取る、という慣例的な配分。
+揃え、欧文のメトリクスが行高を駆動する。`BASELINE_OFFSET = 25` は 1000-UPM
+設計値で、2048-UPM build では `51` として Noto を上に持ち上げる。これにより
+CJK 漢字が Latin の caps と光学的に同じベースラインに乗る。`SCALE = 0.925` は
+UPM 変換ではなく光学的な CJK デザインスケールとして残し、CJK 1 文字の幅が
+Inter の cap-height と揃うように Noto を縮める — 欧文/CJK 混植で CJK を少し
+小さくして釣り合いを取る、という慣例的な配分。
 
 `output.manufacturer = "Yamato Iizuka"`、`output.manufacturerURL =
 "https://yamatoiizuka.com"` でリリース TTF の nameID 8 / 11 を刻印。
@@ -232,8 +251,8 @@ em-square を占有し、`palt` GPOS が runtime に kana / Latin を光学的�
 base metrics に焼き込み、`palt` / `vpal` / `halt` / `vhal` を削除した後に
 残差だけを新しい `palt` feature として追加する。本プロジェクトでは
 `RUNTIME_PALT_BASE_SCALE = 0.34` を使うため、palt-off の役物はすでに部分的に
-詰まり (典型的な `-500` palt advance なら `-170`)、`palt` を有効にすると
-Noto の full palt 目標まで到達する。
+詰まり (典型的な `-500` palt advance なら UPM 換算前で `-170`)、`palt` を
+有効にすると Noto の full palt 目標まで到達する。
 `runtime_vpal` が指定された場合は、一致する Noto `vpal` record も水平
 メトリクスに触らず新しい `vpal` feature として戻す。ビルドでは runtime
 `palt` に `PALT_FEATURE_CHARS` (48 文字)、runtime `vpal` に
@@ -274,7 +293,9 @@ Inter の Latin 専用挙動 (各行のグリフに応じた行高動的調整) 
 
 `_strip_extreme_glyphs` は縦組み用イテレーションマーク `U+3031-U+3035`
 を明示的に無効化し、さらに `yMax > 1200` または `yMin < -400`
-(em = 1000 基準) のグリフも無効化する。Noto Sans JP で bbox の外れ値に
+という 1000-UPM 設計グリッド上の閾値に該当するグリフも無効化する。実際の
+比較前に active UPM へ換算するため、2048-UPM build ではおよそ
+`yMax > 2458` / `yMin < -819` になる。Noto Sans JP で bbox の外れ値に
 なるのは全形の縦組み用イテレーションマークと `vert` / `vrt2` 代替。
 上半分/下半分の名残 (`〳〴〵`) は bbox としては外れ値ではないが、横組み
 テキスト内で Adobe の Japanese コンポーザーを混乱させるため、コードポイント
@@ -297,7 +318,7 @@ Inter の Latin 専用挙動 (各行のグリフに応じた行高動的調整) 
 | | yMin / yMax | span |
 |---|---|---|
 | Before (Noto そのまま) | -1047 / +1807 | 2.85×em |
-| After | 約 -319 / +1108 | ~1.43×em (Inter 相当) |
+| After (final 2048 UPM) | 約 -660 / +2269 | ~1.43×em (Inter 相当) |
 
 ### 設計方針 — UI フォントとして横組み専用
 
@@ -405,7 +426,8 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
   が必要なテスト用に Noto Variable のサブセットをセッション単位でキャッシュ;
   全グリフ走査が必要な mutation テスト用には `FontBuilder` で組み立てた
   最小 TrueType (Noto 17000 グリフを毎回触るのは無駄)。
-- **`tests/test_font_build.py`** — `_glyph_codepoint`, `_is_kana_or_punct`,
+- **`tests/test_font_build.py`** — UPM 設計値換算
+  (`SOURCE_UPM = 1000`, `TARGET_UPM = 2048`)、`_glyph_codepoint`, `_is_kana_or_punct`,
   `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
   `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
   `_apply_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
@@ -428,7 +450,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 91 | グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、runtime feature の retarget |
+| `test_font_build.py` | 96 | UPM 換算ポリシー、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、runtime feature の retarget |
 | `test_proportional.py` | 29 | palt/vpal 抽出、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal 再生成 + base/residual 分割 + optional squeeze helper |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,6 +21,7 @@ consumes the published webfont package.
         │   [1/3] Bake — font-baker, base-only            │
         │         Noto wght axis → static TTF             │
         │         metadataMode=inheritBase                │
+        │         output.upm=2048                         │
         │             ↓                                   │
         │   [2/3] Proportionalise — proportional.py       │
         │      palt → hmtx + runtime yakumono palt/vpal   │
@@ -31,7 +32,8 @@ consumes the published webfont package.
         │         Inter (sub) + proportional Noto (base)  │
         │         subFont.excludeCodepoints keeps         │
         │         CJK-conventional symbols on Noto        │
-        │         metricsSource=sub, manufacturer stamp   │
+        │         output.upm=2048, metricsSource=sub      │
+        │         manufacturer stamp                      │
         │         normalize GSUB/GPOS coverage order      │
         │             ↓                                   │
         │   dist/ttf/  (one TTF per family × weight)      │
@@ -69,6 +71,7 @@ For each (family, weight) in FAMILIES × WEIGHTS:
                     inheritBase passes designer/OFL/version
                     through; only weight is stamped
   → reload inst, read palt/vpal from cached variable font
+    and scale those 1000-UPM records to the active 2048-UPM grid
   → bake Noto palt at full strength except runtime yakumono,
     whose palt is split into a 34% baked base + 66% live feature
     (glyphs without palt keep metrics)
@@ -78,13 +81,14 @@ For each (family, weight) in FAMILIES × WEIGHTS:
     except repeatable no-gap symbols in family["trackingIgnore"]
   → _apply_glyph_spacing applies family["glyphSpacing"] sidebearing tweaks
   → _strip_extreme_glyphs neutralises vertical iteration marks 〱-〵
-    (yMax > 1200 / yMin < -400)
+    (1000-UPM design thresholds: yMax > 1200 / yMin < -400)
   → font-baker merge: Inter + proportional Noto
                      subFont.excludeCodepoints = SUB_EXCLUDE_CODEPOINTS
                      keeps CJK-conventional symbols on Noto;
                      font-baker also auto-renames glyph-name collisions
                      (e.g. Inter U+0298 vs Noto U+25CE both `uni25CE`)
                      family/weight stamped to "Gen Interface JP …"
+                     output.upm=2048 preserves Inter's native grid
                      metricsSource=sub anchors hhea on Inter
                      manufacturer / manufacturerURL stamped
   → reload/save final TTF once so GSUB/GPOS coverage tables are ordered
@@ -133,20 +137,30 @@ Noto's identity records (designer, OFL, manufacturer, version) intact, so
 the inst TTF carries clean source metadata into Stage 2 without manual
 save/restore.
 
+`output.upm = 2048` is set at this first stage. Noto's source is 1000 UPM,
+but Inter / Inter Display are native 2048 UPM; moving the Noto intermediate
+onto Inter's grid before project-owned spacing work avoids rounding Inter
+down to 1000 UPM in the final merge. font-baker is expected to scale the
+full glyph order here, including unmapped vertical alternates that can still
+carry palt records.
+
 ### Stage 2 — Proportionalise + tune metrics
 
 Four sub-passes, all in-place on the inst:
 
 1. **palt baking / runtime vpal** (`proportional.make_proportional`) — palt values are
    read from the cached variable font (instantiation can corrupt palt's
-   ValueRecords at non-default axis positions). XPlacement/XAdvance pairs
-   are added to LSB / advance, outlines shifted. Most Noto palt entries are
+   ValueRecords at non-default axis positions), then scaled from Noto's
+   1000-UPM source grid to the active 2048-UPM build grid.
+   XPlacement/XAdvance pairs are added to LSB / advance, outlines shifted.
+   Most Noto palt entries are
    baked at full strength, but yakumono listed in `PALT_FEATURE_CHARS`
    is split: 34% of the palt adjustment is baked into `hmtx` so the glyph is
    still tightened when `palt` is disabled, and the remaining 66% is
    reinstalled as a live `palt` GPOS feature. For Noto's common
    `XAdvance=-500` yakumono records, that means palt-off gets `-170` baked
-   into the base advance and palt-on applies the remaining `-330`. Noto
+   into the base advance and palt-on applies the remaining `-330` before
+   UPM scaling. Noto
    `vpal` is read from the same variable source and reinstalled for the
    Unicode-mapped yakumono listed in `VPAL_FEATURE_CHARS` (33 glyphs,
    including vertical presentation forms and fullwidth percent). Fullwidth
@@ -161,7 +175,9 @@ Four sub-passes, all in-place on the inst:
 2. **Tracking** (`_apply_tracking`) — advance grows by `tracking`;
    `tracking // 2` is added to LSB so the outline sits centred in the
    wider slot. Kana / punctuation get a separate `trackingKana` value
-   when set on the family. `trackingIgnore` accepts codepoints / ranges
+   when set on the family. These constants are authored on the 1000-UPM
+   design grid (`+30` / `+40` for the normal family) and scaled to the
+   active UPM before application. `trackingIgnore` accepts codepoints / ranges
    and skips glyphs resolved through cmap. The default ignore list keeps
    the Noto tracking stage from widening Box Drawing (`U+2500-U+257F`),
    Block Elements (`U+2580-U+259F`), two-dot / midline leaders
@@ -173,7 +189,8 @@ Four sub-passes, all in-place on the inst:
 3. **Per-glyph spacing** (`_apply_glyph_spacing`) — manual fallback for
    the rare glyph whose sidebearings still read off after palt + uniform
    tracking. The family's `glyphSpacing` dict maps a codepoint or
-   character to a `(lsb_delta, rsb_delta)` pair: `lsb_delta` increases
+   character to a `(lsb_delta, rsb_delta)` pair, authored at 1000 UPM and
+   scaled before application: `lsb_delta` increases
    hmtx LSB and advance by the same amount, while `rsb_delta` only grows
    advance on the right. Outline coordinates are never touched. Populate
    sparingly — each entry hand-tuned for one glyph against a specific
@@ -206,10 +223,13 @@ the glyph name `uni25CE`; rather than letting Inter's outline overwrite
 mechanisms cover both direct overlaps and the trickier name-collision case
 without any manual cmap surgery in this project.
 
-`output.metricsSource = "sub"` anchors the merged hhea / OS/2 envelope on Inter
-so Latin metrics drive line height. `BASELINE_OFFSET = 25` nudges Noto up so CJK
-ideographs share an optical baseline with Latin caps; `SCALE = 0.925` shrinks
-Noto so a CJK character lines up in width with Inter's cap-height — a
+`output.upm = 2048` preserves Inter's native coordinate grid in the final TTF,
+and `output.metricsSource = "sub"` anchors the merged hhea / OS/2 envelope on
+Inter so Latin metrics drive line height. `BASELINE_OFFSET = 25` is a 1000-UPM
+design value (built as `51` at 2048 UPM) that nudges Noto up so CJK ideographs
+share an optical baseline with Latin caps; `SCALE = 0.925` is still the optical
+CJK design scale, not the UPM conversion. It shrinks Noto so a CJK character
+lines up in width with Inter's cap-height — a
 typographic convention for Latin/CJK pairing where CJK is slightly down-scaled
 to feel proportionate.
 
@@ -239,8 +259,8 @@ with `runtime_palt_base_scale`, the build bakes that fraction of each runtime
 record into the base metrics and installs only the residual delta as live
 `palt` after `palt` / `vpal` / `halt` / `vhal` are stripped. The project uses
 `RUNTIME_PALT_BASE_SCALE = 0.34`, so palt-off yakumono is already partially
-tightened (`-170` for the common `-500` palt advance) while enabling `palt`
-still reaches the full Noto palt target.
+tightened (`-170` for the common `-500` palt advance before UPM scaling) while
+enabling `palt` still reaches the full Noto palt target.
 When `runtime_vpal` is provided, matching Noto `vpal` records are also
 reinstalled as a fresh `vpal` feature without affecting horizontal metrics.
 The build uses `PALT_FEATURE_CHARS` (48 chars) for runtime `palt` and
@@ -282,7 +302,9 @@ of new text frames.
 
 `_strip_extreme_glyphs` neutralises vertical-text iteration marks
 `U+3031-U+3035` explicitly, plus any glyph with `yMax > 1200` or
-`yMin < -400` (em = 1000 baseline). In Noto Sans JP the bbox outliers are
+`yMin < -400` on the 1000-UPM design grid. The thresholds are scaled to the
+active font UPM before comparison (about `yMax > 2458` / `yMin < -819` in the
+2048-UPM build). In Noto Sans JP the bbox outliers are
 the full vertical iteration marks and their `vert` / `vrt2` alternates;
 the upper/lower-half remnants (`〳〴〵`) are removed by codepoint because
 they are vertical-only and can confuse Adobe's Japanese composer in
@@ -305,7 +327,7 @@ falls through to .notdef.
 | | yMin / yMax | span |
 |---|---|---|
 | Before (vanilla Noto) | -1047 / +1807 | 2.85×em |
-| After | ~-319 / +1108 | ~1.43×em (Inter-equivalent) |
+| After (final 2048 UPM) | ~-660 / +2269 | ~1.43×em (Inter-equivalent) |
 
 ### Design choice — UI font, horizontal only
 
@@ -416,7 +438,8 @@ Tests live under `tests/`, split by surface:
   Noto Variable for tests that need real palt / vpal / vert / cmap data, and a
   hand-built minimal TrueType (`FontBuilder`) for whole-font mutation
   tests where 17 000 Noto glyphs would be wasteful.
-- **`tests/test_font_build.py`** — `_glyph_codepoint`, `_is_kana_or_punct`,
+- **`tests/test_font_build.py`** — UPM design-unit scaling
+  (`SOURCE_UPM = 1000`, `TARGET_UPM = 2048`), `_glyph_codepoint`, `_is_kana_or_punct`,
   `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
   `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
   `_apply_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
@@ -438,7 +461,7 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 91 | Glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, runtime feature retargeting |
+| `test_font_build.py` | 96 | UPM scaling policy, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, runtime feature retargeting |
 | `test_proportional.py` | 29 | palt/vpal extraction, glyph translation, GPOS feature removal, runtime-palt/vpal reinstall + base/residual split + optional squeeze helper |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.9"
 dependencies = [
-    "ofl-font-baker>=0.4.4",
+    "ofl-font-baker>=0.4.5",
     "freetype-py>=2.4.0",
 ]
 

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -4,15 +4,15 @@ Build Gen Interface JP font families.
 
 Shared pipeline per weight:
   1. Bake Noto Sans JP variable → static TTF  (font-baker, base-only,
-                                                metadataMode=inheritBase
-                                                so Noto's name/OS2 survive)
+                                                metadataMode=inheritBase,
+                                                output.upm=2048)
   2. Convert to proportional metrics           (palt-based, proportional.py)
   3. Apply tracking                            (LSB +half, RSB +half)
   4. Merge Inter/InterDisplay + proportional Noto  (font-baker, with
      subFont.excludeCodepoints to keep CJK-conventional symbols on Noto)
 
 Families:
-  - Gen Interface JP         : Inter       + proportional Noto, tracking +30 (kana/punct +40)
+  - Gen Interface JP         : Inter       + proportional Noto, tracking +30 (kana/punct +40) at 1000 UPM
   - Gen Interface JP Display : InterDisplay + proportional Noto, tracking +0
 
 Outputs TTF into dist/ttf/. Web delivery (subset WOFF2 chunks served via
@@ -38,6 +38,65 @@ from .proportional import (
     _scale_position_adjustment,
     make_proportional,
 )
+
+
+# ---------------------------------------------------------------------------
+# UPM policy
+# ---------------------------------------------------------------------------
+
+# Noto Sans JP's source data is 1000 UPM, but Inter / Inter Display are 2048
+# UPM. Bake Noto intermediates and final merged fonts at Inter's native UPM so
+# Latin outlines and metrics do not get rounded down to the Noto grid.
+SOURCE_UPM = 1000
+TARGET_UPM = 2048
+
+
+def _scale_design_unit(value: int, target_upm: int = TARGET_UPM) -> int:
+    """Scale a project design-unit value from Noto's 1000 UPM grid."""
+    return round(value * target_upm / SOURCE_UPM)
+
+
+def _scale_design_adjustment(
+    adjustment: tuple[int, int],
+    target_upm: int = TARGET_UPM,
+) -> tuple[int, int]:
+    """Scale a two-value OpenType adjustment from the 1000 UPM design grid."""
+    first, second = adjustment
+    return (_scale_design_unit(first, target_upm), _scale_design_unit(second, target_upm))
+
+
+def _scale_design_adjustments(
+    adjustments: dict[str, tuple[int, int]],
+    target_upm: int = TARGET_UPM,
+) -> dict[str, tuple[int, int]]:
+    """Scale glyph-keyed palt/vpal adjustment records from 1000 UPM."""
+    return {
+        glyph_name: _scale_design_adjustment(adjustment, target_upm)
+        for glyph_name, adjustment in adjustments.items()
+    }
+
+
+def _scale_glyph_spacing(
+    spacing: dict | None,
+    target_upm: int = TARGET_UPM,
+) -> dict | None:
+    """Scale codepoint-keyed sidebearing adjustments from 1000 UPM."""
+    if not spacing:
+        return spacing
+    return {
+        key: _scale_design_adjustment(deltas, target_upm)
+        for key, deltas in spacing.items()
+    }
+
+
+def _assert_target_upm(font: TTFont, path: str) -> None:
+    """Fail clearly if a build stage did not produce Inter-native UPM."""
+    upm = font["head"].unitsPerEm
+    if upm != TARGET_UPM:
+        raise RuntimeError(
+            f"Expected {path} to be {TARGET_UPM} UPM, got {upm}. "
+            "Check that the installed ofl-font-baker supports output.upm."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -585,10 +644,11 @@ def _scale_gpos_x(st, scale: float) -> None:
 # Bbox / head-table cleanup
 # ---------------------------------------------------------------------------
 
-# Threshold for "extreme" glyphs whose bbox dominates head.yMax/yMin.
-# em=1000 base; the legitimate Latin/CJK content of Noto stays well within
-# these bounds, so anything past them is the vertical-only iteration-mark
-# glyphs we want to neutralise.
+# Threshold for "extreme" glyphs whose bbox dominates head.yMax/yMin. Values
+# are kept in the project design grid (1000 UPM) and scaled to the font's
+# active UPM before comparison. The legitimate Latin/CJK content of Noto stays
+# well within these bounds, so anything past them is the vertical-only
+# iteration-mark glyphs we want to neutralise.
 _EXTREME_YMAX = 1200
 _EXTREME_YMIN = -400
 _VERTICAL_REPEAT_MARK_CODEPOINTS = tuple(range(0x3031, 0x3036))
@@ -616,6 +676,9 @@ def _strip_extreme_glyphs(font: TTFont) -> None:
     hmtx = font["hmtx"]
     to_remove = set()
     cmap = font.getBestCmap() or {}
+    upm = font["head"].unitsPerEm
+    extreme_ymax = _scale_design_unit(_EXTREME_YMAX, upm)
+    extreme_ymin = _scale_design_unit(_EXTREME_YMIN, upm)
     to_remove.update(
         glyph_name
         for cp, glyph_name in cmap.items()
@@ -627,7 +690,7 @@ def _strip_extreme_glyphs(font: TTFont) -> None:
             continue
         if not hasattr(g, "yMax") or g.yMax is None:
             continue
-        if g.yMax > _EXTREME_YMAX or g.yMin < _EXTREME_YMIN:
+        if g.yMax > extreme_ymax or g.yMin < extreme_ymin:
             to_remove.add(gname)
 
     if not to_remove:
@@ -961,8 +1024,8 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     Pipeline:
 
     1. **Bake** Noto variable → static TTF at the chosen wght axis location,
-       passed through font-baker with ``metadataMode: inheritBase`` so the
-       Noto identity records survive into the inst.
+       passed through font-baker with ``metadataMode: inheritBase`` and
+       ``output.upm = 2048`` so the Noto identity records survive into the inst.
     2. **Proportionalise** the inst — read palt from the variable cache
        (variable instantiation can corrupt palt), bake those adjustments
        into hmtx except selected runtime-palt yakumono, apply tracking,
@@ -990,7 +1053,9 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     # `metadataMode: inheritBase` keeps Noto's name/OS2 records intact so
     # designer/OFL/version metadata survives into the inst TTF (no manual
     # save/restore needed). Only `weight` is overridden to stamp the static
-    # instance — family/italic/width inherit from the Noto base.
+    # instance — family/italic/width inherit from the Noto base. `output.upm`
+    # moves every Noto glyph, including unmapped vertical alternates, onto
+    # Inter's 2048 UPM grid before the in-house spacing passes run.
     print(f"    [1/3] Baking Noto Sans JP (wght={noto_wght})...")
     bake_config = {
         "baseFont": {
@@ -1002,6 +1067,7 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
         "output": {
             "weight": weight_num,
             "metadataMode": "inheritBase",
+            "upm": TARGET_UPM,
         },
         "export": {
             "path": {
@@ -1012,18 +1078,31 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     merge_fonts(bake_config)
 
     # ── Step 2: Convert to proportional + apply tracking ──
-    tracking = family["tracking"]
-    tracking_kana = family["trackingKana"]
+    font = TTFont(inst_path)
+    _assert_target_upm(font, inst_path)
+    font_upm = font["head"].unitsPerEm
+
+    tracking_design = family["tracking"]
+    tracking_kana_design = family["trackingKana"]
+    tracking = _scale_design_unit(tracking_design, font_upm)
+    tracking_kana = (
+        None
+        if tracking_kana_design is None
+        else _scale_design_unit(tracking_kana_design, font_upm)
+    )
     tracking_ignore = family.get("trackingIgnore")
     runtime_palt_chars = family.get("runtimePalt")
     runtime_vpal_chars = family.get("runtimeVpal")
 
     desc = f"tracking +{tracking}"
+    if font_upm != SOURCE_UPM:
+        desc += f" ({tracking_design} at {SOURCE_UPM} UPM)"
     if tracking_kana is not None:
-        desc += f" (kana/punct +{tracking_kana})"
+        kana_desc = f"kana/punct +{tracking_kana}"
+        if font_upm != SOURCE_UPM:
+            kana_desc += f" ({tracking_kana_design} at {SOURCE_UPM} UPM)"
+        desc += f" ({kana_desc})"
     print(f"    [2/3] Proportional (palt) + {desc}...")
-
-    font = TTFont(inst_path)
 
     # Split U+30FB from U+2027 before metrics work. Noto maps both to
     # ``uni2027``, but U+30FB is one of the yakumono glyphs that should
@@ -1036,13 +1115,17 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     # variable instantiation can leave proportional ValueRecords with zeroed
     # or otherwise stale placement/advance pairs. The cached variable read is
     # canonical across all weights.
-    palt_data = dict(_get_variable_palt())
+    palt_data = _scale_design_adjustments(dict(_get_variable_palt()), font_upm)
     if split_source in palt_data:
         palt_data["uni30FB"] = palt_data[split_source]
-    vpal_data = dict(_get_variable_vpal())
+    vpal_data = _scale_design_adjustments(dict(_get_variable_vpal()), font_upm)
     if split_source in vpal_data:
         vpal_data["uni30FB"] = vpal_data[split_source]
-    for glyph_name, value in SYNTHETIC_VPAL_ADJUSTMENTS.items():
+    synthetic_vpal_adjustments = _scale_design_adjustments(
+        SYNTHETIC_VPAL_ADJUSTMENTS,
+        font_upm,
+    )
+    for glyph_name, value in synthetic_vpal_adjustments.items():
         if glyph_name in font.getGlyphOrder():
             vpal_data[glyph_name] = value
             runtime_vpal_glyphs.add(glyph_name)
@@ -1071,7 +1154,10 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
         runtime_vpal=runtime_vpal_glyphs,
     )
     _apply_tracking(font, tracking, tracking_kana, tracking_ignore)
-    spacing_adjusted = _apply_glyph_spacing(font, family.get("glyphSpacing"))
+    spacing_adjusted = _apply_glyph_spacing(
+        font,
+        _scale_glyph_spacing(family.get("glyphSpacing"), font_upm),
+    )
     if spacing_adjusted:
         print(f"          Per-glyph spacing: {spacing_adjusted} glyph(s) adjusted")
     _strip_extreme_glyphs(font)
@@ -1086,6 +1172,7 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     ttf_dir = os.path.join(DIST_TTF, family_name)
     final_path = os.path.join(ttf_dir, f"{file_name}.ttf")
     print(f"    [3/3] Merging {family['interPrefix']} + proportional Noto...")
+    baseline_offset = _scale_design_unit(BASELINE_OFFSET, TARGET_UPM)
     merge_config = {
         "subFont": {
             "path": inter_path,
@@ -1097,7 +1184,7 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
         "baseFont": {
             "path": prop_path,
             "scale": SCALE,
-            "baselineOffset": BASELINE_OFFSET,
+            "baselineOffset": baseline_offset,
             "axes": [],
         },
         "output": {
@@ -1106,6 +1193,7 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
             "italic": False,
             "width": 5,
             "metricsSource": "sub",
+            "upm": TARGET_UPM,
             "manufacturer": "Yamato Iizuka",
             "manufacturerURL": "https://yamatoiizuka.com",
         },
@@ -1117,12 +1205,15 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     }
     with _suppress_fonttools_coverage_warnings():
         merge_fonts(merge_config)
+    final_font = TTFont(final_path)
+    _assert_target_upm(final_font, final_path)
+    final_font.close()
     _normalize_layout_coverage_order(final_path)
     _refresh_runtime_prop_features_after_merge(
         final_path,
         runtime_palt_by_codepoint,
         runtime_vpal_by_codepoint,
-        SYNTHETIC_VPAL_ADJUSTMENTS,
+        synthetic_vpal_adjustments,
     )
     return {
         "fontPath": final_path,

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -29,6 +29,10 @@ from font.build import (
     _retarget_feature_adjustments,
     _retarget_named_adjustments,
     _runtime_palt_residual_adjustment,
+    _scale_design_adjustment,
+    _scale_design_adjustments,
+    _scale_design_unit,
+    _scale_glyph_spacing,
     _split_cmap_codepoint_glyph,
     _strip_extreme_glyphs,
     DISPLAY_PALT_SPACE_ADJUSTMENTS,
@@ -36,12 +40,44 @@ from font.build import (
     PALT_FEATURE_CHARS,
     PALT_SPACE_ADJUSTMENTS,
     RUNTIME_PALT_BASE_SCALE,
+    SOURCE_UPM,
     SUB_EXCLUDE_CODEPOINTS,
     SYNTHETIC_VPAL_ADJUSTMENTS,
+    TARGET_UPM,
     TRACKING_IGNORE_CODEPOINTS,
     VPAL_FEATURE_CHARS,
 )
 from merge_fonts import parse_codepoint_list
+
+
+# ---------------------------------------------------------------------------
+# UPM policy
+# ---------------------------------------------------------------------------
+
+class TestUpmPolicy:
+    """Project-owned design units are authored at 1000 UPM and scaled at build time."""
+
+    def test_target_upm_matches_inter_native_grid(self):
+        assert SOURCE_UPM == 1000
+        assert TARGET_UPM == 2048
+
+    def test_scales_single_design_unit_value(self):
+        assert _scale_design_unit(25) == 51
+        assert _scale_design_unit(30) == 61
+        assert _scale_design_unit(40) == 82
+        assert _scale_design_unit(-400) == -819
+
+    def test_scales_position_adjustment_tuple(self):
+        assert _scale_design_adjustment((-250, -500)) == (-512, -1024)
+
+    def test_scales_glyph_keyed_adjustments(self):
+        assert _scale_design_adjustments({"uni3001": (-250, -500)}) == {
+            "uni3001": (-512, -1024),
+        }
+
+    def test_scales_codepoint_keyed_spacing(self):
+        assert _scale_glyph_spacing({"ょ": (30, 35)}) == {"ょ": (61, 72)}
+        assert _scale_glyph_spacing(None) is None
 
 
 # ---------------------------------------------------------------------------
@@ -374,7 +410,8 @@ class TestStripExtremeGlyphs:
         assert after.numberOfContours == before_contours
 
     def test_threshold_constants_match_implementation(self):
-        # If the constants drift, several call sites assume yMax=1200/yMin=-400.
+        # Constants are authored on the 1000 UPM design grid; the implementation
+        # scales them to the active font UPM before comparison.
         assert _EXTREME_YMAX == 1200
         assert _EXTREME_YMIN == -400
 


### PR DESCRIPTION
## Summary

- build Noto intermediates and final merged TTFs at Inter-native 2048 UPM via font-baker output.upm
- scale project-owned 1000-UPM design values for palt/vpal, tracking, spacing, bbox thresholds, and baseline offset
- bump ofl-font-baker dependency to >=0.4.5 and document the UPM policy in both architecture docs

Fixes #11.

## Validation

- PYTHONPATH=../font-baker/python:src python3 -m pytest -q -> 169 passed
- PYTHONPATH=../font-baker/python:src python3 -m font.build normal Regular -> passed
- PYTHONPATH=../font-baker/python:src python3 -m font.build display Regular -> passed
- Regular final TTF confirmed at 2048 UPM; H hmtx/hhea match Inter Regular
