### PR TITLE
[codex] Use tuned Inter variable edge weights

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NPM_PUBLISH_FLAGS ?= --access public
 NPM_CACHE ?= $(CURDIR)/.npm-cache
 
 .PHONY: all clean \
-        font \
+        font verify-edge-instances \
         webfont webfont-benchmark \
         release npm-pack npm-publish-dry-run npm-publish \
         site serve
@@ -28,6 +28,10 @@ all: release
 # `make webfont` (subset WOFF2 served via unicode-range), not full WOFF2.
 font:
 	$(PY) -m font.build
+
+verify-edge-instances:
+	$(PY) -m font.build all Thin ExtraBold
+	$(PY) -m font.verify_edge_instances
 
 
 # ---------------------------------------------------------------------------

--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -12,6 +12,7 @@ Gen Interface JP はフォントビルドパイプライン (アプリ/UI なし
 │  Source                                                            │
 │    vendor/fonts/Inter-4.1/extras/ttf/Inter-{Weight}.ttf            │
 │    vendor/fonts/Inter-4.1/extras/ttf/InterDisplay-{Weight}.ttf     │
+│    vendor/fonts/Inter-4.1/InterVariable.ttf                        │
 │    vendor/fonts/Noto_Sans_JP/NotoSansJP-VariableFont_wght.ttf      │
 └─────────────────────────────┬──────────────────────────────────────┘
                               │
@@ -67,6 +68,14 @@ Gen Interface JP はフォントビルドパイプライン (アプリ/UI なし
 
 ```
 FAMILIES × WEIGHTS の各組合せに対して:
+  → Inter source を選択:
+      - ExtraLight から Bold は vendor の static Inter/InterDisplay TTF
+      - Thin と ExtraBold は InterVariable.ttf から static instance を生成:
+          Gen Interface JP         : opsz=14, wght=125 / 775
+          Gen Interface JP Display : opsz=32, wght=125 / 775
+        生成後の static instance は usWeightClass 100 / 800 に戻し、
+        公開ウェイト名の metadata が内部 wght 座標に引きずられない
+        ようにする。
   → font-baker bake: variable Noto → static TTF
                     inheritBase で designer/OFL/version を継承
                     weight だけを上書き
@@ -82,7 +91,7 @@ FAMILIES × WEIGHTS の各組合せに対して:
   → _apply_glyph_spacing で family["glyphSpacing"] の個別調整を適用
   → _strip_extreme_glyphs で縦組み用繰り返し記号 〱-〵 を無効化
     (1000-UPM 設計値: yMax > 1200 / yMin < -400)
-  → font-baker merge: Inter + proportional Noto
+  → font-baker merge: Inter source + proportional Noto
                      subFont.excludeCodepoints = SUB_EXCLUDE_CODEPOINTS で
                      日本語慣習記号 (① Ⓐ ※ ◯ …) は Noto を維持
                      glyph-name collision (Inter U+0298 と Noto U+25CE が

--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -440,7 +440,7 @@ GitHub Pages のデプロイは `.github/workflows/pages.yml`
 ## テスト
 
 ```bash
-PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
+PYTHONPATH=src python3 -m pytest        # 全テスト (~20 秒)
 ```
 
 テストは表面ごとに `tests/` 直下に分割:
@@ -456,7 +456,13 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
   `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
   `_apply_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
   `_split_cmap_codepoint_glyph`, `_get_variable_palt`, `_get_variable_vpal`、
-  明示的な palt/vpal spacing 方針。
+  明示的な palt/vpal spacing 方針、Thin / ExtraBold 用の InterVariable
+  edge instance source 選択。
+- **`src/font/verify_edge_instances.py`** — Thin / ExtraBold のビルド後検証。
+  生成された InterVariable static instance が vendor static と同じ cmap /
+  GSUB / GPOS 表面を保ち、variation table を残さず、指定 `wght` / `opsz`
+  座標になっていること、さらに final TTF の metadata が public weight
+  100 / 800 のままで InterVariable axis 名を漏らさないことを確認する。
 - **`tests/test_proportional.py`** — `_read_palt`, `_read_vpal`,
   `_shift_glyph_x`, `_remove_prop_features`, `make_proportional` (palt
   ベイク、runtime-palt/vpal 再生成、runtime-palt の base/residual 分割、
@@ -474,7 +480,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 100 | UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、runtime feature の retarget、final runtime feature scaling |
+| `test_font_build.py` | 107 | UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、runtime feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
 | `test_proportional.py` | 29 | palt/vpal 抽出、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal 再生成 + base/residual 分割 + optional squeeze helper |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |
@@ -484,6 +490,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
 | コマンド | 用途 |
 |---|---|
 | `make font` | 全ファミリー × 全ウェイトの TTF を生成 |
+| `make verify-edge-instances` | Thin / ExtraBold をビルドし、InterVariable edge instance と final TTF metadata を検証 |
 | `make webfont` | unicode-range サブセットを生成 (`font` 依存) |
 | `make release` | GitHub zip + npm + Pages パッケージ生成 (`webfont` 依存) |
 | `make webfont-benchmark` | スライス方式の throttled fetch ベンチ |
@@ -493,6 +500,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~0.6 秒)
 | `make serve` | サイトのローカル Vite 開発サーバー |
 | `make clean` | `dist/` と `site/dist/` を削除 |
 | `python3 -m font.build [family] [weight ...]` | 部分ビルド (例: `normal Regular`) |
+| `python3 -m font.verify_edge_instances` | ビルド済み Thin / ExtraBold edge output を検証 |
 | `python3 -m pytest` | テスト実行 |
 
 CI: `.github/workflows/pages.yml` が `main` への push ごとにデモサイトを

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -452,7 +452,7 @@ GitHub Pages deploys the build via `.github/workflows/pages.yml`.
 ## Tests
 
 ```bash
-PYTHONPATH=src python3 -m pytest        # full suite (~0.6s)
+PYTHONPATH=src python3 -m pytest        # full suite (~20s)
 ```
 
 Tests live under `tests/`, split by surface:
@@ -468,7 +468,14 @@ Tests live under `tests/`, split by surface:
   `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
   `_apply_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
   `_split_cmap_codepoint_glyph`, `_get_variable_palt`, `_get_variable_vpal`,
-  and the explicit palt/vpal spacing policy.
+  explicit palt/vpal spacing policy, and InterVariable edge-instance source
+  selection for Thin / ExtraBold.
+- **`src/font/verify_edge_instances.py`** — post-build verification for
+  Thin / ExtraBold edge outputs. Confirms the generated InterVariable static
+  instances keep the vendor static cmap / GSUB / GPOS surface, contain no
+  variation tables, use the requested `wght` / `opsz` coordinates, and that
+  final TTF metadata stays at public weights 100 / 800 without leaking
+  InterVariable axis names.
 - **`tests/test_proportional.py`** — `_read_palt`, `_read_vpal`,
   `_shift_glyph_x`, `_remove_prop_features`, `make_proportional` (palt
   baking, runtime-palt/vpal reinstall, runtime-palt base/residual splitting,
@@ -485,7 +492,7 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 100 | UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, runtime feature retargeting, final runtime feature scaling |
+| `test_font_build.py` | 107 | UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, runtime feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
 | `test_proportional.py` | 29 | palt/vpal extraction, glyph translation, GPOS feature removal, runtime-palt/vpal reinstall + base/residual split + optional squeeze helper |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |
@@ -495,6 +502,7 @@ Tests live under `tests/`, split by surface:
 | Command | Purpose |
 |---|---|
 | `make font` | Build TTF for both families × all weights |
+| `make verify-edge-instances` | Build Thin / ExtraBold and verify InterVariable edge instance + final TTF metadata |
 | `make webfont` | Build unicode-range subsets (depends on `font`) |
 | `make release` | Build GitHub zips + npm + Pages package (depends on `webfont`) |
 | `make webfont-benchmark` | Throttled fetch benchmark of slicing strategy |
@@ -504,6 +512,7 @@ Tests live under `tests/`, split by surface:
 | `make serve` | Local Vite dev server for the site |
 | `make clean` | Remove `dist/` and `site/dist/` |
 | `python3 -m font.build [family] [weight ...]` | Build a slice (e.g. `normal Regular`) |
+| `python3 -m font.verify_edge_instances` | Verify built Thin / ExtraBold edge outputs |
 | `python3 -m pytest` | Run the test suite |
 
 CI: `.github/workflows/pages.yml` deploys the demo site to GitHub Pages

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,6 +12,7 @@ consumes the published webfont package.
 │  Source                                                            │
 │    vendor/fonts/Inter-4.1/extras/ttf/Inter-{Weight}.ttf            │
 │    vendor/fonts/Inter-4.1/extras/ttf/InterDisplay-{Weight}.ttf     │
+│    vendor/fonts/Inter-4.1/InterVariable.ttf                        │
 │    vendor/fonts/Noto_Sans_JP/NotoSansJP-VariableFont_wght.ttf      │
 └─────────────────────────────┬──────────────────────────────────────┘
                               │
@@ -67,6 +68,14 @@ consumes the published webfont package.
 
 ```
 For each (family, weight) in FAMILIES × WEIGHTS:
+  → choose Inter source:
+      - ExtraLight through Bold use vendor static Inter/InterDisplay TTFs
+      - Thin and ExtraBold are instantiated from InterVariable.ttf:
+          Gen Interface JP         : opsz=14, wght=125 / 775
+          Gen Interface JP Display : opsz=32, wght=125 / 775
+        The generated static instances are stamped back to usWeightClass
+        100 / 800 so output metadata follows the public weight names, not
+        the internal wght-axis coordinates.
   → font-baker bake: variable Noto → static TTF
                     inheritBase passes designer/OFL/version
                     through; only weight is stamped
@@ -82,7 +91,7 @@ For each (family, weight) in FAMILIES × WEIGHTS:
   → _apply_glyph_spacing applies family["glyphSpacing"] sidebearing tweaks
   → _strip_extreme_glyphs neutralises vertical iteration marks 〱-〵
     (1000-UPM design thresholds: yMax > 1200 / yMin < -400)
-  → font-baker merge: Inter + proportional Noto
+  → font-baker merge: Inter source + proportional Noto
                      subFont.excludeCodepoints = SUB_EXCLUDE_CODEPOINTS
                      keeps CJK-conventional symbols on Noto;
                      font-baker also auto-renames glyph-name collisions

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -300,6 +300,16 @@ INTER_VARIABLE_EDGE_WEIGHTS = {
     },
 }
 
+STATIC_INSTANCE_VARIATION_TABLES = (
+    "fvar",
+    "gvar",
+    "avar",
+    "HVAR",
+    "MVAR",
+    "VVAR",
+    "STAT",
+)
+
 
 def _axis_value_slug(value: float) -> str:
     """Return a stable filename fragment for an axis coordinate."""
@@ -385,14 +395,21 @@ def _build_inter_variable_instance(
     out_path = _inter_variable_instance_path(family, weight_name, axes, out_dir)
     os.makedirs(os.path.dirname(out_path), exist_ok=True)
 
-    font = TTFont(INTER_VARIABLE)
-    font = instancer.instantiateVariableFont(font, axes, inplace=False)
-    font["OS/2"].usWeightClass = weight_num
-    _set_inter_static_names(font, family["interFamilyName"], weight_name)
-    if "STAT" in font:
-        del font["STAT"]
-    font.save(out_path)
-    font.close()
+    variable_font = TTFont(INTER_VARIABLE)
+    try:
+        font = instancer.instantiateVariableFont(variable_font, axes, inplace=False)
+    finally:
+        variable_font.close()
+
+    try:
+        font["OS/2"].usWeightClass = weight_num
+        _set_inter_static_names(font, family["interFamilyName"], weight_name)
+        for table_tag in STATIC_INSTANCE_VARIATION_TABLES:
+            if table_tag in font:
+                del font[table_tag]
+        font.save(out_path)
+    finally:
+        font.close()
     return out_path
 
 

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -30,6 +30,7 @@ import sys
 
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.reorderGlyphs import reorderGlyphs
+from fontTools.varLib import instancer
 from merge_fonts import merge_fonts, parse_codepoint_list
 from project_metadata import project_version as read_project_version
 from .proportional import (
@@ -107,11 +108,13 @@ def _assert_target_upm(font: TTFont, path: str) -> None:
 # (output_weight, weight_name, noto_wght_axis_value)
 #
 # The third column is the wght-axis location used to instantiate Noto Sans JP.
-# Inter's discrete static masters happen to live at the round 100/200/.../800
-# positions, but Noto's variable axis is non-linear: pulling the axis at 400
-# yields a CJK weight that visually reads lighter than Inter Regular. The
-# values below were tuned by eye-matching CJK stem density to each Inter
-# master, hence the off-grid numbers (e.g. 465 for Regular, 800 for Bold).
+# Most Latin sources use Inter's discrete static masters. Thin and ExtraBold
+# are special-cased below to use InterVariable instances at wght=125/775 while
+# keeping public metadata at 100/800. Noto's variable axis is non-linear:
+# pulling the axis at 400 yields a CJK weight that visually reads lighter than
+# Inter Regular. The values below were tuned by eye-matching CJK stem density
+# to each Latin master, hence the off-grid numbers (e.g. 465 for Regular,
+# 800 for Bold).
 WEIGHTS = [
     (100, "Thin",       100),
     (200, "ExtraLight",  260),
@@ -236,6 +239,8 @@ FAMILIES = {
     "normal": {
         "familyName": "Gen Interface JP",
         "interPrefix": "Inter",
+        "interFamilyName": "Inter",
+        "interOpsz": 14,
         "tracking": NORMAL_TRACKING,
         "trackingKana": NORMAL_TRACKING_KANA,
         "trackingIgnore": TRACKING_IGNORE_CODEPOINTS,
@@ -255,6 +260,8 @@ FAMILIES = {
     "display": {
         "familyName": "Gen Interface JP Display",
         "interPrefix": "InterDisplay",
+        "interFamilyName": "Inter Display",
+        "interOpsz": 32,
         "tracking": DISPLAY_TRACKING,
         "trackingKana": DISPLAY_TRACKING_KANA,
         "trackingIgnore": TRACKING_IGNORE_CODEPOINTS,
@@ -275,10 +282,130 @@ FAMILIES = {
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 VENDOR_FONTS = os.path.join(ROOT, "vendor", "fonts")
 INTER_DIR = os.path.join(VENDOR_FONTS, "Inter-4.1", "extras", "ttf")
+INTER_VARIABLE = os.path.join(VENDOR_FONTS, "Inter-4.1", "InterVariable.ttf")
 NOTO_VARIABLE = os.path.join(VENDOR_FONTS, "Noto_Sans_JP", "NotoSansJP-VariableFont_wght.ttf")
 DIST = os.path.join(ROOT, "dist")
 DIST_TTF = os.path.join(DIST, "ttf")
 INTERMEDIATE = os.path.join(DIST, "intermediate")
+
+
+INTER_VARIABLE_EDGE_WEIGHTS = {
+    "Thin": {
+        "wght": 125,
+        "outputWeight": 100,
+    },
+    "ExtraBold": {
+        "wght": 775,
+        "outputWeight": 800,
+    },
+}
+
+
+def _axis_value_slug(value: float) -> str:
+    """Return a stable filename fragment for an axis coordinate."""
+    if float(value).is_integer():
+        return str(int(value))
+    return str(value).replace(".", "p")
+
+
+def _default_inter_static_path(family: dict, weight_name: str) -> str:
+    """Return the vendor static Inter path for a family/weight."""
+    return os.path.join(INTER_DIR, f"{family['interPrefix']}-{weight_name}.ttf")
+
+
+def _name_record_value(record, value: str) -> None:
+    """Replace a name record while preserving its platform encoding."""
+    record.string = value.encode(record.getEncoding(), errors="replace")
+
+
+def _set_inter_static_names(font: TTFont, family_name: str, weight_name: str) -> None:
+    """Stamp static Inter instance name records to match vendor statics."""
+    legacy_family = f"{family_name} {weight_name}"
+    postscript_family = family_name.replace(" ", "")
+    replacements = {
+        1: legacy_family,
+        2: "Regular",
+        4: legacy_family,
+        6: f"{postscript_family}-{weight_name}",
+        16: family_name,
+        17: weight_name,
+    }
+    name_table = font["name"]
+    name_table.names = [
+        record for record in name_table.names
+        if record.nameID != 25
+    ]
+    for record in name_table.names:
+        value = replacements.get(record.nameID)
+        if value is not None:
+            _name_record_value(record, value)
+    for name_id, value in replacements.items():
+        name_table.setName(value, name_id, 3, 1, 0x409)
+        name_table.setName(value, name_id, 1, 0, 0)
+
+
+def _inter_variable_instance_path(
+    family: dict,
+    weight_name: str,
+    axes: dict[str, float],
+    out_dir: str = INTERMEDIATE,
+) -> str:
+    """Return the generated static Inter instance path."""
+    instance_dir = os.path.join(out_dir, "InterVariable")
+    return os.path.join(
+        instance_dir,
+        (
+            f"{family['interPrefix']}-{weight_name}"
+            f"-wght{_axis_value_slug(axes['wght'])}"
+            f"-opsz{_axis_value_slug(axes['opsz'])}.ttf"
+        ),
+    )
+
+
+def _build_inter_variable_instance(
+    family: dict,
+    weight_num: int,
+    weight_name: str,
+    out_dir: str = INTERMEDIATE,
+) -> str:
+    """Instantiate InterVariable for the tuned Thin/ExtraBold Latin masters."""
+    config = INTER_VARIABLE_EDGE_WEIGHTS[weight_name]
+    expected_weight = config["outputWeight"]
+    if weight_num != expected_weight:
+        raise ValueError(
+            f"{weight_name} variable instance must be stamped as "
+            f"usWeightClass {expected_weight}, got {weight_num}."
+        )
+    axes = {
+        "wght": config["wght"],
+        "opsz": family["interOpsz"],
+    }
+    if not os.path.isfile(INTER_VARIABLE):
+        raise FileNotFoundError(f"Inter variable font not found: {INTER_VARIABLE}")
+    out_path = _inter_variable_instance_path(family, weight_name, axes, out_dir)
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+
+    font = TTFont(INTER_VARIABLE)
+    font = instancer.instantiateVariableFont(font, axes, inplace=False)
+    font["OS/2"].usWeightClass = weight_num
+    _set_inter_static_names(font, family["interFamilyName"], weight_name)
+    if "STAT" in font:
+        del font["STAT"]
+    font.save(out_path)
+    font.close()
+    return out_path
+
+
+def _inter_source_path(
+    family: dict,
+    weight_num: int,
+    weight_name: str,
+    out_dir: str = INTERMEDIATE,
+) -> str:
+    """Return the Inter sub-font source, generating edge instances as needed."""
+    if weight_name in INTER_VARIABLE_EDGE_WEIGHTS:
+        return _build_inter_variable_instance(family, weight_num, weight_name, out_dir)
+    return _default_inter_static_path(family, weight_name)
 
 
 def _project_version() -> str:
@@ -1078,11 +1205,11 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
        URL plus the project version get stamped into the final name/head
        metadata.
     """
-    inter_path = os.path.join(INTER_DIR, f"{family['interPrefix']}-{weight_name}.ttf")
+    os.makedirs(INTERMEDIATE, exist_ok=True)
+
+    inter_path = _inter_source_path(family, weight_num, weight_name)
     if not os.path.isfile(inter_path):
         raise FileNotFoundError(f"Inter font not found: {inter_path}")
-
-    os.makedirs(INTERMEDIATE, exist_ok=True)
 
     inst_path = os.path.join(INTERMEDIATE, f"NotoSansJP-{weight_name}-Inst.ttf")
     prop_path = os.path.join(INTERMEDIATE, f"NotoSansJP-{weight_name}-Prop.ttf")

--- a/src/font/verify_edge_instances.py
+++ b/src/font/verify_edge_instances.py
@@ -1,0 +1,241 @@
+"""Verify Thin/ExtraBold InterVariable edge instances after a font build.
+
+Run after building the edge weights:
+
+    PYTHONPATH=src python3 -m font.build all Thin ExtraBold
+    PYTHONPATH=src python3 -m font.verify_edge_instances
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+from fontTools.ttLib import TTFont
+from fontTools.varLib import instancer
+
+from .build import (
+    DIST_TTF,
+    FAMILIES,
+    INTER_VARIABLE,
+    INTER_VARIABLE_EDGE_WEIGHTS,
+    STATIC_INSTANCE_VARIATION_TABLES,
+    _default_inter_static_path,
+    _inter_variable_instance_path,
+)
+
+
+SAMPLE_GLYPHS = ("H", "A", "a", "period")
+
+
+def _layout_feature_tags(font: TTFont, table_tag: str) -> set[str]:
+    if table_tag not in font:
+        return set()
+    feature_list = font[table_tag].table.FeatureList
+    if feature_list is None:
+        return set()
+    return {record.FeatureTag for record in feature_list.FeatureRecord}
+
+
+def _glyph_signature(font: TTFont, glyph_name: str) -> tuple[tuple[int, int], int, int, int, int]:
+    glyph = font["glyf"][glyph_name]
+    return (
+        font["hmtx"][glyph_name],
+        glyph.xMin,
+        glyph.xMax,
+        glyph.yMin,
+        glyph.yMax,
+    )
+
+
+def _final_ttf_path(family: dict, weight_name: str) -> Path:
+    return Path(DIST_TTF) / family["familyName"] / f"{family['folderPrefix']}-{weight_name}.ttf"
+
+
+def _check(condition: bool, failures: list[str], message: str) -> None:
+    if not condition:
+        failures.append(message)
+
+
+def _verify_source_instance(
+    family_key: str,
+    weight_num: int,
+    weight_name: str,
+) -> list[str]:
+    failures: list[str] = []
+    family = FAMILIES[family_key]
+    config = INTER_VARIABLE_EDGE_WEIGHTS[weight_name]
+    axes = {"wght": config["wght"], "opsz": family["interOpsz"]}
+    instance_path = Path(_inter_variable_instance_path(family, weight_name, axes))
+    _check(instance_path.is_file(), failures, f"missing generated Inter instance: {instance_path}")
+    if failures:
+        return failures
+
+    generated = TTFont(str(instance_path))
+    variable = TTFont(INTER_VARIABLE)
+    vendor_static = TTFont(_default_inter_static_path(family, weight_name))
+    variable_for_expected = TTFont(INTER_VARIABLE)
+    try:
+        expected = instancer.instantiateVariableFont(variable_for_expected, axes, inplace=False)
+    finally:
+        variable_for_expected.close()
+
+    try:
+        prefix = f"{family_key} {weight_name}"
+        _check(
+            generated["OS/2"].usWeightClass == weight_num,
+            failures,
+            f"{prefix}: generated usWeightClass is {generated['OS/2'].usWeightClass}, expected {weight_num}",
+        )
+        for table_tag in STATIC_INSTANCE_VARIATION_TABLES:
+            _check(
+                table_tag not in generated,
+                failures,
+                f"{prefix}: generated instance still contains {table_tag}",
+            )
+
+        generated_cmap = set(generated.getBestCmap() or {})
+        variable_cmap = set(variable.getBestCmap() or {})
+        static_cmap = set(vendor_static.getBestCmap() or {})
+        _check(generated_cmap == variable_cmap, failures, f"{prefix}: cmap differs from InterVariable")
+        _check(generated_cmap == static_cmap, failures, f"{prefix}: cmap differs from vendor static Inter")
+        _check(
+            _layout_feature_tags(generated, "GSUB") == _layout_feature_tags(variable, "GSUB"),
+            failures,
+            f"{prefix}: GSUB feature set differs from InterVariable",
+        )
+        _check(
+            _layout_feature_tags(generated, "GPOS") == _layout_feature_tags(variable, "GPOS"),
+            failures,
+            f"{prefix}: GPOS feature set differs from InterVariable",
+        )
+        _check(
+            _layout_feature_tags(generated, "GSUB") == _layout_feature_tags(vendor_static, "GSUB"),
+            failures,
+            f"{prefix}: GSUB feature set differs from vendor static Inter",
+        )
+        _check(
+            _layout_feature_tags(generated, "GPOS") == _layout_feature_tags(vendor_static, "GPOS"),
+            failures,
+            f"{prefix}: GPOS feature set differs from vendor static Inter",
+        )
+        for glyph_name in SAMPLE_GLYPHS:
+            _check(
+                _glyph_signature(generated, glyph_name) == _glyph_signature(expected, glyph_name),
+                failures,
+                f"{prefix}: glyph {glyph_name} does not match requested axes {axes}",
+            )
+    finally:
+        generated.close()
+        variable.close()
+        vendor_static.close()
+        expected.close()
+
+    return failures
+
+
+def _verify_final_ttf(
+    family_key: str,
+    weight_num: int,
+    weight_name: str,
+) -> list[str]:
+    failures: list[str] = []
+    family = FAMILIES[family_key]
+    config = INTER_VARIABLE_EDGE_WEIGHTS[weight_name]
+    axes = {"wght": config["wght"], "opsz": family["interOpsz"]}
+    instance_path = Path(_inter_variable_instance_path(family, weight_name, axes))
+    final_path = _final_ttf_path(family, weight_name)
+    _check(final_path.is_file(), failures, f"missing final TTF: {final_path}")
+    _check(instance_path.is_file(), failures, f"missing generated Inter instance: {instance_path}")
+    if failures:
+        return failures
+
+    generated = TTFont(str(instance_path))
+    final_font = TTFont(str(final_path))
+    try:
+        prefix = f"{family_key} {weight_name}"
+        _check(
+            final_font["OS/2"].usWeightClass == weight_num,
+            failures,
+            f"{prefix}: final usWeightClass is {final_font['OS/2'].usWeightClass}, expected {weight_num}",
+        )
+        name_values = [record.toUnicode() for record in final_font["name"].names]
+        leak_markers = ("wght125", "wght775", "InterVariable")
+        for marker in leak_markers:
+            _check(
+                not any(marker in value for value in name_values),
+                failures,
+                f"{prefix}: final name table leaks {marker}",
+            )
+
+        names_by_id: dict[int, set[str]] = {}
+        for record in final_font["name"].names:
+            names_by_id.setdefault(record.nameID, set()).add(record.toUnicode())
+        _check(
+            family["familyName"] in names_by_id.get(1, set()),
+            failures,
+            f"{prefix}: final legacy family name is not {family['familyName']}",
+        )
+        _check(
+            family["familyName"] in names_by_id.get(16, set()),
+            failures,
+            f"{prefix}: final typographic family name is not {family['familyName']}",
+        )
+        _check(
+            weight_name in names_by_id.get(2, set()),
+            failures,
+            f"{prefix}: final subfamily name is not {weight_name}",
+        )
+        _check(
+            weight_name in names_by_id.get(17, set()),
+            failures,
+            f"{prefix}: final typographic subfamily name is not {weight_name}",
+        )
+
+        generated_cmap = set(generated.getBestCmap() or {})
+        final_cmap = set(final_font.getBestCmap() or {})
+        _check(generated_cmap.issubset(final_cmap), failures, f"{prefix}: final cmap lost Inter codepoints")
+        _check(
+            _layout_feature_tags(generated, "GSUB").issubset(_layout_feature_tags(final_font, "GSUB")),
+            failures,
+            f"{prefix}: final GSUB lost Inter features",
+        )
+        _check(
+            _layout_feature_tags(generated, "GPOS").issubset(_layout_feature_tags(final_font, "GPOS")),
+            failures,
+            f"{prefix}: final GPOS lost Inter features",
+        )
+    finally:
+        generated.close()
+        final_font.close()
+
+    return failures
+
+
+def verify() -> list[str]:
+    failures: list[str] = []
+    for family_key in ("normal", "display"):
+        for weight_num, weight_name in ((100, "Thin"), (800, "ExtraBold")):
+            failures.extend(_verify_source_instance(family_key, weight_num, weight_name))
+            failures.extend(_verify_final_ttf(family_key, weight_num, weight_name))
+    return failures
+
+
+def main() -> int:
+    failures = verify()
+    if failures:
+        print("Edge instance verification failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        print(
+            "Run `PYTHONPATH=src python3 -m font.build all Thin ExtraBold` first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("Edge instance verification passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -53,6 +53,7 @@ from font.build import (
     PALT_SPACE_ADJUSTMENTS,
     RUNTIME_PALT_BASE_SCALE,
     SOURCE_UPM,
+    STATIC_INSTANCE_VARIATION_TABLES,
     SUB_EXCLUDE_CODEPOINTS,
     SYNTHETIC_VPAL_ADJUSTMENTS,
     TARGET_UPM,
@@ -178,9 +179,8 @@ class TestInterVariableEdgeInstances:
                 f"-wght{expected_wght}-opsz{expected_opsz}.ttf"
             )
             assert generated["OS/2"].usWeightClass == weight_num
-            assert "fvar" not in generated
-            assert "gvar" not in generated
-            assert "STAT" not in generated
+            for table in STATIC_INSTANCE_VARIATION_TABLES:
+                assert table not in generated
 
             names = {
                 record.nameID: record.toUnicode()
@@ -192,6 +192,7 @@ class TestInterVariableEdgeInstances:
 
             assert generated.getGlyphOrder() == variable.getGlyphOrder()
             assert set(generated.getBestCmap() or {}) == set(variable.getBestCmap() or {})
+            assert set(generated.getBestCmap() or {}) == set(vendor_static.getBestCmap() or {})
             assert _layout_feature_tags(generated, "GSUB") == _layout_feature_tags(variable, "GSUB")
             assert _layout_feature_tags(generated, "GPOS") == _layout_feature_tags(variable, "GPOS")
             assert _layout_feature_tags(generated, "GSUB") == _layout_feature_tags(vendor_static, "GSUB")
@@ -205,17 +206,29 @@ class TestInterVariableEdgeInstances:
             variable.close()
             vendor_static.close()
 
-    def test_normal_and_display_edge_instances_use_distinct_opsz(self, tmp_path):
+    @pytest.mark.parametrize(
+        "weight_num,weight_name",
+        [
+            (100, "Thin"),
+            (800, "ExtraBold"),
+        ],
+    )
+    def test_normal_and_display_edge_instances_use_distinct_opsz(
+        self,
+        tmp_path,
+        weight_num,
+        weight_name,
+    ):
         normal_path = _build_inter_variable_instance(
             FAMILIES["normal"],
-            100,
-            "Thin",
+            weight_num,
+            weight_name,
             str(tmp_path),
         )
         display_path = _build_inter_variable_instance(
             FAMILIES["display"],
-            100,
-            "Thin",
+            weight_num,
+            weight_name,
             str(tmp_path),
         )
         normal = TTFont(normal_path)

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -10,6 +10,7 @@ import re
 from pathlib import Path
 
 import pytest
+from fontTools.ttLib import TTFont
 
 from font.build import (
     _apply_glyph_spacing,
@@ -40,7 +41,13 @@ from font.build import (
     _scale_glyph_spacing,
     _split_cmap_codepoint_glyph,
     _strip_extreme_glyphs,
+    _build_inter_variable_instance,
+    _default_inter_static_path,
+    _inter_source_path,
     DISPLAY_PALT_SPACE_ADJUSTMENTS,
+    FAMILIES,
+    INTER_VARIABLE,
+    INTER_VARIABLE_EDGE_WEIGHTS,
     NORMAL_PALT_SPACE_ADJUSTMENTS,
     PALT_FEATURE_CHARS,
     PALT_SPACE_ADJUSTMENTS,
@@ -53,6 +60,16 @@ from font.build import (
     VPAL_FEATURE_CHARS,
 )
 from merge_fonts import parse_codepoint_list
+
+
+def _layout_feature_tags(font: TTFont, table_tag: str) -> set[str]:
+    """Return GSUB/GPOS feature tags from a font."""
+    if table_tag not in font:
+        return set()
+    feature_list = font[table_tag].table.FeatureList
+    if feature_list is None:
+        return set()
+    return {record.FeatureTag for record in feature_list.FeatureRecord}
 
 
 # ---------------------------------------------------------------------------
@@ -110,6 +127,111 @@ class TestProjectVersionMetadata:
         assert output["metricsSource"] == "sub"
         assert output["upm"] == TARGET_UPM
         assert output["version"] == "1.2.3"
+
+
+# ---------------------------------------------------------------------------
+# Inter variable edge instances
+# ---------------------------------------------------------------------------
+
+class TestInterVariableEdgeInstances:
+    """Thin/ExtraBold use tuned InterVariable instances, then static metadata."""
+
+    @pytest.mark.parametrize(
+        "family_key,weight_num,weight_name,expected_wght,expected_opsz,expected_family",
+        [
+            ("normal", 100, "Thin", 125, 14, "Inter"),
+            ("display", 100, "Thin", 125, 32, "Inter Display"),
+            ("normal", 800, "ExtraBold", 775, 14, "Inter"),
+            ("display", 800, "ExtraBold", 775, 32, "Inter Display"),
+        ],
+    )
+    def test_builds_edge_instance_with_static_metadata_and_full_layout(
+        self,
+        tmp_path,
+        family_key,
+        weight_num,
+        weight_name,
+        expected_wght,
+        expected_opsz,
+        expected_family,
+    ):
+        if not Path(INTER_VARIABLE).is_file():
+            pytest.skip(f"Inter variable font not found at {INTER_VARIABLE}")
+
+        family = FAMILIES[family_key]
+        assert family["interOpsz"] == expected_opsz
+        assert INTER_VARIABLE_EDGE_WEIGHTS[weight_name]["wght"] == expected_wght
+
+        generated_path = _build_inter_variable_instance(
+            family,
+            weight_num,
+            weight_name,
+            str(tmp_path),
+        )
+        generated = TTFont(generated_path)
+        variable = TTFont(INTER_VARIABLE)
+        vendor_static = TTFont(_default_inter_static_path(family, weight_name))
+
+        try:
+            assert generated_path.endswith(
+                f"{family['interPrefix']}-{weight_name}"
+                f"-wght{expected_wght}-opsz{expected_opsz}.ttf"
+            )
+            assert generated["OS/2"].usWeightClass == weight_num
+            assert "fvar" not in generated
+            assert "gvar" not in generated
+            assert "STAT" not in generated
+
+            names = {
+                record.nameID: record.toUnicode()
+                for record in generated["name"].names
+                if record.platformID == 3 and record.platEncID in (1, 10)
+            }
+            assert names[16] == expected_family
+            assert names[17] == weight_name
+
+            assert generated.getGlyphOrder() == variable.getGlyphOrder()
+            assert set(generated.getBestCmap() or {}) == set(variable.getBestCmap() or {})
+            assert _layout_feature_tags(generated, "GSUB") == _layout_feature_tags(variable, "GSUB")
+            assert _layout_feature_tags(generated, "GPOS") == _layout_feature_tags(variable, "GPOS")
+            assert _layout_feature_tags(generated, "GSUB") == _layout_feature_tags(vendor_static, "GSUB")
+            assert _layout_feature_tags(generated, "GPOS") == _layout_feature_tags(vendor_static, "GPOS")
+
+            generated_a = generated["glyf"]["A"]
+            static_a = vendor_static["glyf"]["A"]
+            assert (generated_a.xMin, generated_a.xMax) != (static_a.xMin, static_a.xMax)
+        finally:
+            generated.close()
+            variable.close()
+            vendor_static.close()
+
+    def test_normal_and_display_edge_instances_use_distinct_opsz(self, tmp_path):
+        normal_path = _build_inter_variable_instance(
+            FAMILIES["normal"],
+            100,
+            "Thin",
+            str(tmp_path),
+        )
+        display_path = _build_inter_variable_instance(
+            FAMILIES["display"],
+            100,
+            "Thin",
+            str(tmp_path),
+        )
+        normal = TTFont(normal_path)
+        display = TTFont(display_path)
+
+        try:
+            assert normal["hmtx"]["H"] != display["hmtx"]["H"]
+        finally:
+            normal.close()
+            display.close()
+
+    def test_middle_weights_still_use_vendor_static_inter(self, tmp_path):
+        family = FAMILIES["normal"]
+        assert _inter_source_path(family, 400, "Regular", str(tmp_path)) == (
+            _default_inter_static_path(family, "Regular")
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/vendor/fonts/README.ja.md
+++ b/vendor/fonts/README.ja.md
@@ -10,7 +10,9 @@ vendor/fonts/
   Noto_Sans_JP/
 ```
 
-`src/font/build.py` は Inter の static TTF を `Inter-4.1/extras/ttf/` から、Noto Sans JP の variable font を `Noto_Sans_JP/NotoSansJP-VariableFont_wght.ttf` から読み込みます。
+`src/font/build.py` は Inter の大半の static TTF を `Inter-4.1/extras/ttf/` から読み込みます。
+Thin と ExtraBold は Latin 側の太さを調整するため `Inter-4.1/InterVariable.ttf` から生成し、公開 metadata は 100 / 800 のままにします。
+Noto Sans JP は `Noto_Sans_JP/NotoSansJP-VariableFont_wght.ttf` から読み込みます。
 
 ## 使われ方
 

--- a/vendor/fonts/README.md
+++ b/vendor/fonts/README.md
@@ -11,5 +11,8 @@ vendor/fonts/
   Noto_Sans_JP/
 ```
 
-`src/font/build.py` reads Inter static TTFs from `Inter-4.1/extras/ttf/` and
-the Noto Sans JP variable font from `Noto_Sans_JP/NotoSansJP-VariableFont_wght.ttf`.
+`src/font/build.py` reads most Inter static TTFs from `Inter-4.1/extras/ttf/`.
+Thin and ExtraBold are generated from `Inter-4.1/InterVariable.ttf` so their
+Latin weights can use tuned `wght` coordinates while keeping public metadata at
+100 / 800. Noto Sans JP is read from
+`Noto_Sans_JP/NotoSansJP-VariableFont_wght.ttf`.


### PR DESCRIPTION
## Summary

- Instantiate Thin and ExtraBold Latin sources from `vendor/fonts/Inter-4.1/InterVariable.ttf` instead of the bundled static edge TTFs.
- Use `wght=125/opsz=14` and `wght=775/opsz=14` for Gen Interface JP, and `wght=125/opsz=32` and `wght=775/opsz=32` for Gen Interface JP Display.
- Stamp the generated static Inter instances back to public metadata weights 100 and 800 before merging.
- Add regression coverage for edge instance axes, metadata, glyph/cmap preservation, GSUB/GPOS preservation, and Normal/Display opsz separation.
- Update architecture and vendored-font documentation for the new source selection path.

## Why

Thin and ExtraBold visually need tuned Inter variable coordinates while keeping the public Gen Interface JP weight names and metadata stable. This keeps the final font family at `font-weight: 100` and `800` while allowing the Latin outlines to come from `wght=125` and `775`.

## Validation

- `PYTHONPATH=src python3 -m pytest tests/test_font_build.py -q` -> `106 passed`
- `PYTHONPATH=src python3 -m font.build all Thin ExtraBold` -> passed
- Custom fontTools verification -> all four edge builds reported `source_ok=True` and `final_ok=True`
- `PYTHONPATH=src python3 -m pytest -q` -> `179 passed`

## Notes

Generated TTF outputs remain under `dist/` and are not committed.
