### PR TITLE
[codex] Scale final runtime palt/vpal values

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -241,7 +241,9 @@ merge 後は final TTF を一度 fontTools で reload/save し、GSUB/GPOS cover
 保持した最小 runtime `palt` / `vpal` を final cmap に対して再生成する。
 これは `U+FF40` (｀) のように、Noto では `U+2035` と同じ `uni2035`
 を共有するが、Inter 側の `U+2035` と衝突して merge 後に
-`uni2035.orig` へ rename される glyph で必要になる。
+`uni2035.orig` へ rename される glyph で必要になる。この再生成は final merge
+後に行うため、保持していた feature record も `SCALE` で換算し、live の
+placement / advance が光学スケール済みの Noto base と揃うようにする。
 
 ## プロポーショナルメトリクス (`font/proportional.py`)
 
@@ -273,7 +275,10 @@ TrueType アウトラインのみ対応 (palt のベイクは `glyf` に書き�
 CFF は対象外)。
 Inter との merge では base 側 glyph が rename されることがあるため、
 ビルドは merge 前に runtime palt/vpal 値を codepoint 単位で保持し、
-merge 後の final cmap に対して再インストールする。
+merge 後の final cmap に対して再インストールする。再インストールする record
+には final Noto optical scale (`SCALE = 0.925`) をこの時点でだけ掛ける。
+pre-merge の `palt_data` / `vpal_data` は active UPM grid のままにし、焼き込み
+base metrics は merge 時に一度だけ scale される。
 
 `_remove_prop_features` は GPOS を 2 段で歩く: FeatureRecord の削除と、
 それに対応する LangSys インデックスの再マップ。レコード削除は後ろの全
@@ -460,7 +465,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 98 | UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、runtime feature の retarget |
+| `test_font_build.py` | 100 | UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、runtime feature の retarget、final runtime feature scaling |
 | `test_proportional.py` | 29 | palt/vpal 抽出、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal 再生成 + base/residual 分割 + optional squeeze helper |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -248,7 +248,9 @@ Then the minimal runtime `palt` / `vpal` features are rebuilt one final
 time from codepoint-keyed records captured before the merge. This matters
 for shared Noto glyphs such as `U+FF40` (｀), which uses Noto's `uni2035`
 before merge but may be renamed to `uni2035.orig` when Inter also provides
-`U+2035`.
+`U+2035`. Because this reinstall happens after the final merge, the saved
+feature records are also scaled by `SCALE` so their live placement/advance
+values match the optically scaled Noto base.
 
 ## Proportional Metrics (`font/proportional.py`)
 
@@ -281,7 +283,10 @@ runtime palt/vpal for selected yakumono. Only TrueType outlines are supported
 — palt baking writes back to `glyf`, not CFF.
 Because the Inter merge can rename colliding base glyphs, the build captures
 runtime palt/vpal values by codepoint before the merge and reinstalls them
-against the final cmap afterward.
+against the final cmap afterward. Those reinstalled records are scaled by
+the final Noto optical scale (`SCALE = 0.925`) at reinstall time only; the
+pre-merge `palt_data` / `vpal_data` remain on the active UPM grid so baked
+base metrics are scaled exactly once by the merge.
 
 `_remove_prop_features` walks GPOS in two coordinated passes:
 FeatureRecord deletions and the corresponding LangSys index remap.
@@ -471,7 +476,7 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 98 | UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, runtime feature retargeting |
+| `test_font_build.py` | 100 | UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, runtime feature retargeting, final runtime feature scaling |
 | `test_proportional.py` | 29 | palt/vpal extraction, glyph translation, GPOS feature removal, runtime-palt/vpal reinstall + base/residual split + optional squeeze helper |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -828,6 +828,17 @@ def _runtime_palt_residuals_by_codepoint(
     }
 
 
+def _scale_feature_adjustments(
+    adjustments: dict[int | str, tuple[int, int]],
+    scale: float,
+) -> dict[int | str, tuple[int, int]]:
+    """Scale codepoint- or glyph-keyed OpenType placement/advance records."""
+    return {
+        key: _scale_position_adjustment(value, scale)
+        for key, value in adjustments.items()
+    }
+
+
 def _retarget_feature_adjustments(
     font: TTFont,
     adjustments_by_codepoint: dict[int, tuple[int, int]],
@@ -1233,9 +1244,9 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     _normalize_layout_coverage_order(final_path)
     _refresh_runtime_prop_features_after_merge(
         final_path,
-        runtime_palt_by_codepoint,
-        runtime_vpal_by_codepoint,
-        synthetic_vpal_adjustments,
+        _scale_feature_adjustments(runtime_palt_by_codepoint, SCALE),
+        _scale_feature_adjustments(runtime_vpal_by_codepoint, SCALE),
+        _scale_feature_adjustments(synthetic_vpal_adjustments, SCALE),
     )
     return {
         "fontPath": final_path,

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -35,6 +35,7 @@ from font.build import (
     _runtime_palt_residual_adjustment,
     _scale_design_adjustment,
     _scale_design_adjustments,
+    _scale_feature_adjustments,
     _scale_design_unit,
     _scale_glyph_spacing,
     _split_cmap_codepoint_glyph,
@@ -650,6 +651,26 @@ class TestPaltSymbolPolicy:
         assert RUNTIME_PALT_BASE_SCALE == 0.34
         assert _runtime_palt_residual_adjustment((-250, -500)) == (-165, -330)
         assert _runtime_palt_residual_adjustment((-70, -140)) == (-46, -92)
+
+    def test_scales_final_runtime_feature_adjustments_by_optical_scale(self):
+        adjustments = {
+            0x3001: (-512, -1024),
+            0x3002: (100, -200),
+        }
+
+        assert _scale_feature_adjustments(adjustments, 0.925) == {
+            0x3001: (round(-512 * 0.925), round(-1024 * 0.925)),
+            0x3002: (round(100 * 0.925), round(-200 * 0.925)),
+        }
+
+    def test_scales_glyph_keyed_final_runtime_feature_adjustments(self):
+        adjustments = {
+            "uniFE10": (-512, -1024),
+        }
+
+        assert _scale_feature_adjustments(adjustments, 0.925) == {
+            "uniFE10": (round(-512 * 0.925), round(-1024 * 0.925)),
+        }
 
     def test_noto_vpal_yakumono_uses_separate_runtime_target_set(self):
         vpal = _get_variable_vpal()


### PR DESCRIPTION
## Summary

- scale runtime `palt` / `vpal` values by `SCALE` only when reinstalling them after the final Inter + Noto merge
- leave pre-merge `palt_data` / `vpal_data` on the active UPM grid so baked base metrics are still scaled once by the merge
- document the final runtime feature scaling policy and add unit coverage for codepoint- and glyph-keyed records

## Why

Follow-up to PR #12. The final merge optically scales the Noto base by `SCALE = 0.925`, but runtime proportional feature records reinstalled after that merge also need to be expressed in the final scaled coordinate system.

## Validation

- `PYTHONPATH=src python3 -m pytest tests/test_font_build.py -q` -> 100 passed
- `PYTHONPATH=src python3 -m pytest -q` -> 173 passed
- `PYTHONPATH=src python3 -m font.build all Regular` -> built normal/display Regular
- inspected representative final runtime feature values:
  - `palt U+3001 uni3001`: `actual=(-11, -625)`, `expected=(-11, -625)`
  - `vpal U+FE10 uniFE10`: `actual=(0, -947)`, `expected=(0, -947)`
