### PR TITLE
[codex] Sync font metadata version

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -33,7 +33,7 @@ Gen Interface JP はフォントビルドパイプライン (アプリ/UI なし
         │         subFont.excludeCodepoints で日本語慣習    │
         │         記号は Noto を維持                        │
         │         output.upm=2048, metricsSource=sub      │
-        │         manufacturer 刻印                        │
+        │         project version + manufacturer 刻印      │
         │         GSUB/GPOS coverage order 正規化          │
         │             ↓                                   │
         │   dist/ttf/  (ファミリー × ウェイトごとに TTF)    │
@@ -90,6 +90,7 @@ FAMILIES × WEIGHTS の各組合せに対して:
                      family/weight を「Gen Interface JP …」に刻印
                      output.upm=2048 で Inter ネイティブグリッドを維持
                      metricsSource=sub で Inter 基準の hhea を採用
+                     project version を name metadata に刻印
                      manufacturer / manufacturerURL を刻印
   → final TTF を一度 reload/save し、GSUB/GPOS coverage を
     merge 後の glyph ID 順に正規化
@@ -227,6 +228,12 @@ UPM 変換ではなく光学的な CJK デザインスケールとして残し�
 Inter の cap-height と揃うように Noto を縮める — 欧文/CJK 混植で CJK を少し
 小さくして釣り合いを取る、という慣例的な配分。
 
+`output.version` は共有 helper `project_metadata.project_version()` 経由で
+`pyproject.toml` から読み、final TTF の nameID 5 と nameID 3 に
+release zip / npm package / site metadata と同じ project/release version を
+刻印する。OpenType の version 比較では先頭の `major.minor` numeric prefix
+だけが使われるため、`1.2.3` のような project version は name string には
+残り、`head.fontRevision` は numeric prefix の `1.2` 相当になる。
 `output.manufacturer = "Yamato Iizuka"`、`output.manufacturerURL =
 "https://yamatoiizuka.com"` でリリース TTF の nameID 8 / 11 を刻印。
 merge 後は final TTF を一度 fontTools で reload/save し、GSUB/GPOS coverage を
@@ -402,7 +409,9 @@ dist/release/npm/
   webfont CSS / WOFF2 レイアウトの静的ミラーを、デモサイトの隣で配信。
 
 バージョンは `pyproject.toml` (CI では `GITHUB_REF_NAME`) から読む。
-github / npm / webfonts ディレクトリの隣にある `manifest.json` には
+font build も同じ共有 metadata helper で `pyproject.toml` を読み、final TTF の
+version record を刻印するため、フォント本体とリリース成果物の version source
+は分岐しない。github / npm / webfonts ディレクトリの隣にある `manifest.json` には
 リリース URL が記録され、下流ツールが参照できる。
 
 ## サイト (`site/`)
@@ -426,7 +435,8 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
   が必要なテスト用に Noto Variable のサブセットをセッション単位でキャッシュ;
   全グリフ走査が必要な mutation テスト用には `FontBuilder` で組み立てた
   最小 TrueType (Noto 17000 グリフを毎回触るのは無駄)。
-- **`tests/test_font_build.py`** — UPM 設計値換算
+- **`tests/test_font_build.py`** — UPM 設計値換算、project-version metadata
+  forwarding
   (`SOURCE_UPM = 1000`, `TARGET_UPM = 2048`)、`_glyph_codepoint`, `_is_kana_or_punct`,
   `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
   `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
@@ -450,7 +460,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 96 | UPM 換算ポリシー、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、runtime feature の retarget |
+| `test_font_build.py` | 98 | UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、runtime feature の retarget |
 | `test_proportional.py` | 29 | palt/vpal 抽出、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal 再生成 + base/residual 分割 + optional squeeze helper |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |
@@ -480,14 +490,15 @@ GitHub Pages にデプロイ。リリースパッケージングはローカル�
 
 ### Python
 
-- `ofl-font-baker` (>= 0.4.1) — コンポジットフォントマージエンジン。
+- `ofl-font-baker` (>= 0.4.5) — コンポジットフォントマージエンジン。
   `metadataMode` で base / sub の identity を継承する。Stage 1 (bake) と
   Stage 3 (merge) を駆動。0.4.0 で `subFont.excludeCodepoints` と
   glyph-name collision rename が追加され、merge 段で日本語慣習記号を
   Noto に残すために利用している。0.4.1 で rename / duplicate された
   グリフに対して縦書き metrics (`vmtx` / `VORG`) と `vert` / `vrt2` GSUB
   マッピングを base から継承するように修正され、上書き対象の縦書き
-  位置が崩れない。
+  位置が崩れない。0.4.5 で `output.upm` が追加され、Noto bake と final merge
+  の両段で 2048 UPM の Inter グリッドを維持するために使っている。
 - `fonttools` (>= 4.47.0) — フォントパース、instancer、subsetter、
   GPOS / GSUB の編集。
 - `freetype-py` — メトリクス検証ツーリングで使用。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,7 +33,7 @@ consumes the published webfont package.
         │         subFont.excludeCodepoints keeps         │
         │         CJK-conventional symbols on Noto        │
         │         output.upm=2048, metricsSource=sub      │
-        │         manufacturer stamp                      │
+        │         project version + manufacturer stamp    │
         │         normalize GSUB/GPOS coverage order      │
         │             ↓                                   │
         │   dist/ttf/  (one TTF per family × weight)      │
@@ -90,6 +90,7 @@ For each (family, weight) in FAMILIES × WEIGHTS:
                      family/weight stamped to "Gen Interface JP …"
                      output.upm=2048 preserves Inter's native grid
                      metricsSource=sub anchors hhea on Inter
+                     project version stamped into name metadata
                      manufacturer / manufacturerURL stamped
   → reload/save final TTF once so GSUB/GPOS coverage tables are ordered
     by the final merged glyph IDs
@@ -233,7 +234,13 @@ lines up in width with Inter's cap-height — a
 typographic convention for Latin/CJK pairing where CJK is slightly down-scaled
 to feel proportionate.
 
-`output.manufacturer = "Yamato Iizuka"`, `output.manufacturerURL =
+`output.version` is read from `pyproject.toml` via the shared
+`project_metadata.project_version()` helper, so final TTF nameID 5 and
+nameID 3 carry the same project/release version as the release zip / npm
+package / site metadata. OpenType version comparison only uses the leading
+`major.minor` numeric prefix, so a project version like `1.2.3` appears in
+name strings while `head.fontRevision` resolves to the numeric `1.2`
+prefix. `output.manufacturer = "Yamato Iizuka"`, `output.manufacturerURL =
 "https://yamatoiizuka.com"` stamp nameID 8 / 11 on every released TTF.
 After the merge, the TTF is reloaded and saved once with fontTools so
 GSUB/GPOS coverage tables are sorted against the final merged glyph order.
@@ -414,8 +421,10 @@ Three downstream consumers, three outputs:
   demo site.
 
 Version is read from `pyproject.toml` (or `GITHUB_REF_NAME` in CI). The
-`manifest.json` next to the github / npm / webfonts dirs records release
-URLs for downstream tooling.
+font build also reads `pyproject.toml` through the same shared metadata helper
+when stamping final TTF version records, so font bodies and release artifacts
+do not diverge. The `manifest.json` next to the github / npm / webfonts dirs
+records release URLs for downstream tooling.
 
 ## Site (`site/`)
 
@@ -438,7 +447,8 @@ Tests live under `tests/`, split by surface:
   Noto Variable for tests that need real palt / vpal / vert / cmap data, and a
   hand-built minimal TrueType (`FontBuilder`) for whole-font mutation
   tests where 17 000 Noto glyphs would be wasteful.
-- **`tests/test_font_build.py`** — UPM design-unit scaling
+- **`tests/test_font_build.py`** — UPM design-unit scaling, project-version
+  metadata forwarding
   (`SOURCE_UPM = 1000`, `TARGET_UPM = 2048`), `_glyph_codepoint`, `_is_kana_or_punct`,
   `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
   `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
@@ -461,7 +471,7 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 96 | UPM scaling policy, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, runtime feature retargeting |
+| `test_font_build.py` | 98 | UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, runtime feature retargeting |
 | `test_proportional.py` | 29 | palt/vpal extraction, glyph translation, GPOS feature removal, runtime-palt/vpal reinstall + base/residual split + optional squeeze helper |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |
@@ -491,7 +501,7 @@ flow.
 
 ### Python
 
-- `ofl-font-baker` (>= 0.4.1) — Composite font merge engine. Inherits
+- `ofl-font-baker` (>= 0.4.5) — Composite font merge engine. Inherits
   base/sub identity records via `metadataMode`. Drives Stage 1 (bake)
   and Stage 3 (merge) of the build pipeline. 0.4.0 added
   `subFont.excludeCodepoints` and glyph-name collision rename, used by
@@ -499,7 +509,9 @@ flow.
   preserves vertical metrics (`vmtx` / `VORG`) and `vert` / `vrt2`
   GSUB mappings when glyphs are renamed or duplicated during the merge,
   so vertical typesetting of overridden glyphs continues to land at the
-  base font's intended position.
+  base font's intended position. 0.4.5 adds `output.upm`, used by both
+  the Noto bake and final merge stages to keep the pipeline on the 2048 UPM
+  Inter grid.
 - `fonttools` (>= 4.47.0) — Font parsing, instancer, subsetter, GPOS / GSUB
   table editing.
 - `freetype-py` — Used by tooling around metrics inspection.

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -31,6 +31,7 @@ import sys
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.reorderGlyphs import reorderGlyphs
 from merge_fonts import merge_fonts, parse_codepoint_list
+from project_metadata import project_version as read_project_version
 from .proportional import (
     _install_palt_feature,
     _install_vpal_feature,
@@ -278,6 +279,31 @@ NOTO_VARIABLE = os.path.join(VENDOR_FONTS, "Noto_Sans_JP", "NotoSansJP-VariableF
 DIST = os.path.join(ROOT, "dist")
 DIST_TTF = os.path.join(DIST, "ttf")
 INTERMEDIATE = os.path.join(DIST, "intermediate")
+
+
+def _project_version() -> str:
+    """Read the project version used for final generated font metadata."""
+    return read_project_version(ROOT)
+
+
+def _final_output_metadata(
+    family_name: str,
+    weight_num: int,
+    version: str,
+) -> dict[str, object]:
+    """Return font-baker output metadata for the final Gen Interface JP TTF."""
+    return {
+        "familyName": family_name,
+        "weight": weight_num,
+        "italic": False,
+        "width": 5,
+        "metricsSource": "sub",
+        "upm": TARGET_UPM,
+        "version": version,
+        "manufacturer": "Yamato Iizuka",
+        "manufacturerURL": "https://yamatoiizuka.com",
+    }
+
 
 # Codepoints whose glyphs should stay sourced from the base Noto font even
 # when Inter/InterDisplay also encodes them. Forwarded as
@@ -1038,7 +1064,8 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
        sharing the ``uni25CE`` glyph name with Noto's ◎. Output identity
        is rewritten to "Gen Interface JP", Inter's vertical metrics drive
        the merged hhea (``metricsSource: "sub"``), and our manufacturer /
-       URL get stamped into nameID 8 / 11.
+       URL plus the project version get stamped into the final name/head
+       metadata.
     """
     inter_path = os.path.join(INTER_DIR, f"{family['interPrefix']}-{weight_name}.ttf")
     if not os.path.isfile(inter_path):
@@ -1187,16 +1214,11 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
             "baselineOffset": baseline_offset,
             "axes": [],
         },
-        "output": {
-            "familyName": family_name,
-            "weight": weight_num,
-            "italic": False,
-            "width": 5,
-            "metricsSource": "sub",
-            "upm": TARGET_UPM,
-            "manufacturer": "Yamato Iizuka",
-            "manufacturerURL": "https://yamatoiizuka.com",
-        },
+        "output": _final_output_metadata(
+            family_name,
+            weight_num,
+            _project_version(),
+        ),
         "export": {
             "path": {
                 "font": final_path,

--- a/src/project_metadata.py
+++ b/src/project_metadata.py
@@ -1,0 +1,19 @@
+"""Shared project metadata readers."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def project_version(root: str | Path) -> str:
+    """Read the canonical project version from pyproject.toml."""
+    pyproject = Path(root) / "pyproject.toml"
+    match = re.search(
+        r'^version\s*=\s*"([^"]+)"',
+        pyproject.read_text(encoding="utf-8"),
+        re.M,
+    )
+    if not match:
+        raise ValueError(f"Could not read project version from {pyproject}")
+    return match.group(1)

--- a/src/release/build.py
+++ b/src/release/build.py
@@ -24,13 +24,13 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from font.build import DIST_TTF, FAMILIES, ROOT, WEIGHTS
+from project_metadata import project_version as read_project_version
 
 ROOT_PATH = Path(ROOT)
 DIST_TTF_PATH = Path(DIST_TTF)
@@ -49,11 +49,7 @@ class ReleaseFile:
 
 
 def project_version() -> str:
-    pyproject = ROOT_PATH / "pyproject.toml"
-    match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject.read_text(encoding="utf-8"), re.M)
-    if not match:
-        raise ValueError(f"Could not read project version from {pyproject}")
-    return match.group(1)
+    return read_project_version(ROOT_PATH)
 
 
 def normalized_version(version: str | None) -> str:

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -6,6 +6,8 @@ inspection, horizontal scaling, bbox stripping, and tracking.
 """
 
 import copy
+import re
+from pathlib import Path
 
 import pytest
 
@@ -17,6 +19,7 @@ from font.build import (
     _EXTREME_YMIN,
     _VERTICAL_REPEAT_MARK_CODEPOINTS,
     _feature_adjustments_for_codepoints,
+    _final_output_metadata,
     _get_cjk_glyphs,
     _get_variable_palt,
     _get_variable_vpal,
@@ -26,6 +29,7 @@ from font.build import (
     _is_cjk_codepoint,
     _is_kana_letter,
     _is_kana_or_punct,
+    _project_version,
     _retarget_feature_adjustments,
     _retarget_named_adjustments,
     _runtime_palt_residual_adjustment,
@@ -78,6 +82,33 @@ class TestUpmPolicy:
     def test_scales_codepoint_keyed_spacing(self):
         assert _scale_glyph_spacing({"ょ": (30, 35)}) == {"ょ": (61, 72)}
         assert _scale_glyph_spacing(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Project version metadata
+# ---------------------------------------------------------------------------
+
+class TestProjectVersionMetadata:
+    """Final TTF metadata is stamped from the canonical project version."""
+
+    def test_project_version_matches_pyproject(self):
+        pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+        match = re.search(
+            r'^version\s*=\s*"([^"]+)"',
+            pyproject.read_text(encoding="utf-8"),
+            re.M,
+        )
+        assert match is not None
+        assert _project_version() == match.group(1)
+
+    def test_final_output_metadata_forwards_version_to_font_baker(self):
+        output = _final_output_metadata("Gen Interface JP", 400, "1.2.3")
+
+        assert output["familyName"] == "Gen Interface JP"
+        assert output["weight"] == 400
+        assert output["metricsSource"] == "sub"
+        assert output["upm"] == TARGET_UPM
+        assert output["version"] == "1.2.3"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- read the canonical project version from `pyproject.toml` through a shared helper
- pass that version into the final font-baker merge so generated TTF name metadata is stamped consistently
- keep Stage 1 Noto inst metadata inherited, and document the OpenType `nameID 5` / `head.fontRevision` behavior

## Why

Fixes #9. Final generated fonts were falling back to font-baker's default `Version 1.000`, while release zips, npm metadata, and the site used the project version from `pyproject.toml`.

## Validation

- `PYTHONPATH=src python3 -m pytest -q` -> 171 passed
- `PYTHONPATH=src python3 -m font.build all Regular` -> built normal/display Regular
- inspected generated TTF metadata:
  - `GenInterfaceJP-Regular.ttf`: `nameID 5 = Version 0.2.2`, `nameID 3 = 0.2.2;GenInterfaceJP-Regular`, `head.fontRevision ~= 0.2`, `unitsPerEm = 2048`
  - `GenInterfaceJPDisplay-Regular.ttf`: `nameID 5 = Version 0.2.2`, `nameID 3 = 0.2.2;GenInterfaceJPDisplay-Regular`, `head.fontRevision ~= 0.2`, `unitsPerEm = 2048`
