### PR TITLE
[codex] Add ss09 yakumono punctuation spacing

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -302,7 +302,9 @@ LangSys から参照させる。`kern` は GPOS に残る。横方向の optiona
 GSUB 側で扱う: `_install_ss09_punctuation_feature` が従来の palt 残差から
 `.ss09` metric alternate を作り、UI 名「約物半角」の `ss09` stylistic set
 を生成する。既存の PairPos kerning は `.ss09` alternate にも拡張するため、
-substitution 後も `kern` は効き続ける。
+substitution 後も `kern` は効き続ける。`ss09` を追加した後は GSUB
+`FeatureList` を `FeatureTag` 順に戻し、LangSys の feature index を再マップする。
+lookup order は変更しない。
 
 ## 垂直メトリクスと Illustrator のテキストボックス問題
 

--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -25,7 +25,7 @@ Gen Interface JP はフォントビルドパイプライン (アプリ/UI なし
         │         output.upm=2048                         │
         │             ↓                                   │
         │   [2/3] Proportionalise — proportional.py       │
-        │      palt → hmtx + runtime 役物 palt/vpal       │
+        │      palt → hmtx + 約物 ss09 + runtime vpal     │
         │         tracking (連続記号は除外)              │
         │         + 極端な bbox の除去                    │
         │             ↓                                   │
@@ -81,11 +81,12 @@ FAMILIES × WEIGHTS の各組合せに対して:
                     weight だけを上書き
   → inst を再読込し、キャッシュした variable から palt/vpal 取得
     1000-UPM の record を 2048-UPM のビルドグリッドへ換算
-  → runtime 役物を除き Noto の palt エントリを全量で焼き込み
-    runtime 役物は 34% を base に焼き、66% を live feature に残す
+  → ss09 約物を除き Noto の palt エントリを全量で焼き込み
+    ss09 約物は 34% を base に焼き、66% を ss09 残差として保持
     (palt なしグリフはメトリクス維持)
   → make_proportional で palt → hmtx に焼き込み
-    vpal/halt/vhal を削除し、役物だけの palt/vpal feature を再生成
+    palt/vpal/halt/vhal を削除; runtime vpal は再生成し、
+    横方向の約物残差は final ss09 用に保持
   → _apply_tracking で advance を広げ LSB を半分シフト
     ただし family["trackingIgnore"] の連続・隙間なし記号は除外
   → _apply_glyph_spacing で family["glyphSpacing"] の個別調整を適用
@@ -103,8 +104,8 @@ FAMILIES × WEIGHTS の各組合せに対して:
                      manufacturer / manufacturerURL を刻印
   → final TTF を一度 reload/save し、GSUB/GPOS coverage を
     merge 後の glyph ID 順に正規化
-  → merge 時の glyph rename 後も encoded glyph に live 役物 feature が
-    残るよう、final cmap に対して runtime palt/vpal を再生成
+  → merge 時の glyph rename 後も encoded glyph に optional 約物挙動が
+    残るよう、final cmap に対して yakumono-only ss09 と runtime vpal を生成
 ```
 
 ### 2. Web 用サブセット化 (`webfont.build`)
@@ -159,21 +160,22 @@ palt record を持ちうるため対象に含める。
 
 inst に対して 4 つのサブパスを in-place で実行:
 
-1. **palt のベイク / runtime vpal** (`proportional.make_proportional`) — palt 値は
+1. **palt のベイク / ss09 + runtime vpal** (`proportional.make_proportional`) — palt 値は
    キャッシュ済みの variable から読む (instantiation で非デフォルト軸位置の
    palt ValueRecord が壊れることがあるため)。その値は Noto の 1000-UPM
    ソースグリッドから、実際の 2048-UPM ビルドグリッドへ換算する。
    XPlacement / XAdvance を LSB / advance に加算しアウトラインをシフト。
    Noto の palt エントリは
-   原則として全量で焼き込むが、`PALT_FEATURE_CHARS` の役物は分割する。
-   palt 調整量の 34% を `hmtx` に焼き込んで `palt` 無効時にもある程度
-   詰まる base metrics にし、残り 66% を live `palt` GPOS feature として
-   再生成する。Noto の典型的な `XAdvance=-500` の役物では、palt-off で
-   `-170` が base advance に焼かれ、palt-on で残り `-330` が適用される
+   原則として全量で焼き込むが、`PALT_FEATURE_CHARS` の約物は分割する。
+   palt 調整量の 34% を `hmtx` に焼き込んでデフォルトでもある程度
+   詰まる base metrics にし、残り 66% は final の yakumono-only `ss09`
+   stylistic set「約物半角」用に保持する。Noto の典型的な `XAdvance=-500` の約物では、
+   palt-off で `-170` が base advance に焼かれ、`ss09` 有効時に残り
+   `-330` が適用される
    (いずれも UPM 換算前の設計値)。
    Noto の `vpal` も同じ variable から読み、
    `VPAL_FEATURE_CHARS` に列挙した Unicode-mapped
-   役物 33 glyph (縦組み presentation form と全角パーセントを含む) を
+   約物 33 glyph (縦組み presentation form と全角パーセントを含む) を
    live `vpal` として再生成する。全角コロン / セミコロンは Noto に palt は
    あるが vpal がなく、縦組みコロンは unmapped の `glyph17071` に
    置換されるため、小さな合成 fallback を `SYNTHETIC_VPAL_ADJUSTMENTS` で
@@ -182,7 +184,7 @@ inst に対して 4 つのサブパスを in-place で実行:
    元の `hmtx` を維持する。
    `U+30FB` (・) は Noto では `U+2027` (‧) と同じ `uni2027` を共有して
    いるため、palt ベイク前に `uni30FB` として分離する。これにより `‧` と
-   `・` は必要に応じて別々の live palt record を持てる。
+   `・` は必要に応じて別々の optional spacing record を持てる。
 2. **トラッキング** (`_apply_tracking`) — advance を `tracking` 分広げ、
    `tracking // 2` を LSB に加算してアウトラインを広がった枠の中央に
    配置。kana / 句読点はファミリー設定の `trackingKana` で別値。
@@ -207,8 +209,8 @@ inst に対して 4 つのサブパスを in-place で実行:
    palt 後に詰まり気味に見えるため、このレイヤーで左右に明示的な余白を
    足す。大半の小書き仮名は左右 15 units を基準にしつつ、カタカナの
    小書き「ィ」「ャ」や、ひらがなの小書き「ょ」などは見え方に合わせて
-   個別値を持つ。`U+30FB` (・) を含む役物はここでは扱わない: tracking は
-   通常どおり通し、横方向の詰めは live `palt` feature に任せる。縦方向の
+   個別値を持つ。`U+30FB` (・) を含む約物はここでは扱わない: tracking は
+   通常どおり通し、横方向の詰めは明示的な `ss09` feature に任せる。縦方向の
    proportional spacing は別集合の `VPAL_FEATURE_CHARS` で制御する。
 4. **bbox 除去** (`_strip_extreme_glyphs`) — 下記 [垂直メトリクス] 参照。
 
@@ -247,12 +249,12 @@ release zip / npm package / site metadata と同じ project/release version を
 "https://yamatoiizuka.com"` でリリース TTF の nameID 8 / 11 を刻印。
 merge 後は final TTF を一度 fontTools で reload/save し、GSUB/GPOS coverage を
 最終 glyph order に合わせて正規化する。その後、merge 前に codepoint keyed で
-保持した最小 runtime `palt` / `vpal` を final cmap に対して再生成する。
+保持した最小 runtime `ss09` / `vpal` 挙動を final cmap に対して生成する。
 これは `U+FF40` (｀) のように、Noto では `U+2035` と同じ `uni2035`
 を共有するが、Inter 側の `U+2035` と衝突して merge 後に
-`uni2035.orig` へ rename される glyph で必要になる。この再生成は final merge
-後に行うため、保持していた feature record も `SCALE` で換算し、live の
-placement / advance が光学スケール済みの Noto base と揃うようにする。
+`uni2035.orig` へ rename される glyph で必要になる。この final install は
+merge 後に行うため、保持していた残差 record も `SCALE` で換算し、live `ss09`
+alternate と `vpal` の placement / advance が光学スケール済みの Noto base と揃うようにする。
 
 ## プロポーショナルメトリクス (`font/proportional.py`)
 
@@ -260,32 +262,33 @@ CJK フォントは全角がデフォルト: 全グリフがアウトライン�
 em-square を占有し、`palt` GPOS が runtime に kana / Latin を光学的に
 詰める。`palt` を有効にしないアプリ (Adobe の和文コンポーザー、ブラウザ
 フォールバック、CJK を等幅扱いするレイアウトエンジン) では live の調整が
-効かない。Gen Interface JP では多くの palt を `hmtx` に焼き込み、runtime
-役物にも reduced palt 分を base に焼くことで、palt 無効時も完全な等幅
+効かない。Gen Interface JP では多くの palt を `hmtx` に焼き込み、optional
+約物にも reduced palt 分を base に焼くことで、palt 無効時も完全な等幅
 フォールバックにならないようにする。
 
 `make_proportional` は多くの `palt` 値を static の `hmtx` に焼き込む。
 `runtime_palt` と `runtime_palt_base_scale` が指定された場合は、その割合を
-base metrics に焼き込み、`palt` / `vpal` / `halt` / `vhal` を削除した後に
-残差だけを新しい `palt` feature として追加する。本プロジェクトでは
-`RUNTIME_PALT_BASE_SCALE = 0.34` を使うため、palt-off の役物はすでに部分的に
-詰まり (典型的な `-500` palt advance なら UPM 換算前で `-170`)、`palt` を
-有効にすると Noto の full palt 目標まで到達する。
+base metrics に焼き込む。production build では `install_runtime_palt` を無効化し、
+残差を live `palt` としては公開せず、codepoint 単位で保持して Inter merge 後の
+yakumono-only `ss09` として再生成する。本プロジェクトでは
+`RUNTIME_PALT_BASE_SCALE = 0.34` を使うため、palt-off の約物はすでに部分的に
+詰まり (典型的な `-500` palt advance なら UPM 換算前で `-170`)、`ss09` を
+有効にすると従来の Noto full palt 目標まで到達する。
 `runtime_vpal` が指定された場合は、一致する Noto `vpal` record も水平
-メトリクスに触らず新しい `vpal` feature として戻す。ビルドでは runtime
-`palt` に `PALT_FEATURE_CHARS` (48 文字)、runtime `vpal` に
+メトリクスに触らず新しい `vpal` feature として戻す。ビルドでは横方向の
+`ss09` target に `PALT_FEATURE_CHARS` (48 文字)、runtime `vpal` に
 `VPAL_FEATURE_CHARS` (33 文字) を使う。Noto の vpal には縦組み presentation
 form と `％` が含まれるため、この 2 つの集合は意図的に一致させない。
 `SYNTHETIC_VPAL_ADJUSTMENTS` は Noto が持たない全角コロン / セミコロンの
 縦方向 proportional record を補う。これにより、焼き込み済みの kana /
-Latin に palt が二重適用されることを避けながら、選択した役物だけ
-runtime palt/vpal を公開できる。
+Latin に palt が二重適用されることを避けながら、横方向の optional 約物 spacing
+は `ss09`、縦方向 spacing は runtime `vpal` として公開できる。
 TrueType アウトラインのみ対応 (palt のベイクは `glyf` に書き戻すので
 CFF は対象外)。
 Inter との merge では base 側 glyph が rename されることがあるため、
-ビルドは merge 前に runtime palt/vpal 値を codepoint 単位で保持し、
-merge 後の final cmap に対して再インストールする。再インストールする record
-には final Noto optical scale (`SCALE = 0.925`) をこの時点でだけ掛ける。
+ビルドは merge 前に横方向の残差と runtime vpal 値を codepoint 単位で保持し、
+merge 後の final cmap に対して retarget する。final record には
+Noto optical scale (`SCALE = 0.925`) をこの時点でだけ掛ける。
 pre-merge の `palt_data` / `vpal_data` は active UPM grid のままにし、焼き込み
 base metrics は merge 時に一度だけ scale される。
 
@@ -294,8 +297,12 @@ base metrics は merge 時に一度だけ scale される。
 レコードのインデックスを動かすので、各 LangSys の `FeatureIndex` 配列を
 生き残ったレコードに対して再キーする必要がある。feature 削除後は、どの
 生存 feature からも参照されない lookup だけを pruning する; 共有 lookup は
-残す。再生成した runtime-palt/vpal lookup は削除後に追加し、既存の各
-LangSys から参照させる。`kern` は GPOS に残る。
+残す。再生成した runtime `vpal` lookup は削除後に追加し、既存の各
+LangSys から参照させる。`kern` は GPOS に残る。横方向の optional 約物は
+GSUB 側で扱う: `_install_ss09_punctuation_feature` が従来の palt 残差から
+`.ss09` metric alternate を作り、UI 名「約物半角」の `ss09` stylistic set
+を生成する。既存の PairPos kerning は `.ss09` alternate にも拡張するため、
+substitution 後も `kern` は効き続ける。
 
 ## 垂直メトリクスと Illustrator のテキストボックス問題
 
@@ -440,7 +447,7 @@ GitHub Pages のデプロイは `.github/workflows/pages.yml`
 ## テスト
 
 ```bash
-PYTHONPATH=src python3 -m pytest        # 全テスト (~20 秒)
+PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
 ```
 
 テストは表面ごとに `tests/` 直下に分割:
@@ -456,8 +463,8 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~20 秒)
   `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
   `_apply_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
   `_split_cmap_codepoint_glyph`, `_get_variable_palt`, `_get_variable_vpal`、
-  明示的な palt/vpal spacing 方針、Thin / ExtraBold 用の InterVariable
-  edge instance source 選択。
+  明示的な palt/ss09/vpal spacing 方針、Thin / ExtraBold 用の
+  InterVariable edge instance source 選択。
 - **`src/font/verify_edge_instances.py`** — Thin / ExtraBold のビルド後検証。
   生成された InterVariable static instance が vendor static と同じ cmap /
   GSUB / GPOS 表面を保ち、variation table を残さず、指定 `wght` / `opsz`
@@ -465,10 +472,11 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~20 秒)
   100 / 800 のままで InterVariable axis 名を漏らさないことを確認する。
 - **`tests/test_proportional.py`** — `_read_palt`, `_read_vpal`,
   `_shift_glyph_x`, `_remove_prop_features`, `make_proportional` (palt
-  ベイク、runtime-palt/vpal 再生成、runtime-palt の base/residual 分割、
+  ベイク、optional runtime-palt 再生成、runtime-palt の base/residual 分割、
   reduced palt scale、palt なしグリフのメトリクス維持、
   オプションの squeeze SB sidebearing 計算、
-  palt_override の優先、CFF 拒否、feature 削除後の LangSys index 整合性)。
+  palt_override の優先、CFF 拒否、feature 削除後の LangSys index 整合性)、
+  さらに `ss09` 生成と HarfBuzz shaping。
 - **`tests/test_release.py`** — 公開配布の契約: GitHub アセット URL の形
   (サイトのダウンロードボタンが参照)、npm パッケージのレイアウト
   (`files` glob、生成 README、`cdn/*.css` エントリポイント、`license`
@@ -480,8 +488,8 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~20 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 107 | UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、runtime feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
-| `test_proportional.py` | 29 | palt/vpal 抽出、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal 再生成 + base/residual 分割 + optional squeeze helper |
+| `test_font_build.py` | 108 | UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、ss09/runtime feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
+| `test_proportional.py` | 33 | palt/vpal 抽出、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal 再生成 + base/residual 分割 + optional squeeze helper、ss09 生成 + shaping |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -314,7 +314,9 @@ existing LangSys. `kern` remains in GPOS, and horizontal optional yakumono is
 handled as GSUB: `_install_ss09_punctuation_feature` creates `.ss09` metric
 alternates from the former palt residual and installs an `ss09` stylistic set
 with the UI name "約物半角". Existing PairPos kerning is extended to those
-alternates so `kern` continues to apply after substitution.
+alternates so `kern` continues to apply after substitution. After `ss09` is
+appended, the GSUB `FeatureList` is sorted back into `FeatureTag` order and
+all LangSys feature indices are remapped; lookup order is left untouched.
 
 ## Vertical Metrics & the Illustrator Box Problem
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@ consumes the published webfont package.
         │         output.upm=2048                         │
         │             ↓                                   │
         │   [2/3] Proportionalise — proportional.py       │
-        │      palt → hmtx + runtime yakumono palt/vpal   │
+        │      palt → hmtx + yakumono ss09 + runtime vpal │
         │         tracking (with repeatable skips)        │
         │         + strip extreme bbox                    │
         │             ↓                                   │
@@ -81,11 +81,12 @@ For each (family, weight) in FAMILIES × WEIGHTS:
                     through; only weight is stamped
   → reload inst, read palt/vpal from cached variable font
     and scale those 1000-UPM records to the active 2048-UPM grid
-  → bake Noto palt at full strength except runtime yakumono,
-    whose palt is split into a 34% baked base + 66% live feature
+  → bake Noto palt at full strength except ss09 yakumono,
+    whose palt is split into a 34% baked base + 66% ss09 residual
     (glyphs without palt keep metrics)
-  → make_proportional bakes palt → hmtx, removes vpal/halt/vhal,
-    and reinstalls yakumono-only palt/vpal features
+  → make_proportional bakes palt → hmtx and removes palt/vpal/halt/vhal;
+    runtime vpal is reinstalled, while horizontal yakumono residuals are
+    held for final ss09 alternates
   → _apply_tracking widens advances + half-balances LSB
     except repeatable no-gap symbols in family["trackingIgnore"]
   → _apply_glyph_spacing applies family["glyphSpacing"] sidebearing tweaks
@@ -103,8 +104,9 @@ For each (family, weight) in FAMILIES × WEIGHTS:
                      manufacturer / manufacturerURL stamped
   → reload/save final TTF once so GSUB/GPOS coverage tables are ordered
     by the final merged glyph IDs
-  → reinstall runtime palt/vpal against the final cmap so merge-time
-    glyph renames keep the live yakumono features on the encoded glyphs
+  → install yakumono-only ss09 and runtime vpal
+    against the final cmap so merge-time glyph renames keep optional
+    yakumono behavior on the encoded glyphs
 ```
 
 ### 2. Subset for the Web (`webfont.build`)
@@ -158,7 +160,7 @@ carry palt records.
 
 Four sub-passes, all in-place on the inst:
 
-1. **palt baking / runtime vpal** (`proportional.make_proportional`) — palt values are
+1. **palt baking / ss09 + runtime vpal** (`proportional.make_proportional`) — palt values are
    read from the cached variable font (instantiation can corrupt palt's
    ValueRecords at non-default axis positions), then scaled from Noto's
    1000-UPM source grid to the active 2048-UPM build grid.
@@ -166,11 +168,11 @@ Four sub-passes, all in-place on the inst:
    Most Noto palt entries are
    baked at full strength, but yakumono listed in `PALT_FEATURE_CHARS`
    is split: 34% of the palt adjustment is baked into `hmtx` so the glyph is
-   still tightened when `palt` is disabled, and the remaining 66% is
-   reinstalled as a live `palt` GPOS feature. For Noto's common
+   still tightened by default, and the remaining 66% is held for a final
+   yakumono-only `ss09` stylistic set named "約物半角". For Noto's common
    `XAdvance=-500` yakumono records, that means palt-off gets `-170` baked
-   into the base advance and palt-on applies the remaining `-330` before
-   UPM scaling. Noto
+   into the base advance and enabling `ss09` applies the remaining `-330`
+   before UPM scaling. Noto
    `vpal` is read from the same variable source and reinstalled for the
    Unicode-mapped yakumono listed in `VPAL_FEATURE_CHARS` (33 glyphs,
    including vertical presentation forms and fullwidth percent). Fullwidth
@@ -180,8 +182,8 @@ Four sub-passes, all in-place on the inst:
    are not automatically sidebearing-squeezed; they keep their original
    `hmtx` unless a later explicit spacing rule touches them.
    `U+30FB` (・) is split from Noto's shared `uni2027` glyph before palt
-   baking so `U+2027` (‧) and `U+30FB` (・) can carry separate live palt
-   records when needed.
+   baking so `U+2027` (‧) and `U+30FB` (・) can carry separate optional
+   spacing records when needed.
 2. **Tracking** (`_apply_tracking`) — advance grows by `tracking`;
    `tracking // 2` is added to LSB so the outline sits centred in the
    wider slot. Kana / punctuation get a separate `trackingKana` value
@@ -211,7 +213,8 @@ Four sub-passes, all in-place on the inst:
    side, with a few optical exceptions such as small katakana i (`ィ`),
    small katakana ya (`ャ`), and small hiragana yo (`ょ`). Punctuation,
    including `U+30FB` (・), is intentionally not handled here: it passes
-   through tracking and tightens only through the live `palt` feature.
+   through tracking and tightens only when the explicit `ss09` feature is
+   enabled.
    Vertical proportional spacing is controlled by the separate
    `VPAL_FEATURE_CHARS` set.
 4. **Bbox strip** (`_strip_extreme_glyphs`) — see [Vertical metrics]
@@ -253,13 +256,13 @@ prefix. `output.manufacturer = "Yamato Iizuka"`, `output.manufacturerURL =
 "https://yamatoiizuka.com"` stamp nameID 8 / 11 on every released TTF.
 After the merge, the TTF is reloaded and saved once with fontTools so
 GSUB/GPOS coverage tables are sorted against the final merged glyph order.
-Then the minimal runtime `palt` / `vpal` features are rebuilt one final
-time from codepoint-keyed records captured before the merge. This matters
+Then the minimal runtime `ss09` / `vpal` behavior is rebuilt from
+codepoint-keyed records captured before the merge. This matters
 for shared Noto glyphs such as `U+FF40` (｀), which uses Noto's `uni2035`
 before merge but may be renamed to `uni2035.orig` when Inter also provides
-`U+2035`. Because this reinstall happens after the final merge, the saved
-feature records are also scaled by `SCALE` so their live placement/advance
-values match the optically scaled Noto base.
+`U+2035`. Because this final install happens after the merge, the saved
+residual records are also scaled by `SCALE` so live `ss09` alternates and
+`vpal` placement/advance values match the optically scaled Noto base.
 
 ## Proportional Metrics (`font/proportional.py`)
 
@@ -269,31 +272,34 @@ optically at runtime. Apps that don't enable `palt` (Adobe's Japanese
 composer, browser fallbacks, anything treating CJK as monospaced for
 layout) miss those live adjustments. Gen Interface JP avoids a fully
 monospaced fallback by baking most palt values directly into `hmtx`, and by
-baking a reduced palt fraction for runtime yakumono.
+baking a reduced palt fraction for optional yakumono.
 
 `make_proportional` bakes most `palt` values into the static `hmtx` so the
 font reads proportional everywhere. When `runtime_palt` is provided together
 with `runtime_palt_base_scale`, the build bakes that fraction of each runtime
-record into the base metrics and installs only the residual delta as live
-`palt` after `palt` / `vpal` / `halt` / `vhal` are stripped. The project uses
+record into the base metrics. For the production build, `install_runtime_palt`
+is disabled so the residual is not exposed as live `palt`; instead it is
+captured by codepoint and later reinstalled as yakumono-only `ss09` after the
+Inter merge. The project uses
 `RUNTIME_PALT_BASE_SCALE = 0.34`, so palt-off yakumono is already partially
 tightened (`-170` for the common `-500` palt advance before UPM scaling) while
-enabling `palt` still reaches the full Noto palt target.
+enabling `ss09` reaches the former full Noto palt target.
 When `runtime_vpal` is provided, matching Noto `vpal` records are also
 reinstalled as a fresh `vpal` feature without affecting horizontal metrics.
-The build uses `PALT_FEATURE_CHARS` (48 chars) for runtime `palt` and
+The build uses `PALT_FEATURE_CHARS` (48 chars) for the horizontal `ss09` targets and
 `VPAL_FEATURE_CHARS` (33 chars) for runtime `vpal`; these sets intentionally
 differ because Noto's vertical proportional feature contains vertical
 presentation forms and `％` that are not horizontal palt targets.
 `SYNTHETIC_VPAL_ADJUSTMENTS` adds the missing vertical proportional records
 for fullwidth colon / semicolon that Noto omits.
 This avoids double-applying palt to baked kana / Latin while still exposing
-runtime palt/vpal for selected yakumono. Only TrueType outlines are supported
+optional horizontal yakumono spacing through `ss09` and vertical spacing
+through runtime `vpal`. Only TrueType outlines are supported
 — palt baking writes back to `glyf`, not CFF.
 Because the Inter merge can rename colliding base glyphs, the build captures
-runtime palt/vpal values by codepoint before the merge and reinstalls them
-against the final cmap afterward. Those reinstalled records are scaled by
-the final Noto optical scale (`SCALE = 0.925`) at reinstall time only; the
+horizontal residuals and runtime vpal values by codepoint before the merge and
+retargets them against the final cmap afterward. Those final records are
+scaled by the final Noto optical scale (`SCALE = 0.925`) at install time only; the
 pre-merge `palt_data` / `vpal_data` remain on the active UPM grid so baked
 base metrics are scaled exactly once by the merge.
 
@@ -303,8 +309,12 @@ Removing a record changes the indices of every later record, so each
 LangSys's `FeatureIndex` array is re-keyed against the surviving records.
 After feature removal, lookup indices are pruned only when no surviving
 feature references them; shared lookups stay intact. The regenerated
-runtime-palt/vpal lookups are appended after removal and referenced from
-every existing LangSys. `kern` remains in GPOS.
+runtime `vpal` lookup is appended after removal and referenced from every
+existing LangSys. `kern` remains in GPOS, and horizontal optional yakumono is
+handled as GSUB: `_install_ss09_punctuation_feature` creates `.ss09` metric
+alternates from the former palt residual and installs an `ss09` stylistic set
+with the UI name "約物半角". Existing PairPos kerning is extended to those
+alternates so `kern` continues to apply after substitution.
 
 ## Vertical Metrics & the Illustrator Box Problem
 
@@ -452,7 +462,7 @@ GitHub Pages deploys the build via `.github/workflows/pages.yml`.
 ## Tests
 
 ```bash
-PYTHONPATH=src python3 -m pytest        # full suite (~20s)
+PYTHONPATH=src python3 -m pytest        # full suite (~35s)
 ```
 
 Tests live under `tests/`, split by surface:
@@ -468,8 +478,8 @@ Tests live under `tests/`, split by surface:
   `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
   `_apply_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
   `_split_cmap_codepoint_glyph`, `_get_variable_palt`, `_get_variable_vpal`,
-  explicit palt/vpal spacing policy, and InterVariable edge-instance source
-  selection for Thin / ExtraBold.
+  explicit palt/ss09/vpal spacing policy, and InterVariable edge-instance
+  source selection for Thin / ExtraBold.
 - **`src/font/verify_edge_instances.py`** — post-build verification for
   Thin / ExtraBold edge outputs. Confirms the generated InterVariable static
   instances keep the vendor static cmap / GSUB / GPOS surface, contain no
@@ -478,9 +488,10 @@ Tests live under `tests/`, split by surface:
   InterVariable axis names.
 - **`tests/test_proportional.py`** — `_read_palt`, `_read_vpal`,
   `_shift_glyph_x`, `_remove_prop_features`, `make_proportional` (palt
-  baking, runtime-palt/vpal reinstall, runtime-palt base/residual splitting,
+  baking, optional runtime-palt reinstall, runtime-palt base/residual splitting,
   reduced palt scaling, non-palt metric preservation, optional squeeze SB sidebearing math, palt_override
-  precedence, CFF rejection, LangSys index validity post-removal).
+  precedence, CFF rejection, LangSys index validity post-removal), plus
+  `ss09` construction and HarfBuzz shaping.
 - **`tests/test_release.py`** — public distribution contracts: GitHub
   asset URL shape (referenced by the site download button), npm package
   layout including `files` glob, generated README, `cdn/*.css` entrypoints,
@@ -492,8 +503,8 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 107 | UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, runtime feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
-| `test_proportional.py` | 29 | palt/vpal extraction, glyph translation, GPOS feature removal, runtime-palt/vpal reinstall + base/residual split + optional squeeze helper |
+| `test_font_build.py` | 108 | UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, ss09/runtime feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
+| `test_proportional.py` | 33 | palt/vpal extraction, glyph translation, GPOS feature removal, runtime-palt/vpal reinstall + base/residual split + optional squeeze helper, ss09 construction + shaping |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |
 

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -34,7 +34,7 @@ from fontTools.varLib import instancer
 from merge_fonts import merge_fonts, parse_codepoint_list
 from project_metadata import project_version as read_project_version
 from .proportional import (
-    _install_palt_feature,
+    _install_ss09_punctuation_feature,
     _install_vpal_feature,
     _remove_prop_features,
     _scale_position_adjustment,
@@ -145,9 +145,9 @@ TRACKING_IGNORE_CODEPOINTS = (
     "U+FFE3",          # ￣ FULLWIDTH MACRON
 )
 
-# These yakumono punctuation/symbol glyphs keep a live palt feature instead
-# of receiving hand-tuned hmtx spacing. They still receive normal tracking;
-# palt is applied later by the shaper when the feature is enabled.
+# These yakumono punctuation/symbol glyphs keep a reduced baked base metric
+# and expose the former palt residual through the ss09 "約物半角" stylistic set
+# instead of receiving hand-tuned hmtx spacing. They still receive tracking.
 PALT_FEATURE_CHARS = (
     "、", "。", "，", "．",
     "〈", "〉", "《", "》",
@@ -162,9 +162,9 @@ PALT_FEATURE_CHARS = (
     "＇", "＊", "＾", "｀", "￥",
 )
 
-# Runtime palt yakumono still need a reasonably tight default when callers do
-# not enable palt. Bake this fraction into hmtx, then expose only the remaining
-# palt delta as the live feature.
+# Optional ss09 yakumono still need a reasonably tight default when callers do
+# not enable the feature. Bake this fraction into hmtx, then expose only the
+# remaining palt delta through ss09 alternates.
 RUNTIME_PALT_BASE_SCALE = 0.34
 
 # Unicode-mapped Noto vpal yakumono records kept as a live vertical
@@ -191,10 +191,10 @@ SYNTHETIC_VPAL_ADJUSTMENTS = {
     "uniFF1B": (250, -500),     # U+FF1B ； has no vert substitution
 }
 
-# Glyphs listed here get full Noto palt baked like every other non-runtime
+# Glyphs listed here get full Noto palt baked like every other non-optional
 # palt glyph, then receive explicit hmtx spacing after tracking. Keep this
 # list limited to small kana that need breathing room after palt; yakumono
-# belongs in PALT_FEATURE_CHARS so it can tighten via the live palt feature.
+# belongs in PALT_FEATURE_CHARS so optional tightening stays in ss09.
 PALT_SPACE_ADJUSTMENTS = {
     "ぁ": (15, 15),
     "ぃ": (15, 15),
@@ -934,8 +934,9 @@ def _feature_adjustments_for_codepoints(
     """Capture feature records by codepoint before merge-time glyph renames.
 
     font-baker can rename base glyphs when Inter and Noto both contain the
-    same glyph name. Runtime palt/vpal targets must therefore survive by
-    Unicode scalar, then be retargeted to the final cmap glyph after merge.
+    same glyph name. Optional horizontal and runtime vpal targets must
+    therefore survive by Unicode scalar, then be retargeted to the final cmap
+    glyph after merge.
     """
     if not source_adjustments:
         return {}
@@ -953,7 +954,7 @@ def _feature_adjustments_for_codepoints(
 def _runtime_palt_residual_adjustment(
     adjustment: tuple[int, int],
 ) -> tuple[int, int]:
-    """Return the live palt delta after the default base fraction is baked."""
+    """Return the residual palt delta after the default base fraction is baked."""
     base_placement, base_advance = _scale_position_adjustment(
         adjustment,
         RUNTIME_PALT_BASE_SCALE,
@@ -965,7 +966,7 @@ def _runtime_palt_residual_adjustment(
 def _runtime_palt_residuals_by_codepoint(
     adjustments: dict[int, tuple[int, int]],
 ) -> dict[int, tuple[int, int]]:
-    """Convert full palt records to residual records for final reinstall."""
+    """Convert full palt records to residual records for final ss09 install."""
     return {
         cp: _runtime_palt_residual_adjustment(adjustment)
         for cp, adjustment in adjustments.items()
@@ -1021,22 +1022,22 @@ def _retarget_named_adjustments(
 
 def _refresh_runtime_prop_features_after_merge(
     final_path: str,
-    runtime_palt_by_codepoint: dict[int, tuple[int, int]],
+    ss09_punctuation_by_codepoint: dict[int, tuple[int, int]],
     runtime_vpal_by_codepoint: dict[int, tuple[int, int]],
     runtime_vpal_by_glyph: dict[str, tuple[int, int]],
 ) -> None:
-    """Reinstall live palt/vpal after Inter+Noto merge glyph renaming.
+    """Install yakumono-only ss09 and refresh live vpal after merge.
 
-    The pre-merge proportional Noto already has minimal runtime palt/vpal,
-    but font-baker may rename colliding base glyphs in the final font. Rebuild
-    those features once more against the final cmap so characters such as
-    U+FF40 (｀), which shares Noto's ``uni2035`` glyph before merge, keep their
-    live palt on the renamed final glyph.
+    font-baker may rename colliding base glyphs in the final font. Rebuild the
+    codepoint-keyed optional punctuation behavior against the final cmap so
+    characters such as U+FF40 (｀), which shares Noto's ``uni2035`` glyph before
+    merge, keep their ss09 adjustment on the renamed final glyph. Horizontal
+    palt is intentionally not reinstalled here.
     """
     font = TTFont(final_path)
-    palt_adjustments = _retarget_feature_adjustments(
+    ss09_adjustments = _retarget_feature_adjustments(
         font,
-        runtime_palt_by_codepoint,
+        ss09_punctuation_by_codepoint,
     )
     vpal_adjustments = _retarget_feature_adjustments(
         font,
@@ -1045,7 +1046,7 @@ def _refresh_runtime_prop_features_after_merge(
     vpal_adjustments.update(_retarget_named_adjustments(font, runtime_vpal_by_glyph))
 
     _remove_prop_features(font)
-    _install_palt_feature(font, palt_adjustments)
+    _install_ss09_punctuation_feature(font, ss09_adjustments)
     _install_vpal_feature(font, vpal_adjustments)
     font.save(final_path)
 
@@ -1209,7 +1210,7 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
        ``output.upm = 2048`` so the Noto identity records survive into the inst.
     2. **Proportionalise** the inst — read palt from the variable cache
        (variable instantiation can corrupt palt), bake those adjustments
-       into hmtx except selected runtime-palt yakumono, apply tracking,
+       into hmtx except selected ss09 yakumono, apply tracking,
        apply per-glyph sidebearing tweaks from ``family["glyphSpacing"]``,
        strip extreme bbox glyphs, optionally apply x-scale.
     3. **Merge** the proportional Noto with the matching Inter master via
@@ -1273,7 +1274,7 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
         else _scale_design_unit(tracking_kana_design, font_upm)
     )
     tracking_ignore = family.get("trackingIgnore")
-    runtime_palt_chars = family.get("runtimePalt")
+    ss09_punctuation_chars = family.get("runtimePalt")
     runtime_vpal_chars = family.get("runtimeVpal")
 
     desc = f"tracking +{tracking}"
@@ -1288,9 +1289,9 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
 
     # Split U+30FB from U+2027 before metrics work. Noto maps both to
     # ``uni2027``, but U+30FB is one of the yakumono glyphs that should
-    # keep a live palt record while U+2027 stays on its own palt data.
+    # keep an ss09 alternate while U+2027 stays on its own palt data.
     split_source = _split_cmap_codepoint_glyph(font, 0x30FB, "uni30FB")
-    runtime_palt_glyphs = _glyphs_for_codepoints(font, runtime_palt_chars)
+    ss09_punctuation_glyphs = _glyphs_for_codepoints(font, ss09_punctuation_chars)
     runtime_vpal_glyphs = _glyphs_for_codepoints(font, runtime_vpal_chars)
 
     # Read palt/vpal from the variable source rather than the freshly-baked inst:
@@ -1311,10 +1312,10 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
         if glyph_name in font.getGlyphOrder():
             vpal_data[glyph_name] = value
             runtime_vpal_glyphs.add(glyph_name)
-    runtime_palt_by_codepoint = _runtime_palt_residuals_by_codepoint(
+    ss09_punctuation_by_codepoint = _runtime_palt_residuals_by_codepoint(
         _feature_adjustments_for_codepoints(
             font,
-            runtime_palt_chars,
+            ss09_punctuation_chars,
             palt_data,
         )
     )
@@ -1324,14 +1325,15 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
         vpal_data,
     )
 
-    # Bake Noto palt entries at full strength except runtime yakumono, which
-    # receive a reduced baked base plus a live residual palt feature. Glyphs
-    # without palt keep their original hmtx.
+    # Bake Noto palt entries at full strength except ss09 yakumono, which
+    # receive a reduced baked base. Their residual is captured above and later
+    # exposed as final ss09 alternates. Glyphs without palt keep original hmtx.
     make_proportional(
         font,
         palt_override=palt_data,
-        runtime_palt=runtime_palt_glyphs,
+        runtime_palt=ss09_punctuation_glyphs,
         runtime_palt_base_scale=RUNTIME_PALT_BASE_SCALE,
+        install_runtime_palt=False,
         vpal_override=vpal_data,
         runtime_vpal=runtime_vpal_glyphs,
     )
@@ -1388,7 +1390,7 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     _normalize_layout_coverage_order(final_path)
     _refresh_runtime_prop_features_after_merge(
         final_path,
-        _scale_feature_adjustments(runtime_palt_by_codepoint, SCALE),
+        _scale_feature_adjustments(ss09_punctuation_by_codepoint, SCALE),
         _scale_feature_adjustments(runtime_vpal_by_codepoint, SCALE),
         _scale_feature_adjustments(synthetic_vpal_adjustments, SCALE),
     )

--- a/src/font/proportional.py
+++ b/src/font/proportional.py
@@ -624,6 +624,7 @@ def _install_single_subst_feature(
         if script.LangSysRecord:
             for lsr in script.LangSysRecord:
                 _append_feature_index(lsr.LangSys, feature_index)
+    _sort_feature_list_and_remap_langsys(table)
 
 
 def _stylistic_set_feature_params(font: TTFont):
@@ -665,6 +666,51 @@ def _ensure_script_list(table) -> None:
     table.ScriptList = otTables.ScriptList()
     table.ScriptList.ScriptRecord = [script_record]
     table.ScriptList.ScriptCount = 1
+
+
+def _sort_feature_list_and_remap_langsys(table) -> None:
+    """Sort FeatureRecords by tag and remap LangSys feature indices."""
+    feature_list = getattr(table, "FeatureList", None)
+    script_list = getattr(table, "ScriptList", None)
+    if feature_list is None or script_list is None:
+        return
+    records = list(getattr(feature_list, "FeatureRecord", None) or [])
+    if not records:
+        return
+
+    sorted_pairs = sorted(
+        enumerate(records),
+        key=lambda item: item[1].FeatureTag,
+    )
+    old_to_new = {
+        old_index: new_index
+        for new_index, (old_index, _record) in enumerate(sorted_pairs)
+    }
+    feature_list.FeatureRecord = [
+        record for _old_index, record in sorted_pairs
+    ]
+    feature_list.FeatureCount = len(feature_list.FeatureRecord)
+
+    for script_record in getattr(script_list, "ScriptRecord", None) or []:
+        script = script_record.Script
+        langsystems = []
+        if script.DefaultLangSys:
+            langsystems.append(script.DefaultLangSys)
+        for langsys_record in script.LangSysRecord or []:
+            langsystems.append(langsys_record.LangSys)
+
+        for langsys in langsystems:
+            langsys.FeatureIndex = [
+                old_to_new[index]
+                for index in (langsys.FeatureIndex or [])
+                if index in old_to_new
+            ]
+            langsys.FeatureCount = len(langsys.FeatureIndex)
+            if getattr(langsys, "ReqFeatureIndex", 0xFFFF) != 0xFFFF:
+                langsys.ReqFeatureIndex = old_to_new.get(
+                    langsys.ReqFeatureIndex,
+                    0xFFFF,
+                )
 
 
 def _extend_pairpos_for_alternates(

--- a/src/font/proportional.py
+++ b/src/font/proportional.py
@@ -24,8 +24,9 @@ Usage:
 
 from __future__ import annotations
 
+import copy
 import sys
-from fontTools.ttLib import TTFont
+from fontTools.ttLib import TTFont, newTable
 from fontTools.ttLib.tables import otTables
 
 
@@ -37,6 +38,13 @@ from fontTools.ttLib.tables import otTables
 #   halt  - alternate metrics (horizontal, ½-width / pseudo-half)
 #   vhal  - alternate metrics (vertical)
 PROP_FEATURES = {"palt", "vpal", "halt", "vhal"}
+
+SS09_FEATURE_TAG = "ss09"
+SS09_ALTERNATE_SUFFIX = ".ss09"
+SS09_UI_NAMES = {
+    "en": "Half-width punctuation",
+    "ja": "約物半角",
+}
 
 
 def _scale_position_adjustment(
@@ -61,6 +69,7 @@ def make_proportional(
     palt_override: dict[str, tuple[int, int]] | None = None,
     runtime_palt: set[str] | None = None,
     runtime_palt_base_scale: float = 0.0,
+    install_runtime_palt: bool = True,
     vpal_override: dict[str, tuple[int, int]] | None = None,
     runtime_vpal: set[str] | None = None,
 ) -> None:
@@ -92,6 +101,8 @@ def make_proportional(
     base hmtx and only the remaining delta is reinstalled as live ``palt``.
     This lets selected yakumono stay somewhat tight when ``palt`` is disabled
     while preserving the full palt result when it is enabled.
+    Callers that migrate the residual elsewhere can set
+    ``install_runtime_palt=False`` while keeping the base bake behavior.
 
     ``vpal_override`` / ``runtime_vpal`` mirror that runtime feature path
     for vertical proportional metrics. ``vpal`` is not baked into hmtx; when
@@ -208,7 +219,7 @@ def make_proportional(
     # Remove proportional-metric GPOS features, then install minimal live
     # palt/vpal lookups for glyphs intentionally kept at runtime.
     _remove_prop_features(font)
-    if runtime_palt_adjustments:
+    if install_runtime_palt and runtime_palt_adjustments:
         _install_palt_feature(font, runtime_palt_adjustments)
     if runtime_vpal_adjustments:
         _install_vpal_feature(font, runtime_vpal_adjustments)
@@ -472,6 +483,312 @@ def _install_vpal_feature(
         "YAdvance",
         0x0002 | 0x0008,
     )
+
+
+def _install_ss09_punctuation_feature(
+    font: TTFont,
+    adjustments: dict[str, tuple[int, int]],
+) -> None:
+    """Install an ``ss09`` stylistic set for optional half-width yakumono.
+
+    The default glyphs keep the reduced baked metrics. ``ss09`` substitutes
+    to private alternate glyphs that carry the remaining palt delta in their
+    outline position and hmtx advance. PairPos kerning is extended to those
+    alternates so enabling ``ss09`` does not drop existing ``kern`` pairs.
+    """
+    alternates = _create_metric_alternates(font, adjustments)
+    if not alternates:
+        return
+    _extend_pairpos_for_alternates(font, alternates)
+    _install_single_subst_feature(font, SS09_FEATURE_TAG, alternates)
+
+
+def _create_metric_alternates(
+    font: TTFont,
+    adjustments: dict[str, tuple[int, int]],
+) -> dict[str, str]:
+    """Create suffixed glyph alternates carrying residual metric deltas."""
+    if not adjustments or "glyf" not in font or "hmtx" not in font:
+        return {}
+
+    glyph_order = list(font.getGlyphOrder())
+    glyph_order_set = set(glyph_order)
+    glyf = font["glyf"]
+    hmtx = font["hmtx"]
+    alternates: dict[str, str] = {}
+
+    for glyph_name, (x_placement, x_advance) in adjustments.items():
+        if glyph_name not in glyph_order_set:
+            continue
+        if glyph_name not in glyf or glyph_name not in hmtx.metrics:
+            continue
+        alternate_name = f"{glyph_name}{SS09_ALTERNATE_SUFFIX}"
+        if alternate_name not in glyph_order_set:
+            glyph_order.append(alternate_name)
+            glyph_order_set.add(alternate_name)
+        alternate_glyph = copy.deepcopy(glyf[glyph_name])
+        if (
+            x_placement
+            and alternate_glyph.numberOfContours != 0
+            and hasattr(alternate_glyph, "xMin")
+            and alternate_glyph.xMin is not None
+        ):
+            _shift_glyph_x(alternate_glyph, x_placement)
+        glyf[alternate_name] = alternate_glyph
+
+        advance_width, lsb = hmtx[glyph_name]
+        hmtx[alternate_name] = (
+            advance_width + x_advance,
+            lsb + x_placement,
+        )
+        alternates[glyph_name] = alternate_name
+
+    if alternates:
+        font.setGlyphOrder(glyph_order)
+        if "maxp" in font:
+            font["maxp"].numGlyphs = len(glyph_order)
+    return alternates
+
+
+def _install_single_subst_feature(
+    font: TTFont,
+    feature_tag: str,
+    substitutions: dict[str, str],
+) -> None:
+    """Install a GSUB SingleSubst feature for ``substitutions``."""
+    if not substitutions:
+        return
+
+    gsub = font.get("GSUB")
+    if gsub is None or gsub.table is None:
+        gsub = newTable("GSUB")
+        font["GSUB"] = gsub
+        gsub.table = otTables.GSUB()
+        gsub.table.Version = 0x00010000
+
+    table = gsub.table
+    if getattr(table, "LookupList", None) is None:
+        table.LookupList = otTables.LookupList()
+        table.LookupList.Lookup = []
+        table.LookupList.LookupCount = 0
+    if getattr(table, "FeatureList", None) is None:
+        table.FeatureList = otTables.FeatureList()
+        table.FeatureList.FeatureRecord = []
+        table.FeatureList.FeatureCount = 0
+    _ensure_script_list(table)
+
+    glyph_order = {glyph_name: i for i, glyph_name in enumerate(font.getGlyphOrder())}
+    glyphs = [
+        glyph_name for glyph_name in substitutions
+        if glyph_name in glyph_order and substitutions[glyph_name] in glyph_order
+    ]
+    glyphs.sort(key=glyph_order.__getitem__)
+    if not glyphs:
+        return
+
+    subtable = otTables.SingleSubst()
+    subtable.mapping = {
+        glyph_name: substitutions[glyph_name]
+        for glyph_name in glyphs
+    }
+
+    lookup = otTables.Lookup()
+    lookup.LookupType = 1  # SingleSubst
+    lookup.LookupFlag = 0
+    lookup.SubTable = [subtable]
+    lookup.SubTableCount = 1
+
+    lookup_list = table.LookupList
+    lookup_index = lookup_list.LookupCount
+    lookup_list.Lookup.append(lookup)
+    lookup_list.LookupCount += 1
+
+    feature = otTables.Feature()
+    feature.FeatureParams = _stylistic_set_feature_params(font)
+    feature.LookupListIndex = [lookup_index]
+    feature.LookupCount = 1
+
+    feature_record = otTables.FeatureRecord()
+    feature_record.FeatureTag = feature_tag
+    feature_record.Feature = feature
+
+    feature_list = table.FeatureList
+    feature_index = feature_list.FeatureCount
+    feature_list.FeatureRecord.append(feature_record)
+    feature_list.FeatureCount += 1
+
+    for script_record in table.ScriptList.ScriptRecord:
+        script = script_record.Script
+        if script.DefaultLangSys:
+            _append_feature_index(script.DefaultLangSys, feature_index)
+        if script.LangSysRecord:
+            for lsr in script.LangSysRecord:
+                _append_feature_index(lsr.LangSys, feature_index)
+
+
+def _stylistic_set_feature_params(font: TTFont):
+    """Return FeatureParams for the Japanese UI label of ss09."""
+    name_id = font["name"].addMultilingualName(
+        SS09_UI_NAMES,
+        ttFont=font,
+        minNameID=256,
+    )
+    params = otTables.FeatureParamsStylisticSet()
+    params.Version = 0
+    params.UINameID = name_id
+    return params
+
+
+def _ensure_script_list(table) -> None:
+    """Create a minimal DFLT ScriptList when a layout table has none."""
+    if (
+        getattr(table, "ScriptList", None) is not None
+        and table.ScriptList.ScriptCount
+    ):
+        return
+
+    langsys = otTables.LangSys()
+    langsys.LookupOrder = None
+    langsys.ReqFeatureIndex = 0xFFFF
+    langsys.FeatureIndex = []
+    langsys.FeatureCount = 0
+
+    script = otTables.Script()
+    script.DefaultLangSys = langsys
+    script.LangSysRecord = []
+    script.LangSysCount = 0
+
+    script_record = otTables.ScriptRecord()
+    script_record.ScriptTag = "DFLT"
+    script_record.Script = script
+
+    table.ScriptList = otTables.ScriptList()
+    table.ScriptList.ScriptRecord = [script_record]
+    table.ScriptList.ScriptCount = 1
+
+
+def _extend_pairpos_for_alternates(
+    font: TTFont,
+    alternates: dict[str, str],
+) -> None:
+    """Teach existing GPOS PairPos lookups about GSUB alternate glyphs."""
+    gpos = font.get("GPOS")
+    if gpos is None or gpos.table is None or gpos.table.LookupList is None:
+        return
+    glyph_order = {glyph: i for i, glyph in enumerate(font.getGlyphOrder())}
+    for lookup in gpos.table.LookupList.Lookup:
+        _extend_pairpos_lookup(lookup, alternates, glyph_order)
+
+
+def _extend_pairpos_lookup(
+    lookup,
+    alternates: dict[str, str],
+    glyph_order: dict[str, int],
+) -> None:
+    """Extend PairPos subtables, unwrapping extension lookups when needed."""
+    if lookup.LookupType == 9:
+        for subtable in lookup.SubTable:
+            if getattr(subtable, "ExtensionLookupType", None) == 2:
+                _extend_pairpos_subtable(
+                    subtable.ExtSubTable,
+                    alternates,
+                    glyph_order,
+                )
+        return
+    if lookup.LookupType != 2:
+        return
+    for subtable in lookup.SubTable:
+        _extend_pairpos_subtable(subtable, alternates, glyph_order)
+
+
+def _extend_pairpos_subtable(
+    subtable,
+    alternates: dict[str, str],
+    glyph_order: dict[str, int],
+) -> None:
+    if subtable.Format == 1:
+        _extend_pairpos_format1(subtable, alternates, glyph_order)
+    elif subtable.Format == 2:
+        _extend_pairpos_format2(subtable, alternates, glyph_order)
+
+
+def _extend_pairpos_format1(
+    subtable,
+    alternates: dict[str, str],
+    glyph_order: dict[str, int],
+) -> None:
+    """Duplicate explicit pair records for substituted first/second glyphs."""
+    if subtable.Coverage is None:
+        return
+
+    pairsets = {
+        first_glyph: pairset
+        for first_glyph, pairset in zip(subtable.Coverage.glyphs, subtable.PairSet)
+    }
+    for pairset in list(pairsets.values()):
+        _extend_pairset_seconds(pairset, alternates, glyph_order)
+
+    for first_glyph, alternate_first in alternates.items():
+        if first_glyph not in pairsets or alternate_first in pairsets:
+            continue
+        pairsets[alternate_first] = copy.deepcopy(pairsets[first_glyph])
+
+    entries = sorted(
+        pairsets.items(),
+        key=lambda item: glyph_order.get(item[0], 1_000_000),
+    )
+    subtable.Coverage.glyphs = [first_glyph for first_glyph, _ in entries]
+    subtable.PairSet = [pairset for _, pairset in entries]
+    subtable.PairSetCount = len(subtable.PairSet)
+
+
+def _extend_pairset_seconds(
+    pairset,
+    alternates: dict[str, str],
+    glyph_order: dict[str, int],
+) -> None:
+    existing = {
+        record.SecondGlyph
+        for record in pairset.PairValueRecord
+    }
+    records = list(pairset.PairValueRecord)
+    for record in list(pairset.PairValueRecord):
+        alternate_second = alternates.get(record.SecondGlyph)
+        if alternate_second is None or alternate_second in existing:
+            continue
+        cloned = copy.deepcopy(record)
+        cloned.SecondGlyph = alternate_second
+        records.append(cloned)
+        existing.add(alternate_second)
+
+    records.sort(key=lambda record: glyph_order.get(record.SecondGlyph, 1_000_000))
+    pairset.PairValueRecord = records
+    pairset.PairValueCount = len(records)
+
+
+def _extend_pairpos_format2(
+    subtable,
+    alternates: dict[str, str],
+    glyph_order: dict[str, int],
+) -> None:
+    """Assign substituted glyphs to the same PairPos classes as their bases."""
+    if subtable.Coverage is not None:
+        coverage_glyphs = set(subtable.Coverage.glyphs)
+        for first_glyph, alternate_first in alternates.items():
+            if first_glyph in coverage_glyphs:
+                coverage_glyphs.add(alternate_first)
+        subtable.Coverage.glyphs = sorted(
+            coverage_glyphs,
+            key=lambda glyph: glyph_order.get(glyph, 1_000_000),
+        )
+
+    for class_def in (subtable.ClassDef1, subtable.ClassDef2):
+        if class_def is None:
+            continue
+        for glyph_name, alternate_name in alternates.items():
+            class_value = class_def.classDefs.get(glyph_name)
+            if class_value is not None and alternate_name not in class_def.classDefs:
+                class_def.classDefs[alternate_name] = class_value
 
 
 def _install_single_pos_feature(

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -60,6 +60,7 @@ from font.build import (
     TRACKING_IGNORE_CODEPOINTS,
     VPAL_FEATURE_CHARS,
 )
+from font.proportional import _install_ss09_punctuation_feature
 from merge_fonts import parse_codepoint_list
 
 
@@ -747,7 +748,7 @@ class TestApplyTracking:
 # ---------------------------------------------------------------------------
 
 class TestPaltSymbolPolicy:
-    """Full palt is baked by default; selected yakumono keeps split runtime palt."""
+    """Full palt is baked by default; selected yakumono keeps an ss09 residual."""
 
     def test_tracking_only_symbols_are_implicit_palt_entries(self):
         palt = _get_variable_palt()
@@ -772,7 +773,7 @@ class TestPaltSymbolPolicy:
         assert "uniFF57" not in palt  # ｗ
         assert "uniFF40" not in palt  # ｀
 
-    def test_yakumono_uses_runtime_palt_not_spacing(self):
+    def test_yakumono_uses_ss09_targets_not_spacing(self):
         assert len(PALT_FEATURE_CHARS) == 48
         for char in (
             "、。，．〈〉《》「」『』【】〔〕〖〗〘〙〚〛"
@@ -781,6 +782,22 @@ class TestPaltSymbolPolicy:
         ):
             assert char in PALT_FEATURE_CHARS
             assert char not in PALT_SPACE_ADJUSTMENTS
+
+    def test_ss09_install_preserves_inter_stylistic_sets(self):
+        inter_path = _default_inter_static_path(FAMILIES["normal"], "Regular")
+        if not Path(inter_path).is_file():
+            pytest.skip(f"Inter font not found at {inter_path}")
+        font = TTFont(inter_path)
+        before = _layout_feature_tags(font, "GSUB")
+        inter_sets = {f"ss{i:02d}" for i in range(1, 9)}
+        assert inter_sets <= before
+
+        _install_ss09_punctuation_feature(font, {"A": (0, -10)})
+
+        after_gsub = _layout_feature_tags(font, "GSUB")
+        after_gpos = _layout_feature_tags(font, "GPOS")
+        assert inter_sets | {"ss09"} <= after_gsub
+        assert "halt" not in after_gpos
 
     def test_runtime_palt_keeps_reduced_base_metrics(self):
         assert RUNTIME_PALT_BASE_SCALE == 0.34

--- a/tests/test_proportional.py
+++ b/tests/test_proportional.py
@@ -107,6 +107,62 @@ def _install_synthetic_pairpos_kern(
     gpos.table.FeatureList.FeatureCount = 1
 
 
+def _install_synthetic_gsub_single_subst_feature(
+    font,
+    feature_tag: str,
+    mapping: dict[str, str],
+) -> None:
+    gsub = newTable("GSUB")
+    font["GSUB"] = gsub
+    gsub.table = otTables.GSUB()
+    gsub.table.Version = 0x00010000
+
+    langsys = otTables.LangSys()
+    langsys.LookupOrder = None
+    langsys.ReqFeatureIndex = 0
+    langsys.FeatureIndex = [0]
+    langsys.FeatureCount = 1
+
+    script = otTables.Script()
+    script.DefaultLangSys = langsys
+    script.LangSysRecord = []
+    script.LangSysCount = 0
+
+    script_record = otTables.ScriptRecord()
+    script_record.ScriptTag = "DFLT"
+    script_record.Script = script
+
+    gsub.table.ScriptList = otTables.ScriptList()
+    gsub.table.ScriptList.ScriptRecord = [script_record]
+    gsub.table.ScriptList.ScriptCount = 1
+
+    subtable = otTables.SingleSubst()
+    subtable.mapping = mapping
+
+    lookup = otTables.Lookup()
+    lookup.LookupType = 1
+    lookup.LookupFlag = 0
+    lookup.SubTable = [subtable]
+    lookup.SubTableCount = 1
+
+    gsub.table.LookupList = otTables.LookupList()
+    gsub.table.LookupList.Lookup = [lookup]
+    gsub.table.LookupList.LookupCount = 1
+
+    feature = otTables.Feature()
+    feature.FeatureParams = None
+    feature.LookupListIndex = [0]
+    feature.LookupCount = 1
+
+    feature_record = otTables.FeatureRecord()
+    feature_record.FeatureTag = feature_tag
+    feature_record.Feature = feature
+
+    gsub.table.FeatureList = otTables.FeatureList()
+    gsub.table.FeatureList.FeatureRecord = [feature_record]
+    gsub.table.FeatureList.FeatureCount = 1
+
+
 # ---------------------------------------------------------------------------
 # _read_palt
 # ---------------------------------------------------------------------------
@@ -401,6 +457,63 @@ class TestInstallSS09Punctuation:
             ("uni3042", 920),
             ("uni3001.ss09", 900),
         ]
+
+    def test_sorts_gsub_features_and_remaps_langsys(self, synthetic_ttf):
+        hb = pytest.importorskip("uharfbuzz")
+        _install_synthetic_gsub_single_subst_feature(
+            synthetic_ttf,
+            "zero",
+            {"A": "A"},
+        )
+
+        _install_ss09_punctuation_feature(
+            synthetic_ttf,
+            {"uni3001": (0, -100)},
+        )
+
+        gsub = synthetic_ttf["GSUB"].table
+        tags = [
+            record.FeatureTag
+            for record in gsub.FeatureList.FeatureRecord
+        ]
+        assert tags == sorted(tags)
+        assert tags == ["ss09", "zero"]
+
+        for script_record in gsub.ScriptList.ScriptRecord:
+            script = script_record.Script
+            langsystems = []
+            if script.DefaultLangSys:
+                langsystems.append(script.DefaultLangSys)
+            langsystems.extend(
+                langsys_record.LangSys
+                for langsys_record in script.LangSysRecord or []
+            )
+
+            for langsys in langsystems:
+                referenced_tags = {
+                    gsub.FeatureList.FeatureRecord[index].FeatureTag
+                    for index in langsys.FeatureIndex
+                }
+                assert referenced_tags == {"ss09", "zero"}
+                assert gsub.FeatureList.FeatureRecord[
+                    langsys.ReqFeatureIndex
+                ].FeatureTag == "zero"
+
+        buffer = io.BytesIO()
+        synthetic_ttf.save(buffer)
+        font_data = buffer.getvalue()
+        glyph_order = synthetic_ttf.getGlyphOrder()
+        face = hb.Face(font_data)
+        hb_font = hb.Font(face)
+        hb_buffer = hb.Buffer()
+        hb_buffer.add_str("、")
+        hb_buffer.guess_segment_properties()
+        hb.shape(hb_font, hb_buffer, {"ss09": 1})
+
+        assert [
+            (glyph_order[info.codepoint], pos.x_advance)
+            for info, pos in zip(hb_buffer.glyph_infos, hb_buffer.glyph_positions)
+        ] == [("uni3001.ss09", 900)]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_proportional.py
+++ b/tests/test_proportional.py
@@ -4,14 +4,107 @@ Covers palt extraction, glyph translation, GPOS feature removal, and the
 ``make_proportional`` integration that ties them together.
 """
 
+import io
+
+import pytest
+
+from fontTools.ttLib import newTable
+from fontTools.ttLib.tables import otTables
+
 from font.proportional import (
     PROP_FEATURES,
+    _install_ss09_punctuation_feature,
     _read_palt,
     _read_vpal,
     _remove_prop_features,
     _shift_glyph_x,
     make_proportional,
 )
+
+
+def _feature_record(font, table_tag: str, feature_tag: str):
+    table = font[table_tag].table
+    for index, record in enumerate(table.FeatureList.FeatureRecord):
+        if record.FeatureTag == feature_tag:
+            return index, record
+    raise AssertionError(f"{feature_tag} not found in {table_tag}")
+
+
+def _install_synthetic_pairpos_kern(
+    font,
+    first_glyph: str,
+    second_glyph: str,
+    x_advance: int,
+) -> None:
+    gpos = newTable("GPOS")
+    font["GPOS"] = gpos
+    gpos.table = otTables.GPOS()
+    gpos.table.Version = 0x00010000
+
+    langsys = otTables.LangSys()
+    langsys.LookupOrder = None
+    langsys.ReqFeatureIndex = 0xFFFF
+    langsys.FeatureIndex = [0]
+    langsys.FeatureCount = 1
+
+    script = otTables.Script()
+    script.DefaultLangSys = langsys
+    script.LangSysRecord = []
+    script.LangSysCount = 0
+
+    script_record = otTables.ScriptRecord()
+    script_record.ScriptTag = "DFLT"
+    script_record.Script = script
+
+    gpos.table.ScriptList = otTables.ScriptList()
+    gpos.table.ScriptList.ScriptRecord = [script_record]
+    gpos.table.ScriptList.ScriptCount = 1
+
+    value = otTables.ValueRecord()
+    value.XAdvance = x_advance
+
+    pair_record = otTables.PairValueRecord()
+    pair_record.SecondGlyph = second_glyph
+    pair_record.Value1 = value
+    pair_record.Value2 = None
+
+    pairset = otTables.PairSet()
+    pairset.PairValueRecord = [pair_record]
+    pairset.PairValueCount = 1
+
+    coverage = otTables.Coverage()
+    coverage.glyphs = [first_glyph]
+
+    subtable = otTables.PairPos()
+    subtable.Format = 1
+    subtable.Coverage = coverage
+    subtable.ValueFormat1 = 0x0004
+    subtable.ValueFormat2 = 0
+    subtable.PairSet = [pairset]
+    subtable.PairSetCount = 1
+
+    lookup = otTables.Lookup()
+    lookup.LookupType = 2
+    lookup.LookupFlag = 0
+    lookup.SubTable = [subtable]
+    lookup.SubTableCount = 1
+
+    gpos.table.LookupList = otTables.LookupList()
+    gpos.table.LookupList.Lookup = [lookup]
+    gpos.table.LookupList.LookupCount = 1
+
+    feature = otTables.Feature()
+    feature.FeatureParams = None
+    feature.LookupListIndex = [0]
+    feature.LookupCount = 1
+
+    feature_record = otTables.FeatureRecord()
+    feature_record.FeatureTag = "kern"
+    feature_record.Feature = feature
+
+    gpos.table.FeatureList = otTables.FeatureList()
+    gpos.table.FeatureList.FeatureRecord = [feature_record]
+    gpos.table.FeatureList.FeatureCount = 1
 
 
 # ---------------------------------------------------------------------------
@@ -204,6 +297,113 @@ class TestRemovePropFeatures:
 
 
 # ---------------------------------------------------------------------------
+# ss09 punctuation feature
+# ---------------------------------------------------------------------------
+
+class TestInstallSS09Punctuation:
+    """GSUB ss09 construction for optional yakumono spacing."""
+
+    def test_installs_ss09_alternates_and_feature_name(self, synthetic_ttf):
+        _install_synthetic_pairpos_kern(
+            synthetic_ttf,
+            "uni3042",
+            "uni3001",
+            -80,
+        )
+        before_order = list(synthetic_ttf.getGlyphOrder())
+
+        _install_ss09_punctuation_feature(
+            synthetic_ttf,
+            {"uni3001": (-25, -100)},
+        )
+
+        assert synthetic_ttf.getGlyphOrder() == before_order + ["uni3001.ss09"]
+        feature_index, record = _feature_record(synthetic_ttf, "GSUB", "ss09")
+        assert feature_index >= 0
+        ui_name_id = record.Feature.FeatureParams.UINameID
+        names = {
+            name.toUnicode()
+            for name in synthetic_ttf["name"].names
+            if name.nameID == ui_name_id
+        }
+        assert "約物半角" in names
+        assert _feature_record(synthetic_ttf, "GPOS", "kern")
+
+    def test_harfbuzz_uses_ss09_only_when_feature_is_enabled(self, synthetic_ttf):
+        hb = pytest.importorskip("uharfbuzz")
+        _install_synthetic_pairpos_kern(
+            synthetic_ttf,
+            "uni3042",
+            "uni3001",
+            -80,
+        )
+        _install_ss09_punctuation_feature(
+            synthetic_ttf,
+            {"uni3001": (-25, -100)},
+        )
+        buffer = io.BytesIO()
+        synthetic_ttf.save(buffer)
+        font_data = buffer.getvalue()
+        glyph_order = synthetic_ttf.getGlyphOrder()
+
+        def shape(features):
+            face = hb.Face(font_data)
+            hb_font = hb.Font(face)
+            hb_buffer = hb.Buffer()
+            hb_buffer.add_str("、")
+            hb_buffer.guess_segment_properties()
+            hb.shape(hb_font, hb_buffer, features)
+            return [
+                (glyph_order[info.codepoint], pos.x_advance, pos.x_offset)
+                for info, pos in zip(hb_buffer.glyph_infos, hb_buffer.glyph_positions)
+            ]
+
+        assert shape({}) == [("uni3001", 1000, 0)]
+        assert shape({"kern": 1}) == [("uni3001", 1000, 0)]
+        assert shape({"ss09": 1}) == [("uni3001.ss09", 900, 0)]
+        assert shape({"kern": 1, "ss09": 1}) == [("uni3001.ss09", 900, 0)]
+
+    def test_harfbuzz_applies_ss09_and_kern_together(self, synthetic_ttf):
+        hb = pytest.importorskip("uharfbuzz")
+        _install_synthetic_pairpos_kern(
+            synthetic_ttf,
+            "uni3042",
+            "uni3001",
+            -80,
+        )
+        _install_ss09_punctuation_feature(
+            synthetic_ttf,
+            {"uni3001": (0, -100)},
+        )
+        buffer = io.BytesIO()
+        synthetic_ttf.save(buffer)
+        font_data = buffer.getvalue()
+        glyph_order = synthetic_ttf.getGlyphOrder()
+
+        def shape(features):
+            face = hb.Face(font_data)
+            hb_font = hb.Font(face)
+            hb_buffer = hb.Buffer()
+            hb_buffer.add_str("あ、")
+            hb_buffer.guess_segment_properties()
+            hb.shape(hb_font, hb_buffer, features)
+            return [
+                (glyph_order[info.codepoint], pos.x_advance)
+                for info, pos in zip(hb_buffer.glyph_infos, hb_buffer.glyph_positions)
+            ]
+
+        assert shape({"kern": 1}) == [("uni3042", 920), ("uni3001", 1000)]
+        assert shape({"ss09": 1, "kern": 0}) == [
+            ("uni3042", 1000),
+            ("uni3001.ss09", 900),
+        ]
+        assert shape({"kern": 1, "ss09": 1}) == [
+            ("uni3042", 920),
+            ("uni3001.ss09", 900),
+        ]
+
+
+# ---------------------------------------------------------------------------
 # make_proportional
 # ---------------------------------------------------------------------------
 
@@ -286,6 +486,31 @@ class TestMakeProportional:
                 x_advance - base_x_advance,
             )
         }
+
+    def test_runtime_palt_base_fraction_can_skip_live_palt_reinstall(self, noto_subset):
+        cmap = noto_subset.getBestCmap()
+        punct_glyph = cmap.get(0x3001)  # 、
+        palt = _read_palt(noto_subset)
+        if punct_glyph not in palt:
+            pytest.skip("subset palt does not cover U+3001")
+
+        before_aw, before_lsb = noto_subset["hmtx"][punct_glyph]
+        x_placement, x_advance = palt[punct_glyph]
+        base_x_placement = round(x_placement * 0.34)
+        base_x_advance = round(x_advance * 0.34)
+
+        make_proportional(
+            noto_subset,
+            runtime_palt={punct_glyph},
+            runtime_palt_base_scale=0.34,
+            install_runtime_palt=False,
+        )
+
+        assert noto_subset["hmtx"][punct_glyph] == (
+            before_aw + base_x_advance,
+            before_lsb + base_x_placement,
+        )
+        assert _read_palt(noto_subset) == {}
 
     def test_runtime_palt_and_vpal_can_be_reinstalled_together(self, noto_subset):
         cmap = noto_subset.getBestCmap()


### PR DESCRIPTION
## Summary

- add a Japanese-named `ss09` stylistic set, "約物半角", for optional yakumono half-width spacing
- generate `.ss09` metric alternates from the retained palt residual and extend PairPos kerning to those alternates so `kern` still applies after substitution
- refresh the architecture docs and regression tests for the ss09/runtime vpal pipeline

Fixes #16.

## Validation

- `PYTHONPATH=src python3 -m pytest -q` -> 185 passed
- `git diff --check` -> passed
- `PYTHONPATH=src python3 -m font.build all Regular` -> generated Regular TTFs for Gen Interface JP and Display
- verified generated Regular fonts expose `ss09` with UI name `約物半角`, do not expose final `palt`/`halt`, and shape `す。` tighter with `ss09+kern`