### PR TITLE
[codex] Consolidate yakumono spacing under ss09

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -25,7 +25,7 @@ Gen Interface JP はフォントビルドパイプライン (アプリ/UI なし
         │         output.upm=2048                         │
         │             ↓                                   │
         │   [2/3] Proportionalise — proportional.py       │
-        │      palt → hmtx + 約物 ss09 + runtime vpal     │
+        │      palt → hmtx + 約物 ss09                    │
         │         tracking (連続記号は除外)              │
         │         + 極端な bbox の除去                    │
         │             ↓                                   │
@@ -79,14 +79,13 @@ FAMILIES × WEIGHTS の各組合せに対して:
   → font-baker bake: variable Noto → static TTF
                     inheritBase で designer/OFL/version を継承
                     weight だけを上書き
-  → inst を再読込し、キャッシュした variable から palt/vpal 取得
+  → inst を再読込し、キャッシュした variable から palt 取得
     1000-UPM の record を 2048-UPM のビルドグリッドへ換算
   → ss09 約物を除き Noto の palt エントリを全量で焼き込み
     ss09 約物は 34% を base に焼き、66% を ss09 残差として保持
     (palt なしグリフはメトリクス維持)
   → make_proportional で palt → hmtx に焼き込み
-    palt/vpal/halt/vhal を削除; runtime vpal は再生成し、
-    横方向の約物残差は final ss09 用に保持
+    palt/vpal/halt/vhal を削除; 横方向の約物残差は final ss09 用に保持
   → _apply_tracking で advance を広げ LSB を半分シフト
     ただし family["trackingIgnore"] の連続・隙間なし記号は除外
   → _apply_glyph_spacing で family["glyphSpacing"] の個別調整を適用
@@ -105,7 +104,7 @@ FAMILIES × WEIGHTS の各組合せに対して:
   → final TTF を一度 reload/save し、GSUB/GPOS coverage を
     merge 後の glyph ID 順に正規化
   → merge 時の glyph rename 後も encoded glyph に optional 約物挙動が
-    残るよう、final cmap に対して yakumono-only ss09 と runtime vpal を生成
+    残るよう、final cmap に対して yakumono-only ss09 を生成
 ```
 
 ### 2. Web 用サブセット化 (`webfont.build`)
@@ -160,7 +159,7 @@ palt record を持ちうるため対象に含める。
 
 inst に対して 4 つのサブパスを in-place で実行:
 
-1. **palt のベイク / ss09 + runtime vpal** (`proportional.make_proportional`) — palt 値は
+1. **palt のベイク / 約物 ss09** (`proportional.make_proportional`) — palt 値は
    キャッシュ済みの variable から読む (instantiation で非デフォルト軸位置の
    palt ValueRecord が壊れることがあるため)。その値は Noto の 1000-UPM
    ソースグリッドから、実際の 2048-UPM ビルドグリッドへ換算する。
@@ -172,14 +171,9 @@ inst に対して 4 つのサブパスを in-place で実行:
    stylistic set「約物半角」用に保持する。Noto の典型的な `XAdvance=-500` の約物では、
    palt-off で `-170` が base advance に焼かれ、`ss09` 有効時に残り
    `-330` が適用される
-   (いずれも UPM 換算前の設計値)。
-   Noto の `vpal` も同じ variable から読み、
-   `VPAL_FEATURE_CHARS` に列挙した Unicode-mapped
-   約物 33 glyph (縦組み presentation form と全角パーセントを含む) を
-   live `vpal` として再生成する。全角コロン / セミコロンは Noto に palt は
-   あるが vpal がなく、縦組みコロンは unmapped の `glyph17071` に
-   置換されるため、小さな合成 fallback を `SYNTHETIC_VPAL_ADJUSTMENTS` で
-   足す。`vpal` は `hmtx` には焼き込まない。palt なしグリフは自動的に
+   (いずれも UPM 換算前の設計値)。runtime `vpal` は再生成しない。
+   final font では `palt`, `vpal`, `halt`, `vhal` を削除し、optional
+   約物 spacing は `ss09` だけで公開する。palt なしグリフは自動的に
    sidebearing を詰めない; 後続の明示的な spacing ルールが触らない限り
    元の `hmtx` を維持する。
    `U+30FB` (・) は Noto では `U+2027` (‧) と同じ `uni2027` を共有して
@@ -210,8 +204,7 @@ inst に対して 4 つのサブパスを in-place で実行:
    足す。大半の小書き仮名は左右 15 units を基準にしつつ、カタカナの
    小書き「ィ」「ャ」や、ひらがなの小書き「ょ」などは見え方に合わせて
    個別値を持つ。`U+30FB` (・) を含む約物はここでは扱わない: tracking は
-   通常どおり通し、横方向の詰めは明示的な `ss09` feature に任せる。縦方向の
-   proportional spacing は別集合の `VPAL_FEATURE_CHARS` で制御する。
+   通常どおり通し、横方向の詰めは明示的な `ss09` feature に任せる。
 4. **bbox 除去** (`_strip_extreme_glyphs`) — 下記 [垂直メトリクス] 参照。
 
 オプションの **横スケール** (`xScale` 設定、現在未使用) は上記の後に
@@ -249,12 +242,12 @@ release zip / npm package / site metadata と同じ project/release version を
 "https://yamatoiizuka.com"` でリリース TTF の nameID 8 / 11 を刻印。
 merge 後は final TTF を一度 fontTools で reload/save し、GSUB/GPOS coverage を
 最終 glyph order に合わせて正規化する。その後、merge 前に codepoint keyed で
-保持した最小 runtime `ss09` / `vpal` 挙動を final cmap に対して生成する。
+保持した最小 runtime `ss09` 挙動を final cmap に対して生成する。
 これは `U+FF40` (｀) のように、Noto では `U+2035` と同じ `uni2035`
 を共有するが、Inter 側の `U+2035` と衝突して merge 後に
 `uni2035.orig` へ rename される glyph で必要になる。この final install は
 merge 後に行うため、保持していた残差 record も `SCALE` で換算し、live `ss09`
-alternate と `vpal` の placement / advance が光学スケール済みの Noto base と揃うようにする。
+alternate が光学スケール済みの Noto base と揃うようにする。
 
 ## プロポーショナルメトリクス (`font/proportional.py`)
 
@@ -274,37 +267,32 @@ yakumono-only `ss09` として再生成する。本プロジェクトでは
 `RUNTIME_PALT_BASE_SCALE = 0.34` を使うため、palt-off の約物はすでに部分的に
 詰まり (典型的な `-500` palt advance なら UPM 換算前で `-170`)、`ss09` を
 有効にすると従来の Noto full palt 目標まで到達する。
-`runtime_vpal` が指定された場合は、一致する Noto `vpal` record も水平
-メトリクスに触らず新しい `vpal` feature として戻す。ビルドでは横方向の
-`ss09` target に `PALT_FEATURE_CHARS` (48 文字)、runtime `vpal` に
-`VPAL_FEATURE_CHARS` (33 文字) を使う。Noto の vpal には縦組み presentation
-form と `％` が含まれるため、この 2 つの集合は意図的に一致させない。
-`SYNTHETIC_VPAL_ADJUSTMENTS` は Noto が持たない全角コロン / セミコロンの
-縦方向 proportional record を補う。これにより、焼き込み済みの kana /
-Latin に palt が二重適用されることを避けながら、横方向の optional 約物 spacing
-は `ss09`、縦方向 spacing は runtime `vpal` として公開できる。
-TrueType アウトラインのみ対応 (palt のベイクは `glyf` に書き戻すので
+production build では `PALT_FEATURE_CHARS` (48 文字) を唯一の runtime
+約物 target set として使う。これにより、焼き込み済みの kana / Latin に
+palt が二重適用されることを避けながら、optional 約物 spacing は `ss09`
+に集約する。TrueType アウトラインのみ対応 (palt のベイクは `glyf` に書き戻すので
 CFF は対象外)。
 Inter との merge では base 側 glyph が rename されることがあるため、
-ビルドは merge 前に横方向の残差と runtime vpal 値を codepoint 単位で保持し、
-merge 後の final cmap に対して retarget する。final record には
-Noto optical scale (`SCALE = 0.925`) をこの時点でだけ掛ける。
-pre-merge の `palt_data` / `vpal_data` は active UPM grid のままにし、焼き込み
-base metrics は merge 時に一度だけ scale される。
+ビルドは merge 前に横方向の残差を codepoint 単位で保持し、merge 後の final
+cmap に対して retarget する。final record には Noto optical scale
+(`SCALE = 0.925`) をこの時点でだけ掛ける。pre-merge の `palt_data` は
+active UPM grid のままにし、焼き込み base metrics は merge 時に一度だけ
+scale される。
 
 `_remove_prop_features` は GPOS を 2 段で歩く: FeatureRecord の削除と、
 それに対応する LangSys インデックスの再マップ。レコード削除は後ろの全
 レコードのインデックスを動かすので、各 LangSys の `FeatureIndex` 配列を
 生き残ったレコードに対して再キーする必要がある。feature 削除後は、どの
 生存 feature からも参照されない lookup だけを pruning する; 共有 lookup は
-残す。再生成した runtime `vpal` lookup は削除後に追加し、既存の各
-LangSys から参照させる。`kern` は GPOS に残る。横方向の optional 約物は
+残す。`kern` は GPOS に残る。横方向の optional 約物は
 GSUB 側で扱う: `_install_ss09_punctuation_feature` が従来の palt 残差から
 `.ss09` metric alternate を作り、UI 名「約物半角」の `ss09` stylistic set
 を生成する。既存の PairPos kerning は `.ss09` alternate にも拡張するため、
-substitution 後も `kern` は効き続ける。`ss09` を追加した後は GSUB
-`FeatureList` を `FeatureTag` 順に戻し、LangSys の feature index を再マップする。
-lookup order は変更しない。
+substitution 後も `kern` は効き続ける。alternate は元 glyph の `vmtx`
+record もコピーするため、保存後の font でも vertical metrics table の長さが
+拡張後の glyph order と揃う。`ss09` を追加した後は GSUB `FeatureList` を
+`FeatureTag` 順に戻し、LangSys の feature index を再マップする。lookup order
+は変更しない。
 
 ## 垂直メトリクスと Illustrator のテキストボックス問題
 
@@ -464,8 +452,8 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
   `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
   `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
   `_apply_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
-  `_split_cmap_codepoint_glyph`, `_get_variable_palt`, `_get_variable_vpal`、
-  明示的な palt/ss09/vpal spacing 方針、Thin / ExtraBold 用の
+  `_split_cmap_codepoint_glyph`, `_get_variable_palt`、
+  明示的な palt/ss09 spacing 方針、Thin / ExtraBold 用の
   InterVariable edge instance source 選択。
 - **`src/font/verify_edge_instances.py`** — Thin / ExtraBold のビルド後検証。
   生成された InterVariable static instance が vendor static と同じ cmap /
@@ -490,8 +478,8 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 108 | UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、ss09/runtime feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
-| `test_proportional.py` | 33 | palt/vpal 抽出、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal 再生成 + base/residual 分割 + optional squeeze helper、ss09 生成 + shaping |
+| `test_font_build.py` | 103 | UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
+| `test_proportional.py` | 35 | palt/vpal 抽出、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal helper coverage + base/residual 分割 + optional squeeze helper、ss09 生成 + shaping |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@ consumes the published webfont package.
         │         output.upm=2048                         │
         │             ↓                                   │
         │   [2/3] Proportionalise — proportional.py       │
-        │      palt → hmtx + yakumono ss09 + runtime vpal │
+        │      palt → hmtx + yakumono ss09                │
         │         tracking (with repeatable skips)        │
         │         + strip extreme bbox                    │
         │             ↓                                   │
@@ -79,14 +79,13 @@ For each (family, weight) in FAMILIES × WEIGHTS:
   → font-baker bake: variable Noto → static TTF
                     inheritBase passes designer/OFL/version
                     through; only weight is stamped
-  → reload inst, read palt/vpal from cached variable font
+  → reload inst, read palt from cached variable font
     and scale those 1000-UPM records to the active 2048-UPM grid
   → bake Noto palt at full strength except ss09 yakumono,
     whose palt is split into a 34% baked base + 66% ss09 residual
     (glyphs without palt keep metrics)
   → make_proportional bakes palt → hmtx and removes palt/vpal/halt/vhal;
-    runtime vpal is reinstalled, while horizontal yakumono residuals are
-    held for final ss09 alternates
+    horizontal yakumono residuals are held for final ss09 alternates
   → _apply_tracking widens advances + half-balances LSB
     except repeatable no-gap symbols in family["trackingIgnore"]
   → _apply_glyph_spacing applies family["glyphSpacing"] sidebearing tweaks
@@ -104,9 +103,8 @@ For each (family, weight) in FAMILIES × WEIGHTS:
                      manufacturer / manufacturerURL stamped
   → reload/save final TTF once so GSUB/GPOS coverage tables are ordered
     by the final merged glyph IDs
-  → install yakumono-only ss09 and runtime vpal
-    against the final cmap so merge-time glyph renames keep optional
-    yakumono behavior on the encoded glyphs
+  → install yakumono-only ss09 against the final cmap so merge-time glyph
+    renames keep optional yakumono behavior on the encoded glyphs
 ```
 
 ### 2. Subset for the Web (`webfont.build`)
@@ -160,7 +158,7 @@ carry palt records.
 
 Four sub-passes, all in-place on the inst:
 
-1. **palt baking / ss09 + runtime vpal** (`proportional.make_proportional`) — palt values are
+1. **palt baking / yakumono ss09** (`proportional.make_proportional`) — palt values are
    read from the cached variable font (instantiation can corrupt palt's
    ValueRecords at non-default axis positions), then scaled from Noto's
    1000-UPM source grid to the active 2048-UPM build grid.
@@ -172,14 +170,10 @@ Four sub-passes, all in-place on the inst:
    yakumono-only `ss09` stylistic set named "約物半角". For Noto's common
    `XAdvance=-500` yakumono records, that means palt-off gets `-170` baked
    into the base advance and enabling `ss09` applies the remaining `-330`
-   before UPM scaling. Noto
-   `vpal` is read from the same variable source and reinstalled for the
-   Unicode-mapped yakumono listed in `VPAL_FEATURE_CHARS` (33 glyphs,
-   including vertical presentation forms and fullwidth percent). Fullwidth
-   colon / semicolon need a small synthesized fallback because Noto has palt
-   for them but no vpal, and vertical colon is substituted to the unmapped
-   `glyph17071`. `vpal` is not baked into `hmtx`. Glyphs without palt entries
-   are not automatically sidebearing-squeezed; they keep their original
+   before UPM scaling. Runtime `vpal` is not reinstalled; final fonts strip
+   it along with `palt`, `halt`, and `vhal` so optional yakumono spacing is
+   exposed through `ss09` only. Glyphs without palt entries are not
+   automatically sidebearing-squeezed; they keep their original
    `hmtx` unless a later explicit spacing rule touches them.
    `U+30FB` (・) is split from Noto's shared `uni2027` glyph before palt
    baking so `U+2027` (‧) and `U+30FB` (・) can carry separate optional
@@ -215,8 +209,6 @@ Four sub-passes, all in-place on the inst:
    including `U+30FB` (・), is intentionally not handled here: it passes
    through tracking and tightens only when the explicit `ss09` feature is
    enabled.
-   Vertical proportional spacing is controlled by the separate
-   `VPAL_FEATURE_CHARS` set.
 4. **Bbox strip** (`_strip_extreme_glyphs`) — see [Vertical metrics]
    below.
 
@@ -256,13 +248,13 @@ prefix. `output.manufacturer = "Yamato Iizuka"`, `output.manufacturerURL =
 "https://yamatoiizuka.com"` stamp nameID 8 / 11 on every released TTF.
 After the merge, the TTF is reloaded and saved once with fontTools so
 GSUB/GPOS coverage tables are sorted against the final merged glyph order.
-Then the minimal runtime `ss09` / `vpal` behavior is rebuilt from
+Then the minimal runtime `ss09` behavior is rebuilt from
 codepoint-keyed records captured before the merge. This matters
 for shared Noto glyphs such as `U+FF40` (｀), which uses Noto's `uni2035`
 before merge but may be renamed to `uni2035.orig` when Inter also provides
 `U+2035`. Because this final install happens after the merge, the saved
-residual records are also scaled by `SCALE` so live `ss09` alternates and
-`vpal` placement/advance values match the optically scaled Noto base.
+residual records are also scaled by `SCALE` so live `ss09` alternates match
+the optically scaled Noto base.
 
 ## Proportional Metrics (`font/proportional.py`)
 
@@ -284,37 +276,31 @@ Inter merge. The project uses
 `RUNTIME_PALT_BASE_SCALE = 0.34`, so palt-off yakumono is already partially
 tightened (`-170` for the common `-500` palt advance before UPM scaling) while
 enabling `ss09` reaches the former full Noto palt target.
-When `runtime_vpal` is provided, matching Noto `vpal` records are also
-reinstalled as a fresh `vpal` feature without affecting horizontal metrics.
-The build uses `PALT_FEATURE_CHARS` (48 chars) for the horizontal `ss09` targets and
-`VPAL_FEATURE_CHARS` (33 chars) for runtime `vpal`; these sets intentionally
-differ because Noto's vertical proportional feature contains vertical
-presentation forms and `％` that are not horizontal palt targets.
-`SYNTHETIC_VPAL_ADJUSTMENTS` adds the missing vertical proportional records
-for fullwidth colon / semicolon that Noto omits.
-This avoids double-applying palt to baked kana / Latin while still exposing
-optional horizontal yakumono spacing through `ss09` and vertical spacing
-through runtime `vpal`. Only TrueType outlines are supported
+The production build uses `PALT_FEATURE_CHARS` (48 chars) as the only
+runtime yakumono target set. This avoids double-applying palt to baked
+kana / Latin while consolidating optional yakumono spacing under `ss09`.
+Only TrueType outlines are supported
 — palt baking writes back to `glyf`, not CFF.
 Because the Inter merge can rename colliding base glyphs, the build captures
-horizontal residuals and runtime vpal values by codepoint before the merge and
-retargets them against the final cmap afterward. Those final records are
-scaled by the final Noto optical scale (`SCALE = 0.925`) at install time only; the
-pre-merge `palt_data` / `vpal_data` remain on the active UPM grid so baked
-base metrics are scaled exactly once by the merge.
+horizontal residuals by codepoint before the merge and retargets them against
+the final cmap afterward. Those final records are scaled by the final Noto
+optical scale (`SCALE = 0.925`) at install time only; the pre-merge
+`palt_data` remains on the active UPM grid so baked base metrics are scaled
+exactly once by the merge.
 
 `_remove_prop_features` walks GPOS in two coordinated passes:
 FeatureRecord deletions and the corresponding LangSys index remap.
 Removing a record changes the indices of every later record, so each
 LangSys's `FeatureIndex` array is re-keyed against the surviving records.
 After feature removal, lookup indices are pruned only when no surviving
-feature references them; shared lookups stay intact. The regenerated
-runtime `vpal` lookup is appended after removal and referenced from every
-existing LangSys. `kern` remains in GPOS, and horizontal optional yakumono is
+feature references them; shared lookups stay intact. `kern` remains in GPOS,
+and horizontal optional yakumono is
 handled as GSUB: `_install_ss09_punctuation_feature` creates `.ss09` metric
 alternates from the former palt residual and installs an `ss09` stylistic set
 with the UI name "約物半角". Existing PairPos kerning is extended to those
-alternates so `kern` continues to apply after substitution. After `ss09` is
+alternates so `kern` continues to apply after substitution. The alternates
+also copy their source glyphs' `vmtx` records so saved fonts keep vertical
+metrics table length in sync with the expanded glyph order. After `ss09` is
 appended, the GSUB `FeatureList` is sorted back into `FeatureTag` order and
 all LangSys feature indices are remapped; lookup order is left untouched.
 
@@ -479,8 +465,8 @@ Tests live under `tests/`, split by surface:
   `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
   `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
   `_apply_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
-  `_split_cmap_codepoint_glyph`, `_get_variable_palt`, `_get_variable_vpal`,
-  explicit palt/ss09/vpal spacing policy, and InterVariable edge-instance
+  `_split_cmap_codepoint_glyph`, `_get_variable_palt`,
+  explicit palt/ss09 spacing policy, and InterVariable edge-instance
   source selection for Thin / ExtraBold.
 - **`src/font/verify_edge_instances.py`** — post-build verification for
   Thin / ExtraBold edge outputs. Confirms the generated InterVariable static
@@ -505,8 +491,8 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 108 | UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, ss09/runtime feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
-| `test_proportional.py` | 33 | palt/vpal extraction, glyph translation, GPOS feature removal, runtime-palt/vpal reinstall + base/residual split + optional squeeze helper, ss09 construction + shaping |
+| `test_font_build.py` | 103 | UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
+| `test_proportional.py` | 35 | palt/vpal extraction, glyph translation, GPOS feature removal, runtime-palt/vpal helper coverage + base/residual split + optional squeeze helper, ss09 construction + shaping |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |
 

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -35,7 +35,6 @@ from merge_fonts import merge_fonts, parse_codepoint_list
 from project_metadata import project_version as read_project_version
 from .proportional import (
     _install_ss09_punctuation_feature,
-    _install_vpal_feature,
     _remove_prop_features,
     _scale_position_adjustment,
     make_proportional,
@@ -71,7 +70,7 @@ def _scale_design_adjustments(
     adjustments: dict[str, tuple[int, int]],
     target_upm: int = TARGET_UPM,
 ) -> dict[str, tuple[int, int]]:
-    """Scale glyph-keyed palt/vpal adjustment records from 1000 UPM."""
+    """Scale glyph-keyed OpenType adjustment records from 1000 UPM."""
     return {
         glyph_name: _scale_design_adjustment(adjustment, target_upm)
         for glyph_name, adjustment in adjustments.items()
@@ -167,30 +166,6 @@ PALT_FEATURE_CHARS = (
 # remaining palt delta through ss09 alternates.
 RUNTIME_PALT_BASE_SCALE = 0.34
 
-# Unicode-mapped Noto vpal yakumono records kept as a live vertical
-# proportional feature. This intentionally differs from PALT_FEATURE_CHARS:
-# Noto's vpal source contains vertical presentation forms and fullwidth
-# percent, so those remain available for vertical shaping even though they
-# are not horizontal palt targets.
-VPAL_FEATURE_CHARS = (
-    "〒", "・",
-    "︐", "︑", "︒", "︗", "︘",
-    "︵", "︶", "︷", "︸", "︹", "︺",
-    "︻", "︼", "︽", "︾", "︿", "﹀",
-    "﹁", "﹂", "﹃", "﹄", "﹇", "﹈",
-    "！", "＃", "＄", "％", "＆", "＊", "？", "￥",
-)
-
-# Noto has palt for fullwidth colon/semicolon but no matching vpal. In
-# vertical layout U+FF1A (：) is GSUB-vert substituted to the unmapped
-# glyph17071, so a Unicode-driven VPAL_FEATURE_CHARS pass cannot reach it.
-# Synthesize the vertical analogue of Noto's palt (-250, -500): shift down
-# into the half-height slot and reduce vertical advance by 500.
-SYNTHETIC_VPAL_ADJUSTMENTS = {
-    "glyph17071": (250, -500),  # vertical alternate for U+FF1A ：
-    "uniFF1B": (250, -500),     # U+FF1B ； has no vert substitution
-}
-
 # Glyphs listed here get full Noto palt baked like every other non-optional
 # palt glyph, then receive explicit hmtx spacing after tracking. Keep this
 # list limited to small kana that need breathing room after palt; yakumono
@@ -245,7 +220,6 @@ FAMILIES = {
         "trackingKana": NORMAL_TRACKING_KANA,
         "trackingIgnore": TRACKING_IGNORE_CODEPOINTS,
         "runtimePalt": PALT_FEATURE_CHARS,
-        "runtimeVpal": VPAL_FEATURE_CHARS,
         "folderPrefix": "GenInterfaceJP",
         # Per-glyph sidebearing tweaks applied after tracking. Map a
         # codepoint (int) or single-char string to a (lsb_delta, rsb_delta)
@@ -266,7 +240,6 @@ FAMILIES = {
         "trackingKana": DISPLAY_TRACKING_KANA,
         "trackingIgnore": TRACKING_IGNORE_CODEPOINTS,
         "runtimePalt": PALT_FEATURE_CHARS,
-        "runtimeVpal": VPAL_FEATURE_CHARS,
         "folderPrefix": "GenInterfaceJPDisplay",
         "glyphSpacing": {
             **DISPLAY_PALT_SPACE_ADJUSTMENTS,
@@ -491,11 +464,10 @@ SCALE = 0.925
 
 
 # ---------------------------------------------------------------------------
-# Variable-font palt/vpal caches
+# Variable-font palt cache
 # ---------------------------------------------------------------------------
 
 _variable_palt_cache: dict | None = None
-_variable_vpal_cache: dict | None = None
 
 
 def _get_variable_palt() -> dict[str, tuple[int, int]]:
@@ -515,22 +487,6 @@ def _get_variable_palt() -> dict[str, tuple[int, int]]:
         font = TTFont(NOTO_VARIABLE)
         _variable_palt_cache = _read_palt(font)
     return _variable_palt_cache
-
-
-def _get_variable_vpal() -> dict[str, tuple[int, int]]:
-    """Read vpal adjustments from the original Noto variable font (cached).
-
-    Mirrors :func:`_get_variable_palt`; the final build only reinstalls the
-    subset that overlaps runtime yakumono glyphs, but the source of truth is
-    still the vendor variable font.
-    """
-    global _variable_vpal_cache
-    if _variable_vpal_cache is None:
-        from .proportional import _read_vpal
-
-        font = TTFont(NOTO_VARIABLE)
-        _variable_vpal_cache = _read_vpal(font)
-    return _variable_vpal_cache
 
 
 # ---------------------------------------------------------------------------
@@ -934,9 +890,8 @@ def _feature_adjustments_for_codepoints(
     """Capture feature records by codepoint before merge-time glyph renames.
 
     font-baker can rename base glyphs when Inter and Noto both contain the
-    same glyph name. Optional horizontal and runtime vpal targets must
-    therefore survive by Unicode scalar, then be retargeted to the final cmap
-    glyph after merge.
+    same glyph name. Optional ss09 targets must therefore survive by Unicode
+    scalar, then be retargeted to the final cmap glyph after merge.
     """
     if not source_adjustments:
         return {}
@@ -1000,54 +955,26 @@ def _retarget_feature_adjustments(
     }
 
 
-def _retarget_named_adjustments(
-    font: TTFont,
-    adjustments_by_glyph: dict[str, tuple[int, int]],
-) -> dict[str, tuple[int, int]]:
-    """Map glyph-name fallback records onto the final font when possible."""
-    if not adjustments_by_glyph:
-        return {}
-    cmap = font.getBestCmap() or {}
-    glyph_order = set(font.getGlyphOrder())
-    retargeted = {}
-    for glyph_name, value in adjustments_by_glyph.items():
-        if glyph_name in glyph_order:
-            retargeted[glyph_name] = value
-            continue
-        cp = _glyph_codepoint(glyph_name)
-        if cp is not None and (target_glyph := cmap.get(cp)) in glyph_order:
-            retargeted[target_glyph] = value
-    return retargeted
-
-
-def _refresh_runtime_prop_features_after_merge(
+def _refresh_ss09_feature_after_merge(
     final_path: str,
     ss09_punctuation_by_codepoint: dict[int, tuple[int, int]],
-    runtime_vpal_by_codepoint: dict[int, tuple[int, int]],
-    runtime_vpal_by_glyph: dict[str, tuple[int, int]],
 ) -> None:
-    """Install yakumono-only ss09 and refresh live vpal after merge.
+    """Install yakumono-only ss09 after merge.
 
     font-baker may rename colliding base glyphs in the final font. Rebuild the
     codepoint-keyed optional punctuation behavior against the final cmap so
     characters such as U+FF40 (｀), which shares Noto's ``uni2035`` glyph before
     merge, keep their ss09 adjustment on the renamed final glyph. Horizontal
-    palt is intentionally not reinstalled here.
+    palt and vertical vpal are intentionally not reinstalled here.
     """
     font = TTFont(final_path)
     ss09_adjustments = _retarget_feature_adjustments(
         font,
         ss09_punctuation_by_codepoint,
     )
-    vpal_adjustments = _retarget_feature_adjustments(
-        font,
-        runtime_vpal_by_codepoint,
-    )
-    vpal_adjustments.update(_retarget_named_adjustments(font, runtime_vpal_by_glyph))
 
     _remove_prop_features(font)
     _install_ss09_punctuation_feature(font, ss09_adjustments)
-    _install_vpal_feature(font, vpal_adjustments)
     font.save(final_path)
 
 
@@ -1275,7 +1202,6 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     )
     tracking_ignore = family.get("trackingIgnore")
     ss09_punctuation_chars = family.get("runtimePalt")
-    runtime_vpal_chars = family.get("runtimeVpal")
 
     desc = f"tracking +{tracking}"
     if font_upm != SOURCE_UPM:
@@ -1292,37 +1218,20 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     # keep an ss09 alternate while U+2027 stays on its own palt data.
     split_source = _split_cmap_codepoint_glyph(font, 0x30FB, "uni30FB")
     ss09_punctuation_glyphs = _glyphs_for_codepoints(font, ss09_punctuation_chars)
-    runtime_vpal_glyphs = _glyphs_for_codepoints(font, runtime_vpal_chars)
 
-    # Read palt/vpal from the variable source rather than the freshly-baked inst:
+    # Read palt from the variable source rather than the freshly-baked inst:
     # variable instantiation can leave proportional ValueRecords with zeroed
     # or otherwise stale placement/advance pairs. The cached variable read is
     # canonical across all weights.
     palt_data = _scale_design_adjustments(dict(_get_variable_palt()), font_upm)
     if split_source in palt_data:
         palt_data["uni30FB"] = palt_data[split_source]
-    vpal_data = _scale_design_adjustments(dict(_get_variable_vpal()), font_upm)
-    if split_source in vpal_data:
-        vpal_data["uni30FB"] = vpal_data[split_source]
-    synthetic_vpal_adjustments = _scale_design_adjustments(
-        SYNTHETIC_VPAL_ADJUSTMENTS,
-        font_upm,
-    )
-    for glyph_name, value in synthetic_vpal_adjustments.items():
-        if glyph_name in font.getGlyphOrder():
-            vpal_data[glyph_name] = value
-            runtime_vpal_glyphs.add(glyph_name)
     ss09_punctuation_by_codepoint = _runtime_palt_residuals_by_codepoint(
         _feature_adjustments_for_codepoints(
             font,
             ss09_punctuation_chars,
             palt_data,
         )
-    )
-    runtime_vpal_by_codepoint = _feature_adjustments_for_codepoints(
-        font,
-        runtime_vpal_chars,
-        vpal_data,
     )
 
     # Bake Noto palt entries at full strength except ss09 yakumono, which
@@ -1334,8 +1243,6 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
         runtime_palt=ss09_punctuation_glyphs,
         runtime_palt_base_scale=RUNTIME_PALT_BASE_SCALE,
         install_runtime_palt=False,
-        vpal_override=vpal_data,
-        runtime_vpal=runtime_vpal_glyphs,
     )
     _apply_tracking(font, tracking, tracking_kana, tracking_ignore)
     spacing_adjusted = _apply_glyph_spacing(
@@ -1388,11 +1295,9 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     _assert_target_upm(final_font, final_path)
     final_font.close()
     _normalize_layout_coverage_order(final_path)
-    _refresh_runtime_prop_features_after_merge(
+    _refresh_ss09_feature_after_merge(
         final_path,
         _scale_feature_adjustments(ss09_punctuation_by_codepoint, SCALE),
-        _scale_feature_adjustments(runtime_vpal_by_codepoint, SCALE),
-        _scale_feature_adjustments(synthetic_vpal_adjustments, SCALE),
     )
     return {
         "fontPath": final_path,

--- a/src/font/proportional.py
+++ b/src/font/proportional.py
@@ -515,6 +515,7 @@ def _create_metric_alternates(
     glyph_order_set = set(glyph_order)
     glyf = font["glyf"]
     hmtx = font["hmtx"]
+    vmtx = font["vmtx"] if "vmtx" in font else None
     alternates: dict[str, str] = {}
 
     for glyph_name, (x_placement, x_advance) in adjustments.items():
@@ -541,6 +542,8 @@ def _create_metric_alternates(
             advance_width + x_advance,
             lsb + x_placement,
         )
+        if vmtx is not None and glyph_name in vmtx.metrics:
+            vmtx.metrics[alternate_name] = vmtx.metrics[glyph_name]
         alternates[glyph_name] = alternate_name
 
     if alternates:

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -818,11 +818,11 @@ class TestPaltSymbolPolicy:
 
     def test_scales_glyph_keyed_final_runtime_feature_adjustments(self):
         adjustments = {
-            "uniFE10": (-512, -1024),
+            "uni3001.ss09": (-512, -1024),
         }
 
         assert _scale_feature_adjustments(adjustments, 0.925) == {
-            "uniFE10": (round(-512 * 0.925), round(-1024 * 0.925)),
+            "uni3001.ss09": (round(-512 * 0.925), round(-1024 * 0.925)),
         }
 
     def test_palt_spacing_adjustments_are_small_kana_only(self):

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -23,7 +23,6 @@ from font.build import (
     _final_output_metadata,
     _get_cjk_glyphs,
     _get_variable_palt,
-    _get_variable_vpal,
     _get_vert_alternates,
     _glyphs_for_codepoints,
     _glyph_codepoint,
@@ -32,7 +31,6 @@ from font.build import (
     _is_kana_or_punct,
     _project_version,
     _retarget_feature_adjustments,
-    _retarget_named_adjustments,
     _runtime_palt_residual_adjustment,
     _scale_design_adjustment,
     _scale_design_adjustments,
@@ -55,10 +53,8 @@ from font.build import (
     SOURCE_UPM,
     STATIC_INSTANCE_VARIATION_TABLES,
     SUB_EXCLUDE_CODEPOINTS,
-    SYNTHETIC_VPAL_ADJUSTMENTS,
     TARGET_UPM,
     TRACKING_IGNORE_CODEPOINTS,
-    VPAL_FEATURE_CHARS,
 )
 from font.proportional import _install_ss09_punctuation_feature
 from merge_fonts import parse_codepoint_list
@@ -804,6 +800,11 @@ class TestPaltSymbolPolicy:
         assert _runtime_palt_residual_adjustment((-250, -500)) == (-165, -330)
         assert _runtime_palt_residual_adjustment((-70, -140)) == (-46, -92)
 
+    def test_family_config_exposes_ss09_without_runtime_vpal(self):
+        for family in FAMILIES.values():
+            assert family["runtimePalt"] == PALT_FEATURE_CHARS
+            assert "runtimeVpal" not in family
+
     def test_scales_final_runtime_feature_adjustments_by_optical_scale(self):
         adjustments = {
             0x3001: (-512, -1024),
@@ -822,60 +823,6 @@ class TestPaltSymbolPolicy:
 
         assert _scale_feature_adjustments(adjustments, 0.925) == {
             "uniFE10": (round(-512 * 0.925), round(-1024 * 0.925)),
-        }
-
-    def test_noto_vpal_yakumono_uses_separate_runtime_target_set(self):
-        vpal = _get_variable_vpal()
-        assert len(VPAL_FEATURE_CHARS) == 33
-
-        palt_overlap = set("！？・〒＃＄＆＊￥")
-        vpal_only = set("︐︑︒︗︘︵︶︷︸︹︺︻︼︽︾︿﹀﹁﹂﹃﹄﹇﹈％")
-
-        assert set(VPAL_FEATURE_CHARS) & set(PALT_FEATURE_CHARS) == palt_overlap
-        assert set(VPAL_FEATURE_CHARS) - set(PALT_FEATURE_CHARS) == vpal_only
-
-        expected_glyphs = {
-            "uni3012",  # 〒
-            "uni2027",  # ・ (Noto source glyph before U+30FB split)
-            "uniFF01",  # ！
-            "uniFF03",  # ＃
-            "uniFF04",  # ＄
-            "uniFF06",  # ＆
-            "uniFF0A",  # ＊
-            "uniFF1F",  # ？
-            "uniFFE5",  # ￥
-            "uniFE10",  # ︐
-            "uniFE11",  # ︑
-            "uniFE12",  # ︒
-            "uniFE17",  # ︗
-            "uniFE18",  # ︘
-            "uniFE35",  # ︵
-            "uniFE36",  # ︶
-            "uniFE37",  # ︷
-            "uniFE38",  # ︸
-            "uniFE39",  # ︹
-            "uniFE3A",  # ︺
-            "uniFE3B",  # ︻
-            "uniFE3C",  # ︼
-            "uniFE3D",  # ︽
-            "uniFE3E",  # ︾
-            "uniFE3F",  # ︿
-            "uniFE40",  # ﹀
-            "uniFE41",  # ﹁
-            "uniFE42",  # ﹂
-            "uniFE43",  # ﹃
-            "uniFE44",  # ﹄
-            "uniFE47",  # ﹇
-            "uniFE48",  # ﹈
-            "uniFF05",  # ％
-        }
-
-        assert expected_glyphs <= set(vpal)
-
-    def test_colon_vpal_is_synthesized_for_vertical_glyph(self):
-        assert SYNTHETIC_VPAL_ADJUSTMENTS == {
-            "glyph17071": (250, -500),
-            "uniFF1B": (250, -500),
         }
 
     def test_palt_spacing_adjustments_are_small_kana_only(self):
@@ -957,24 +904,6 @@ class TestPaltSymbolPolicy:
         )
 
         assert adjustments == {0xFF40: (-199, -500)}
-
-    def test_named_fallback_adjustments_can_retarget_by_codepoint(self, synthetic_ttf):
-        synthetic_ttf.setGlyphOrder([
-            *synthetic_ttf.getGlyphOrder(),
-            "uniFF1B.orig",
-        ])
-        synthetic_ttf["glyf"]["uniFF1B.orig"] = copy.deepcopy(synthetic_ttf["glyf"]["A"])
-        synthetic_ttf["hmtx"].metrics["uniFF1B.orig"] = synthetic_ttf["hmtx"]["A"]
-        for table in synthetic_ttf["cmap"].tables:
-            table.cmap[0xFF1B] = "uniFF1B.orig"
-
-        retargeted = _retarget_named_adjustments(
-            synthetic_ttf,
-            {"uniFF1B": (250, -500), "glyph17071": (250, -500)},
-        )
-
-        assert retargeted == {"uniFF1B.orig": (250, -500)}
-
 
 # ---------------------------------------------------------------------------
 # _apply_glyph_spacing
@@ -1129,31 +1058,4 @@ class TestGetVariablePalt:
         # Two calls return the same cached dict — module-level cache.
         first = _get_variable_palt()
         second = _get_variable_palt()
-        assert first is second
-
-
-# ---------------------------------------------------------------------------
-# _get_variable_vpal
-# ---------------------------------------------------------------------------
-
-class TestGetVariableVpal:
-    """Cached read of vpal from the vendor Noto Variable."""
-
-    def test_returns_dict(self):
-        vpal = _get_variable_vpal()
-        assert isinstance(vpal, dict)
-        assert len(vpal) > 0
-
-    def test_returns_yplacement_yadvance_tuples(self):
-        vpal = _get_variable_vpal()
-        for gname, value in list(vpal.items())[:5]:
-            assert isinstance(gname, str)
-            assert isinstance(value, tuple)
-            assert len(value) == 2
-            assert all(isinstance(v, int) for v in value)
-
-    def test_cached_returns_same_instance(self):
-        # Two calls return the same cached dict — module-level cache.
-        first = _get_variable_vpal()
-        second = _get_variable_vpal()
         assert first is second

--- a/tests/test_proportional.py
+++ b/tests/test_proportional.py
@@ -385,6 +385,27 @@ class TestInstallSS09Punctuation:
         assert "約物半角" in names
         assert _feature_record(synthetic_ttf, "GPOS", "kern")
 
+    def test_installs_ss09_alternates_with_vmtx_metrics(self, synthetic_ttf):
+        vmtx = newTable("vmtx")
+        vmtx.metrics = {
+            glyph_name: (1000, 0)
+            for glyph_name in synthetic_ttf.getGlyphOrder()
+        }
+        synthetic_ttf["vmtx"] = vmtx
+
+        _install_ss09_punctuation_feature(
+            synthetic_ttf,
+            {"uni3001": (-25, -100)},
+        )
+
+        assert synthetic_ttf["vmtx"].metrics["uni3001.ss09"] == (
+            1000,
+            0,
+        )
+        assert len(synthetic_ttf["vmtx"].metrics) == len(
+            synthetic_ttf.getGlyphOrder()
+        )
+
     def test_harfbuzz_uses_ss09_only_when_feature_is_enabled(self, synthetic_ttf):
         hb = pytest.importorskip("uharfbuzz")
         _install_synthetic_pairpos_kern(


### PR DESCRIPTION
## Summary

- remove the production runtime `vpal` surface and keep optional yakumono spacing consolidated under `ss09` (`約物半角` / `Half-width punctuation`)
- stop reading, retargeting, synthesizing, and reinstalling `vpal` in the final build pipeline
- keep `.ss09` alternates vertically well-formed by copying source `vmtx` records, and update docs/tests for the new feature surface

## Why

The v0.5.0 spacing surface should be a single explicit feature for optional yakumono spacing. Keeping runtime `vpal` alongside `ss09` leaves another proportional feature exposed from the v0.2.0 design, which makes the final OpenType surface less predictable.

## Validation

- `PYTHONPATH=src python3 -m pytest -q` -> 182 passed
- `PYTHONPATH=src python3 -m pytest tests/test_font_build.py tests/test_proportional.py -q` -> 138 passed
- `git diff --check` -> passed
- `PYTHONPATH=src python3 -m font.build all Regular` -> generated Regular TTFs for both families
- verified generated Regular fonts expose `ss09`, do not expose `palt` / `vpal` / `halt` / `vhal`, and have matching `vmtx` and glyph-order counts
