### PR TITLE
[codex] Apply ss09 yakumono spacing vertically

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -79,13 +79,14 @@ FAMILIES × WEIGHTS の各組合せに対して:
   → font-baker bake: variable Noto → static TTF
                     inheritBase で designer/OFL/version を継承
                     weight だけを上書き
-  → inst を再読込し、キャッシュした variable から palt 取得
+  → inst を再読込し、キャッシュした variable から palt/vpal 取得
     1000-UPM の record を 2048-UPM のビルドグリッドへ換算
   → ss09 約物を除き Noto の palt エントリを全量で焼き込み
     ss09 約物は 34% を base に焼き、66% を ss09 残差として保持
     (palt なしグリフはメトリクス維持)
   → make_proportional で palt → hmtx に焼き込み
-    palt/vpal/halt/vhal を削除; 横方向の約物残差は final ss09 用に保持
+    palt/vpal/halt/vhal を削除; 横方向の palt 残差と縦方向の
+    vpal record は final ss09 用に保持
   → _apply_tracking で advance を広げ LSB を半分シフト
     ただし family["trackingIgnore"] の連続・隙間なし記号は除外
   → _apply_glyph_spacing で family["glyphSpacing"] の個別調整を適用
@@ -103,8 +104,8 @@ FAMILIES × WEIGHTS の各組合せに対して:
                      manufacturer / manufacturerURL を刻印
   → final TTF を一度 reload/save し、GSUB/GPOS coverage を
     merge 後の glyph ID 順に正規化
-  → merge 時の glyph rename 後も encoded glyph に optional 約物挙動が
-    残るよう、final cmap に対して yakumono-only ss09 を生成
+  → merge 時の glyph rename 後も horizontal / vertical glyph に optional
+    約物挙動が残るよう、final cmap / glyph 名に対して yakumono-only ss09 を生成
 ```
 
 ### 2. Web 用サブセット化 (`webfont.build`)
@@ -171,9 +172,11 @@ inst に対して 4 つのサブパスを in-place で実行:
    stylistic set「約物半角」用に保持する。Noto の典型的な `XAdvance=-500` の約物では、
    palt-off で `-170` が base advance に焼かれ、`ss09` 有効時に残り
    `-330` が適用される
-   (いずれも UPM 換算前の設計値)。runtime `vpal` は再生成しない。
-   final font では `palt`, `vpal`, `halt`, `vhal` を削除し、optional
-   約物 spacing は `ss09` だけで公開する。palt なしグリフは自動的に
+   (いずれも UPM 換算前の設計値)。runtime `vpal` は feature としては
+   再生成しないが、選択した約物 record は縦組み用 `.ss09` alternate の
+   source data として保持し、`vmtx` に縦方向の placement / advance delta を
+   焼き込む。final font では `palt`, `vpal`, `halt`, `vhal` を削除し、
+   optional 約物 spacing は `ss09` だけで公開する。palt なしグリフは自動的に
    sidebearing を詰めない; 後続の明示的な spacing ルールが触らない限り
    元の `hmtx` を維持する。
    `U+30FB` (・) は Noto では `U+2027` (‧) と同じ `uni2027` を共有して
@@ -242,7 +245,8 @@ release zip / npm package / site metadata と同じ project/release version を
 "https://yamatoiizuka.com"` でリリース TTF の nameID 8 / 11 を刻印。
 merge 後は final TTF を一度 fontTools で reload/save し、GSUB/GPOS coverage を
 最終 glyph order に合わせて正規化する。その後、merge 前に codepoint keyed で
-保持した最小 runtime `ss09` 挙動を final cmap に対して生成する。
+保持した横方向 record と codepoint / glyph keyed の縦方向 record から、
+最小 runtime `ss09` 挙動を final cmap / glyph order に対して生成する。
 これは `U+FF40` (｀) のように、Noto では `U+2035` と同じ `uni2035`
 を共有するが、Inter 側の `U+2035` と衝突して merge 後に
 `uni2035.orig` へ rename される glyph で必要になる。この final install は
@@ -267,17 +271,21 @@ yakumono-only `ss09` として再生成する。本プロジェクトでは
 `RUNTIME_PALT_BASE_SCALE = 0.34` を使うため、palt-off の約物はすでに部分的に
 詰まり (典型的な `-500` palt advance なら UPM 換算前で `-170`)、`ss09` を
 有効にすると従来の Noto full palt 目標まで到達する。
-production build では `PALT_FEATURE_CHARS` (48 文字) を唯一の runtime
-約物 target set として使う。これにより、焼き込み済みの kana / Latin に
-palt が二重適用されることを避けながら、optional 約物 spacing は `ss09`
-に集約する。TrueType アウトラインのみ対応 (palt のベイクは `glyf` に書き戻すので
+production build では横方向の `ss09` target に `PALT_FEATURE_CHARS`
+(48 文字)、縦方向の `ss09` target に `SS09_VERTICAL_FEATURE_CHARS` と
+`SS09_VERTICAL_FEATURE_GLYPHS` を使う。後者は Noto の `vpal` 値を
+source data として使うが、runtime `vpal` feature は公開せず alternate glyph
+metrics に焼き込む。これにより、焼き込み済みの kana / Latin に palt が
+二重適用されることを避けながら、optional 約物 spacing は `ss09` に集約する。
+TrueType アウトラインのみ対応 (palt のベイクは `glyf` に書き戻すので
 CFF は対象外)。
 Inter との merge では base 側 glyph が rename されることがあるため、
-ビルドは merge 前に横方向の残差を codepoint 単位で保持し、merge 後の final
-cmap に対して retarget する。final record には Noto optical scale
-(`SCALE = 0.925`) をこの時点でだけ掛ける。pre-merge の `palt_data` は
-active UPM grid のままにし、焼き込み base metrics は merge 時に一度だけ
-scale される。
+ビルドは merge 前に横方向の残差を codepoint 単位で、縦方向の調整を
+codepoint または glyph 名で保持し、merge 後の final cmap / glyph order に
+対して retarget する。final record には Noto optical scale (`SCALE = 0.925`)
+をこの時点でだけ掛ける。pre-merge の `palt_data` / `vpal_data` は active
+UPM grid のままにし、焼き込み base metrics は merge 時に一度だけ scale
+される。
 
 `_remove_prop_features` は GPOS を 2 段で歩く: FeatureRecord の削除と、
 それに対応する LangSys インデックスの再マップ。レコード削除は後ろの全
@@ -287,10 +295,12 @@ scale される。
 残す。`kern` は GPOS に残る。横方向の optional 約物は
 GSUB 側で扱う: `_install_ss09_punctuation_feature` が従来の palt 残差から
 `.ss09` metric alternate を作り、UI 名「約物半角」の `ss09` stylistic set
-を生成する。既存の PairPos kerning は `.ss09` alternate にも拡張するため、
-substitution 後も `kern` は効き続ける。alternate は元 glyph の `vmtx`
-record もコピーするため、保存後の font でも vertical metrics table の長さが
-拡張後の glyph order と揃う。`ss09` を追加した後は GSUB `FeatureList` を
+を生成する。縦組み用 glyph については、従来の vpal YPlacement / YAdvance を
+`vmtx` に焼き込んだ `.ss09` alternate を作る。既存の PairPos kerning は
+`.ss09` alternate にも拡張するため、substitution 後も `kern` は効き続ける。
+横方向のみの alternate は元 glyph の `vmtx` record もコピーするため、保存後の
+font でも vertical metrics table の長さが拡張後の glyph order と揃う。
+`ss09` を追加した後は GSUB `FeatureList` を
 `FeatureTag` 順に戻し、LangSys の feature index を再マップする。lookup order
 は変更しない。
 
@@ -478,8 +488,8 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 103 | UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
-| `test_proportional.py` | 35 | palt/vpal 抽出、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal helper coverage + base/residual 分割 + optional squeeze helper、ss09 生成 + shaping |
+| `test_font_build.py` | 108 | UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
+| `test_proportional.py` | 36 | palt/vpal 抽出、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal helper coverage + base/residual 分割 + optional squeeze helper、ss09 生成 + shaping |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -79,13 +79,14 @@ For each (family, weight) in FAMILIES × WEIGHTS:
   → font-baker bake: variable Noto → static TTF
                     inheritBase passes designer/OFL/version
                     through; only weight is stamped
-  → reload inst, read palt from cached variable font
+  → reload inst, read palt/vpal from cached variable font
     and scale those 1000-UPM records to the active 2048-UPM grid
   → bake Noto palt at full strength except ss09 yakumono,
     whose palt is split into a 34% baked base + 66% ss09 residual
     (glyphs without palt keep metrics)
   → make_proportional bakes palt → hmtx and removes palt/vpal/halt/vhal;
-    horizontal yakumono residuals are held for final ss09 alternates
+    horizontal palt residuals and vertical vpal records are held for
+    final ss09 alternates
   → _apply_tracking widens advances + half-balances LSB
     except repeatable no-gap symbols in family["trackingIgnore"]
   → _apply_glyph_spacing applies family["glyphSpacing"] sidebearing tweaks
@@ -103,8 +104,9 @@ For each (family, weight) in FAMILIES × WEIGHTS:
                      manufacturer / manufacturerURL stamped
   → reload/save final TTF once so GSUB/GPOS coverage tables are ordered
     by the final merged glyph IDs
-  → install yakumono-only ss09 against the final cmap so merge-time glyph
-    renames keep optional yakumono behavior on the encoded glyphs
+  → install yakumono-only ss09 against the final cmap / glyph names so
+    merge-time glyph renames keep optional yakumono behavior on both
+    horizontal and vertical glyphs
 ```
 
 ### 2. Subset for the Web (`webfont.build`)
@@ -170,9 +172,11 @@ Four sub-passes, all in-place on the inst:
    yakumono-only `ss09` stylistic set named "約物半角". For Noto's common
    `XAdvance=-500` yakumono records, that means palt-off gets `-170` baked
    into the base advance and enabling `ss09` applies the remaining `-330`
-   before UPM scaling. Runtime `vpal` is not reinstalled; final fonts strip
-   it along with `palt`, `halt`, and `vhal` so optional yakumono spacing is
-   exposed through `ss09` only. Glyphs without palt entries are not
+   before UPM scaling. Runtime `vpal` is not reinstalled as a feature; its
+   selected yakumono records are kept as source data for vertical `.ss09`
+   alternates whose `vmtx` carries the vertical placement / advance delta.
+   Final fonts strip `palt`, `vpal`, `halt`, and `vhal` so optional yakumono
+   spacing is exposed through `ss09` only. Glyphs without palt entries are not
    automatically sidebearing-squeezed; they keep their original
    `hmtx` unless a later explicit spacing rule touches them.
    `U+30FB` (・) is split from Noto's shared `uni2027` glyph before palt
@@ -248,8 +252,9 @@ prefix. `output.manufacturer = "Yamato Iizuka"`, `output.manufacturerURL =
 "https://yamatoiizuka.com"` stamp nameID 8 / 11 on every released TTF.
 After the merge, the TTF is reloaded and saved once with fontTools so
 GSUB/GPOS coverage tables are sorted against the final merged glyph order.
-Then the minimal runtime `ss09` behavior is rebuilt from
-codepoint-keyed records captured before the merge. This matters
+Then the minimal runtime `ss09` behavior is rebuilt from codepoint-keyed
+horizontal records and codepoint/glyph-keyed vertical records captured before
+the merge. This matters
 for shared Noto glyphs such as `U+FF40` (｀), which uses Noto's `uni2035`
 before merge but may be renamed to `uni2035.orig` when Inter also provides
 `U+2035`. Because this final install happens after the merge, the saved
@@ -276,17 +281,21 @@ Inter merge. The project uses
 `RUNTIME_PALT_BASE_SCALE = 0.34`, so palt-off yakumono is already partially
 tightened (`-170` for the common `-500` palt advance before UPM scaling) while
 enabling `ss09` reaches the former full Noto palt target.
-The production build uses `PALT_FEATURE_CHARS` (48 chars) as the only
-runtime yakumono target set. This avoids double-applying palt to baked
-kana / Latin while consolidating optional yakumono spacing under `ss09`.
-Only TrueType outlines are supported
+The production build uses `PALT_FEATURE_CHARS` (48 chars) for horizontal
+`ss09` targets and `SS09_VERTICAL_FEATURE_CHARS` plus
+`SS09_VERTICAL_FEATURE_GLYPHS` for vertical `ss09` targets. The latter uses
+Noto's `vpal` values as source data but bakes them into alternate glyph
+metrics instead of exposing a runtime `vpal` feature. This avoids
+double-applying palt to baked kana / Latin while consolidating optional
+yakumono spacing under `ss09`. Only TrueType outlines are supported
 — palt baking writes back to `glyf`, not CFF.
 Because the Inter merge can rename colliding base glyphs, the build captures
-horizontal residuals by codepoint before the merge and retargets them against
-the final cmap afterward. Those final records are scaled by the final Noto
+horizontal residuals by codepoint and vertical adjustments by codepoint or
+glyph name before the merge, then retargets them against the final cmap /
+glyph order afterward. Those final records are scaled by the final Noto
 optical scale (`SCALE = 0.925`) at install time only; the pre-merge
-`palt_data` remains on the active UPM grid so baked base metrics are scaled
-exactly once by the merge.
+`palt_data` / `vpal_data` remain on the active UPM grid so baked base metrics
+are scaled exactly once by the merge.
 
 `_remove_prop_features` walks GPOS in two coordinated passes:
 FeatureRecord deletions and the corresponding LangSys index remap.
@@ -297,10 +306,12 @@ feature references them; shared lookups stay intact. `kern` remains in GPOS,
 and horizontal optional yakumono is
 handled as GSUB: `_install_ss09_punctuation_feature` creates `.ss09` metric
 alternates from the former palt residual and installs an `ss09` stylistic set
-with the UI name "約物半角". Existing PairPos kerning is extended to those
-alternates so `kern` continues to apply after substitution. The alternates
-also copy their source glyphs' `vmtx` records so saved fonts keep vertical
-metrics table length in sync with the expanded glyph order. After `ss09` is
+with the UI name "約物半角". For vertical glyphs, it creates `.ss09`
+alternates whose `vmtx` bakes the former vpal YPlacement/YAdvance. Existing
+PairPos kerning is extended to those alternates so `kern` continues to apply
+after substitution. Horizontal-only alternates copy their source glyphs'
+`vmtx` records so saved fonts keep vertical metrics table length in sync with
+the expanded glyph order. After `ss09` is
 appended, the GSUB `FeatureList` is sorted back into `FeatureTag` order and
 all LangSys feature indices are remapped; lookup order is left untouched.
 
@@ -491,8 +502,8 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 103 | UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
-| `test_proportional.py` | 35 | palt/vpal extraction, glyph translation, GPOS feature removal, runtime-palt/vpal helper coverage + base/residual split + optional squeeze helper, ss09 construction + shaping |
+| `test_font_build.py` | 108 | UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
+| `test_proportional.py` | 36 | palt/vpal extraction, glyph translation, GPOS feature removal, runtime-palt/vpal helper coverage + base/residual split + optional squeeze helper, ss09 construction + shaping |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |
 

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -166,6 +166,25 @@ PALT_FEATURE_CHARS = (
 # remaining palt delta through ss09 alternates.
 RUNTIME_PALT_BASE_SCALE = 0.34
 
+# Vertical yakumono glyphs also live under the ss09 "約物半角" feature. The
+# build uses Noto's vpal records as source data but bakes them into .ss09 vmtx
+# alternates instead of exposing a runtime vpal feature.
+SS09_VERTICAL_FEATURE_CHARS = (
+    "〒", "・",
+    "︐", "︑", "︒", "︗", "︘",
+    "︵", "︶", "︷", "︸", "︹", "︺",
+    "︻", "︼", "︽", "︾", "︿", "﹀",
+    "﹁", "﹂", "﹃", "﹄", "﹇", "﹈",
+    "！", "＃", "＄", "％", "＆", "＊", "？", "￥", "；",
+)
+
+# U+FF1A (：) vertically substitutes to unmapped glyph17071, so codepoint
+# retargeting cannot reach it. U+FF1B (；) has no Noto vpal record.
+SS09_VERTICAL_FEATURE_GLYPHS = ("glyph17071",)
+SS09_SYNTHETIC_VERTICAL_ADJUSTMENTS = {
+    "uniFF1B": (250, -500),
+}
+
 # Glyphs listed here get full Noto palt baked like every other non-optional
 # palt glyph, then receive explicit hmtx spacing after tracking. Keep this
 # list limited to small kana that need breathing room after palt; yakumono
@@ -468,6 +487,7 @@ SCALE = 0.925
 # ---------------------------------------------------------------------------
 
 _variable_palt_cache: dict | None = None
+_variable_vpal_cache: dict | None = None
 
 
 def _get_variable_palt() -> dict[str, tuple[int, int]]:
@@ -487,6 +507,21 @@ def _get_variable_palt() -> dict[str, tuple[int, int]]:
         font = TTFont(NOTO_VARIABLE)
         _variable_palt_cache = _read_palt(font)
     return _variable_palt_cache
+
+
+def _get_variable_vpal() -> dict[str, tuple[int, int]]:
+    """Read vpal adjustments from the original Noto variable font (cached).
+
+    The production build does not expose runtime vpal. These records are only
+    used as source data for vertical ss09 metric alternates.
+    """
+    global _variable_vpal_cache
+    if _variable_vpal_cache is None:
+        from .proportional import _read_vpal
+
+        font = TTFont(NOTO_VARIABLE)
+        _variable_vpal_cache = _read_vpal(font)
+    return _variable_vpal_cache
 
 
 # ---------------------------------------------------------------------------
@@ -955,9 +990,31 @@ def _retarget_feature_adjustments(
     }
 
 
+def _retarget_named_adjustments(
+    font: TTFont,
+    adjustments_by_glyph: dict[str, tuple[int, int]],
+) -> dict[str, tuple[int, int]]:
+    """Map glyph-name fallback records onto the final font when possible."""
+    if not adjustments_by_glyph:
+        return {}
+    cmap = font.getBestCmap() or {}
+    glyph_order = set(font.getGlyphOrder())
+    retargeted = {}
+    for glyph_name, value in adjustments_by_glyph.items():
+        if glyph_name in glyph_order:
+            retargeted[glyph_name] = value
+            continue
+        cp = _glyph_codepoint(glyph_name)
+        if cp is not None and (target_glyph := cmap.get(cp)) in glyph_order:
+            retargeted[target_glyph] = value
+    return retargeted
+
+
 def _refresh_ss09_feature_after_merge(
     final_path: str,
     ss09_punctuation_by_codepoint: dict[int, tuple[int, int]],
+    ss09_vertical_by_codepoint: dict[int, tuple[int, int]],
+    ss09_vertical_by_glyph: dict[str, tuple[int, int]],
 ) -> None:
     """Install yakumono-only ss09 after merge.
 
@@ -972,9 +1029,20 @@ def _refresh_ss09_feature_after_merge(
         font,
         ss09_punctuation_by_codepoint,
     )
+    ss09_vertical_adjustments = _retarget_feature_adjustments(
+        font,
+        ss09_vertical_by_codepoint,
+    )
+    ss09_vertical_adjustments.update(
+        _retarget_named_adjustments(font, ss09_vertical_by_glyph)
+    )
 
     _remove_prop_features(font)
-    _install_ss09_punctuation_feature(font, ss09_adjustments)
+    _install_ss09_punctuation_feature(
+        font,
+        ss09_adjustments,
+        ss09_vertical_adjustments,
+    )
     font.save(final_path)
 
 
@@ -1219,13 +1287,23 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     split_source = _split_cmap_codepoint_glyph(font, 0x30FB, "uni30FB")
     ss09_punctuation_glyphs = _glyphs_for_codepoints(font, ss09_punctuation_chars)
 
-    # Read palt from the variable source rather than the freshly-baked inst:
+    # Read palt/vpal from the variable source rather than the freshly-baked inst:
     # variable instantiation can leave proportional ValueRecords with zeroed
     # or otherwise stale placement/advance pairs. The cached variable read is
     # canonical across all weights.
     palt_data = _scale_design_adjustments(dict(_get_variable_palt()), font_upm)
     if split_source in palt_data:
         palt_data["uni30FB"] = palt_data[split_source]
+    vpal_data = _scale_design_adjustments(dict(_get_variable_vpal()), font_upm)
+    if split_source in vpal_data:
+        vpal_data["uni30FB"] = vpal_data[split_source]
+    synthetic_vertical_adjustments = _scale_design_adjustments(
+        SS09_SYNTHETIC_VERTICAL_ADJUSTMENTS,
+        font_upm,
+    )
+    for glyph_name, value in synthetic_vertical_adjustments.items():
+        if glyph_name in font.getGlyphOrder() and glyph_name not in vpal_data:
+            vpal_data[glyph_name] = value
     ss09_punctuation_by_codepoint = _runtime_palt_residuals_by_codepoint(
         _feature_adjustments_for_codepoints(
             font,
@@ -1233,6 +1311,16 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
             palt_data,
         )
     )
+    ss09_vertical_by_codepoint = _feature_adjustments_for_codepoints(
+        font,
+        SS09_VERTICAL_FEATURE_CHARS,
+        vpal_data,
+    )
+    ss09_vertical_by_glyph = {
+        glyph_name: vpal_data[glyph_name]
+        for glyph_name in SS09_VERTICAL_FEATURE_GLYPHS
+        if glyph_name in font.getGlyphOrder() and glyph_name in vpal_data
+    }
 
     # Bake Noto palt entries at full strength except ss09 yakumono, which
     # receive a reduced baked base. Their residual is captured above and later
@@ -1298,6 +1386,8 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     _refresh_ss09_feature_after_merge(
         final_path,
         _scale_feature_adjustments(ss09_punctuation_by_codepoint, SCALE),
+        _scale_feature_adjustments(ss09_vertical_by_codepoint, SCALE),
+        _scale_feature_adjustments(ss09_vertical_by_glyph, SCALE),
     )
     return {
         "fontPath": final_path,

--- a/src/font/proportional.py
+++ b/src/font/proportional.py
@@ -488,15 +488,21 @@ def _install_vpal_feature(
 def _install_ss09_punctuation_feature(
     font: TTFont,
     adjustments: dict[str, tuple[int, int]],
+    vertical_adjustments: dict[str, tuple[int, int]] | None = None,
 ) -> None:
     """Install an ``ss09`` stylistic set for optional half-width yakumono.
 
     The default glyphs keep the reduced baked metrics. ``ss09`` substitutes
     to private alternate glyphs that carry the remaining palt delta in their
-    outline position and hmtx advance. PairPos kerning is extended to those
-    alternates so enabling ``ss09`` does not drop existing ``kern`` pairs.
+    outline position and hmtx advance. In vertical writing, the same feature
+    substitutes vertical-form glyphs to alternates whose vmtx carries the
+    former vpal delta. PairPos kerning is extended to those alternates so
+    enabling ``ss09`` does not drop existing ``kern`` pairs.
     """
     alternates = _create_metric_alternates(font, adjustments)
+    alternates.update(
+        _create_vertical_metric_alternates(font, vertical_adjustments or {})
+    )
     if not alternates:
         return
     _extend_pairpos_for_alternates(font, alternates)
@@ -544,6 +550,49 @@ def _create_metric_alternates(
         )
         if vmtx is not None and glyph_name in vmtx.metrics:
             vmtx.metrics[alternate_name] = vmtx.metrics[glyph_name]
+        alternates[glyph_name] = alternate_name
+
+    if alternates:
+        font.setGlyphOrder(glyph_order)
+        if "maxp" in font:
+            font["maxp"].numGlyphs = len(glyph_order)
+    return alternates
+
+
+def _create_vertical_metric_alternates(
+    font: TTFont,
+    adjustments: dict[str, tuple[int, int]],
+) -> dict[str, str]:
+    """Create suffixed glyph alternates carrying vertical metric deltas."""
+    if not adjustments or "glyf" not in font or "hmtx" not in font or "vmtx" not in font:
+        return {}
+
+    glyph_order = list(font.getGlyphOrder())
+    glyph_order_set = set(glyph_order)
+    glyf = font["glyf"]
+    hmtx = font["hmtx"]
+    vmtx = font["vmtx"]
+    alternates: dict[str, str] = {}
+
+    for glyph_name, (y_placement, y_advance) in adjustments.items():
+        if glyph_name not in glyph_order_set:
+            continue
+        if glyph_name not in glyf or glyph_name not in hmtx.metrics:
+            continue
+        if glyph_name not in vmtx.metrics:
+            continue
+        alternate_name = f"{glyph_name}{SS09_ALTERNATE_SUFFIX}"
+        if alternate_name not in glyph_order_set:
+            glyph_order.append(alternate_name)
+            glyph_order_set.add(alternate_name)
+            glyf[alternate_name] = copy.deepcopy(glyf[glyph_name])
+            hmtx[alternate_name] = hmtx[glyph_name]
+
+        advance_height, top_side_bearing = vmtx[glyph_name]
+        vmtx[alternate_name] = (
+            advance_height + y_advance,
+            top_side_bearing - y_placement,
+        )
         alternates[glyph_name] = alternate_name
 
     if alternates:

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -23,6 +23,7 @@ from font.build import (
     _final_output_metadata,
     _get_cjk_glyphs,
     _get_variable_palt,
+    _get_variable_vpal,
     _get_vert_alternates,
     _glyphs_for_codepoints,
     _glyph_codepoint,
@@ -31,6 +32,7 @@ from font.build import (
     _is_kana_or_punct,
     _project_version,
     _retarget_feature_adjustments,
+    _retarget_named_adjustments,
     _runtime_palt_residual_adjustment,
     _scale_design_adjustment,
     _scale_design_adjustments,
@@ -51,6 +53,9 @@ from font.build import (
     PALT_SPACE_ADJUSTMENTS,
     RUNTIME_PALT_BASE_SCALE,
     SOURCE_UPM,
+    SS09_SYNTHETIC_VERTICAL_ADJUSTMENTS,
+    SS09_VERTICAL_FEATURE_CHARS,
+    SS09_VERTICAL_FEATURE_GLYPHS,
     STATIC_INSTANCE_VARIATION_TABLES,
     SUB_EXCLUDE_CODEPOINTS,
     TARGET_UPM,
@@ -805,6 +810,35 @@ class TestPaltSymbolPolicy:
             assert family["runtimePalt"] == PALT_FEATURE_CHARS
             assert "runtimeVpal" not in family
 
+    def test_vertical_yakumono_uses_ss09_targets_not_runtime_vpal(self):
+        vpal = _get_variable_vpal()
+        assert "glyph17071" in SS09_VERTICAL_FEATURE_GLYPHS
+        assert SS09_SYNTHETIC_VERTICAL_ADJUSTMENTS == {
+            "uniFF1B": (250, -500),
+        }
+
+        for char in (
+            "〒・︐︑︒︗︘︵︶︷︸︹︺︻︼︽︾︿﹀﹁﹂﹃﹄﹇﹈"
+            "！＃＄％＆＊？￥；"
+        ):
+            assert char in SS09_VERTICAL_FEATURE_CHARS
+
+        expected_glyphs = {
+            "uni3012",  # 〒
+            "uni2027",  # ・ (Noto source glyph before U+30FB split)
+            "uniFE10",  # ︐
+            "uniFE11",  # ︑
+            "uniFE12",  # ︒
+            "uniFE35",  # ︵
+            "uniFE36",  # ︶
+            "uniFE41",  # ﹁
+            "uniFE42",  # ﹂
+            "uniFF01",  # ！
+            "uniFF05",  # ％
+        }
+
+        assert expected_glyphs <= set(vpal)
+
     def test_scales_final_runtime_feature_adjustments_by_optical_scale(self):
         adjustments = {
             0x3001: (-512, -1024),
@@ -904,6 +938,23 @@ class TestPaltSymbolPolicy:
         )
 
         assert adjustments == {0xFF40: (-199, -500)}
+
+    def test_named_fallback_adjustments_can_retarget_by_codepoint(self, synthetic_ttf):
+        synthetic_ttf.setGlyphOrder([
+            *synthetic_ttf.getGlyphOrder(),
+            "uniFF1B.orig",
+        ])
+        synthetic_ttf["glyf"]["uniFF1B.orig"] = copy.deepcopy(synthetic_ttf["glyf"]["A"])
+        synthetic_ttf["hmtx"].metrics["uniFF1B.orig"] = synthetic_ttf["hmtx"]["A"]
+        for table in synthetic_ttf["cmap"].tables:
+            table.cmap[0xFF1B] = "uniFF1B.orig"
+
+        retargeted = _retarget_named_adjustments(
+            synthetic_ttf,
+            {"uniFF1B": (250, -500), "glyph17071": (250, -500)},
+        )
+
+        assert retargeted == {"uniFF1B.orig": (250, -500)}
 
 # ---------------------------------------------------------------------------
 # _apply_glyph_spacing
@@ -1058,4 +1109,30 @@ class TestGetVariablePalt:
         # Two calls return the same cached dict — module-level cache.
         first = _get_variable_palt()
         second = _get_variable_palt()
+        assert first is second
+
+
+# ---------------------------------------------------------------------------
+# _get_variable_vpal
+# ---------------------------------------------------------------------------
+
+class TestGetVariableVpal:
+    """Cached vpal source data for vertical ss09 alternates."""
+
+    def test_returns_dict(self):
+        vpal = _get_variable_vpal()
+        assert isinstance(vpal, dict)
+        assert len(vpal) > 0
+
+    def test_returns_yplacement_yadvance_tuples(self):
+        vpal = _get_variable_vpal()
+        for gname, value in list(vpal.items())[:5]:
+            assert isinstance(gname, str)
+            assert isinstance(value, tuple)
+            assert len(value) == 2
+            assert all(isinstance(v, int) for v in value)
+
+    def test_cached_returns_same_instance(self):
+        first = _get_variable_vpal()
+        second = _get_variable_vpal()
         assert first is second

--- a/tests/test_proportional.py
+++ b/tests/test_proportional.py
@@ -4,6 +4,7 @@ Covers palt extraction, glyph translation, GPOS feature removal, and the
 ``make_proportional`` integration that ties them together.
 """
 
+import copy
 import io
 
 import pytest
@@ -405,6 +406,40 @@ class TestInstallSS09Punctuation:
         assert len(synthetic_ttf["vmtx"].metrics) == len(
             synthetic_ttf.getGlyphOrder()
         )
+
+    def test_installs_vertical_ss09_alternates_with_vmtx_delta(self, synthetic_ttf):
+        glyph_order = [*synthetic_ttf.getGlyphOrder(), "uniFE11"]
+        synthetic_ttf.setGlyphOrder(glyph_order)
+        synthetic_ttf["glyf"]["uniFE11"] = copy.deepcopy(
+            synthetic_ttf["glyf"]["uni3001"]
+        )
+        synthetic_ttf["hmtx"].metrics["uniFE11"] = synthetic_ttf["hmtx"]["uni3001"]
+        vmtx = newTable("vmtx")
+        vmtx.metrics = {
+            glyph_name: (1000, 100)
+            for glyph_name in synthetic_ttf.getGlyphOrder()
+        }
+        synthetic_ttf["vmtx"] = vmtx
+
+        _install_ss09_punctuation_feature(
+            synthetic_ttf,
+            {},
+            {"uniFE11": (250, -500)},
+        )
+
+        assert synthetic_ttf["hmtx"].metrics["uniFE11.ss09"] == (
+            synthetic_ttf["hmtx"].metrics["uniFE11"]
+        )
+        assert synthetic_ttf["vmtx"].metrics["uniFE11.ss09"] == (
+            500,
+            -150,
+        )
+        feature_index, _record = _feature_record(synthetic_ttf, "GSUB", "ss09")
+        lookup_index = synthetic_ttf["GSUB"].table.FeatureList.FeatureRecord[
+            feature_index
+        ].Feature.LookupListIndex[0]
+        lookup = synthetic_ttf["GSUB"].table.LookupList.Lookup[lookup_index]
+        assert lookup.SubTable[0].mapping["uniFE11"] == "uniFE11.ss09"
 
     def test_harfbuzz_uses_ss09_only_when_feature_is_enabled(self, synthetic_ttf):
         hb = pytest.importorskip("uharfbuzz")


### PR DESCRIPTION
## Summary

- extend `ss09` (`約物半角` / `Half-width punctuation`) to vertical yakumono glyphs
- keep runtime `vpal` removed, but reuse Noto vpal records as source data for `.ss09` vertical `vmtx` alternates
- update architecture docs and tests for horizontal + vertical ss09 behavior

## Why

After consolidating yakumono spacing under `ss09`, vertical writing still shaped punctuation through `vert` / `vrt2` glyphs such as `uniFE11`, so the horizontal-only ss09 substitutions did not apply. This keeps the single-feature surface while making the same feature work in vertical composition.

## Validation

- `PYTHONPATH=src python3 -m pytest -q` -> 188 passed
- `git diff --check` -> passed
- `PYTHONPATH=src python3 -m font.build all Regular` -> generated Regular TTFs for both families
- HarfBuzz vertical shaping check: `、。` with `ss09` now substitutes to `uniFE11.ss09` / `uniFE12.ss09` and narrows vertical advance; final Regular fonts still expose no `palt` / `vpal` / `halt` / `vhal`
