### PR TITLE
[codex] Use font-baker 0.4.6 layout scaling

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -163,7 +163,10 @@ inst に対して 4 つのサブパスを in-place で実行:
 1. **palt のベイク / 約物 ss09** (`proportional.make_proportional`) — palt 値は
    font-baker が作った freshly baked inst TTF から読む。Stage 1 は
    `output.upm = 2048` で実行済みなので、GPOS ValueRecord はすでに active
-   build grid 上にあり、このプロジェクト側では再スケールしない。
+   build grid 上にあり、このプロジェクト側では再スケールしない。同じ glyph に
+   複数の SinglePos lookup が掛かる場合 (Noto の weight-dependent
+   FeatureVariations 適用後など) は、lookup 順に placement / advance delta を
+   加算して読む。
    XPlacement / XAdvance を LSB / advance に加算しアウトラインをシフト。
    Noto の palt エントリは
    原則として全量で焼き込むが、`PALT_FEATURE_CHARS` の約物は分割する。
@@ -489,7 +492,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
 | `test_font_build.py` | 102 | UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
-| `test_proportional.py` | 36 | palt/vpal 抽出、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal helper coverage + base/residual 分割 + optional squeeze helper、ss09 生成 + shaping |
+| `test_proportional.py` | 37 | palt/vpal 抽出、SinglePos lookup の加算読み取り、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal helper coverage + base/residual 分割 + optional squeeze helper、ss09 生成 + shaping |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |
 

--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -166,7 +166,9 @@ inst に対して 4 つのサブパスを in-place で実行:
    build grid 上にあり、このプロジェクト側では再スケールしない。同じ glyph に
    複数の SinglePos lookup が掛かる場合 (Noto の weight-dependent
    FeatureVariations 適用後など) は、lookup 順に placement / advance delta を
-   加算して読む。
+   加算して読む。Noto の太ウェイト用 FeatureVariation は全角 `Ｍ` と `ｗ` の
+   palt record を追加するが、この 2 glyph は明示的に bake 対象から外し、
+   project 側の tracking-only な全角 Latin spacing 方針を維持する。
    XPlacement / XAdvance を LSB / advance に加算しアウトラインをシフト。
    Noto の palt エントリは
    原則として全量で焼き込むが、`PALT_FEATURE_CHARS` の約物は分割する。

--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -79,8 +79,8 @@ FAMILIES × WEIGHTS の各組合せに対して:
   → font-baker bake: variable Noto → static TTF
                     inheritBase で designer/OFL/version を継承
                     weight だけを上書き
-  → inst を再読込し、キャッシュした variable から palt/vpal 取得
-    1000-UPM の record を 2048-UPM のビルドグリッドへ換算
+  → inst を再読込し、font-baker が 2048-UPM で bake した出力から
+    palt/vpal 取得 (record はすでに active build grid 上)
   → ss09 約物を除き Noto の palt エントリを全量で焼き込み
     ss09 約物は 34% を base に焼き、66% を ss09 残差として保持
     (palt なしグリフはメトリクス維持)
@@ -161,18 +161,18 @@ palt record を持ちうるため対象に含める。
 inst に対して 4 つのサブパスを in-place で実行:
 
 1. **palt のベイク / 約物 ss09** (`proportional.make_proportional`) — palt 値は
-   キャッシュ済みの variable から読む (instantiation で非デフォルト軸位置の
-   palt ValueRecord が壊れることがあるため)。その値は Noto の 1000-UPM
-   ソースグリッドから、実際の 2048-UPM ビルドグリッドへ換算する。
+   font-baker が作った freshly baked inst TTF から読む。Stage 1 は
+   `output.upm = 2048` で実行済みなので、GPOS ValueRecord はすでに active
+   build grid 上にあり、このプロジェクト側では再スケールしない。
    XPlacement / XAdvance を LSB / advance に加算しアウトラインをシフト。
    Noto の palt エントリは
    原則として全量で焼き込むが、`PALT_FEATURE_CHARS` の約物は分割する。
    palt 調整量の 34% を `hmtx` に焼き込んでデフォルトでもある程度
    詰まる base metrics にし、残り 66% は final の yakumono-only `ss09`
-   stylistic set「約物半角」用に保持する。Noto の典型的な `XAdvance=-500` の約物では、
-   palt-off で `-170` が base advance に焼かれ、`ss09` 有効時に残り
-   `-330` が適用される
-   (いずれも UPM 換算前の設計値)。runtime `vpal` は feature としては
+   stylistic set「約物半角」用に保持する。Noto の典型的な 1000-UPM source
+   scale の `XAdvance=-500` 約物は 2048-UPM では `-1024` 相当になり、
+   palt-off で `-348` が base advance に焼かれ、`ss09` 有効時に残り
+   `-676` が適用される。runtime `vpal` は feature としては
    再生成しないが、選択した約物 record は縦組み用 `.ss09` alternate の
    source data として保持し、`vmtx` に縦方向の placement / advance delta を
    焼き込む。final font では `palt`, `vpal`, `halt`, `vhal` を削除し、
@@ -269,8 +269,8 @@ base metrics に焼き込む。production build では `install_runtime_palt` �
 残差を live `palt` としては公開せず、codepoint 単位で保持して Inter merge 後の
 yakumono-only `ss09` として再生成する。本プロジェクトでは
 `RUNTIME_PALT_BASE_SCALE = 0.34` を使うため、palt-off の約物はすでに部分的に
-詰まり (典型的な `-500` palt advance なら UPM 換算前で `-170`)、`ss09` を
-有効にすると従来の Noto full palt 目標まで到達する。
+詰まり (2048-UPM build grid 上の典型的な `-1024` palt advance なら `-348`)、
+`ss09` を有効にすると従来の Noto full palt 目標まで到達する。
 production build では横方向の `ss09` target に `PALT_FEATURE_CHARS`
 (48 文字)、縦方向の `ss09` target に `SS09_VERTICAL_FEATURE_CHARS` と
 `SS09_VERTICAL_FEATURE_GLYPHS` を使う。後者は Noto の `vpal` 値を
@@ -462,8 +462,8 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
   `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
   `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
   `_apply_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
-  `_split_cmap_codepoint_glyph`, `_get_variable_palt`、
-  明示的な palt/ss09 spacing 方針、Thin / ExtraBold 用の
+  `_split_cmap_codepoint_glyph`、明示的な palt/ss09 spacing 方針、
+  vendor palt/vpal policy check、Thin / ExtraBold 用の
   InterVariable edge instance source 選択。
 - **`src/font/verify_edge_instances.py`** — Thin / ExtraBold のビルド後検証。
   生成された InterVariable static instance が vendor static と同じ cmap /
@@ -488,7 +488,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 108 | UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
+| `test_font_build.py` | 102 | UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
 | `test_proportional.py` | 36 | palt/vpal 抽出、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal helper coverage + base/residual 分割 + optional squeeze helper、ss09 生成 + shaping |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |
@@ -520,7 +520,7 @@ GitHub Pages にデプロイ。リリースパッケージングはローカル�
 
 ### Python
 
-- `ofl-font-baker` (>= 0.4.5) — コンポジットフォントマージエンジン。
+- `ofl-font-baker` (>= 0.4.6) — コンポジットフォントマージエンジン。
   `metadataMode` で base / sub の identity を継承する。Stage 1 (bake) と
   Stage 3 (merge) を駆動。0.4.0 で `subFont.excludeCodepoints` と
   glyph-name collision rename が追加され、merge 段で日本語慣習記号を
@@ -528,7 +528,9 @@ GitHub Pages にデプロイ。リリースパッケージングはローカル�
   グリフに対して縦書き metrics (`vmtx` / `VORG`) と `vert` / `vrt2` GSUB
   マッピングを base から継承するように修正され、上書き対象の縦書き
   位置が崩れない。0.4.5 で `output.upm` が追加され、Noto bake と final merge
-  の両段で 2048 UPM の Inter グリッドを維持するために使っている。
+  の両段で 2048 UPM の Inter グリッドを維持するために使っている。0.4.6 で
+  `output.upm` 適用時の layout table もスケールされるため、この pipeline が
+  読むプロポーショナル / 縦書き位置データも active build grid 上に揃う。
 - `fonttools` (>= 4.47.0) — フォントパース、instancer、subsetter、
   GPOS / GSUB の編集。
 - `freetype-py` — メトリクス検証ツーリングで使用。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -163,7 +163,10 @@ Four sub-passes, all in-place on the inst:
 1. **palt baking / yakumono ss09** (`proportional.make_proportional`) — palt values are
    read from the freshly baked inst TTF produced by font-baker. Because
    Stage 1 already runs with `output.upm = 2048`, the GPOS ValueRecords are
-   on the active build grid and are not scaled again by this project.
+   on the active build grid and are not scaled again by this project. When
+   a feature contains multiple SinglePos lookups for the same glyph (for
+   example after Noto's weight-dependent FeatureVariations are applied),
+   their placement / advance deltas are accumulated in lookup order.
    XPlacement/XAdvance pairs are added to LSB / advance, outlines shifted.
    Most Noto palt entries are
    baked at full strength, but yakumono listed in `PALT_FEATURE_CHARS`
@@ -504,7 +507,7 @@ Tests live under `tests/`, split by surface:
 | File | Tests | Verifies |
 |---|---|---|
 | `test_font_build.py` | 102 | UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
-| `test_proportional.py` | 36 | palt/vpal extraction, glyph translation, GPOS feature removal, runtime-palt/vpal helper coverage + base/residual split + optional squeeze helper, ss09 construction + shaping |
+| `test_proportional.py` | 37 | palt/vpal extraction, cumulative SinglePos lookup reading, glyph translation, GPOS feature removal, runtime-palt/vpal helper coverage + base/residual split + optional squeeze helper, ss09 construction + shaping |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -166,7 +166,10 @@ Four sub-passes, all in-place on the inst:
    on the active build grid and are not scaled again by this project. When
    a feature contains multiple SinglePos lookups for the same glyph (for
    example after Noto's weight-dependent FeatureVariations are applied),
-   their placement / advance deltas are accumulated in lookup order.
+   their placement / advance deltas are accumulated in lookup order. Noto's
+   heavy-weight FeatureVariation adds palt records for fullwidth `Ｍ` and `ｗ`;
+   those two glyphs are explicitly removed from the bake set so they keep the
+   project's tracking-only fullwidth Latin spacing policy.
    XPlacement/XAdvance pairs are added to LSB / advance, outlines shifted.
    Most Noto palt entries are
    baked at full strength, but yakumono listed in `PALT_FEATURE_CHARS`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -79,8 +79,8 @@ For each (family, weight) in FAMILIES × WEIGHTS:
   → font-baker bake: variable Noto → static TTF
                     inheritBase passes designer/OFL/version
                     through; only weight is stamped
-  → reload inst, read palt/vpal from cached variable font
-    and scale those 1000-UPM records to the active 2048-UPM grid
+  → reload inst, read palt/vpal from font-baker's 2048-UPM baked output
+    (records are already on the active build grid)
   → bake Noto palt at full strength except ss09 yakumono,
     whose palt is split into a 34% baked base + 66% ss09 residual
     (glyphs without palt keep metrics)
@@ -161,18 +161,19 @@ carry palt records.
 Four sub-passes, all in-place on the inst:
 
 1. **palt baking / yakumono ss09** (`proportional.make_proportional`) — palt values are
-   read from the cached variable font (instantiation can corrupt palt's
-   ValueRecords at non-default axis positions), then scaled from Noto's
-   1000-UPM source grid to the active 2048-UPM build grid.
+   read from the freshly baked inst TTF produced by font-baker. Because
+   Stage 1 already runs with `output.upm = 2048`, the GPOS ValueRecords are
+   on the active build grid and are not scaled again by this project.
    XPlacement/XAdvance pairs are added to LSB / advance, outlines shifted.
    Most Noto palt entries are
    baked at full strength, but yakumono listed in `PALT_FEATURE_CHARS`
    is split: 34% of the palt adjustment is baked into `hmtx` so the glyph is
    still tightened by default, and the remaining 66% is held for a final
    yakumono-only `ss09` stylistic set named "約物半角". For Noto's common
-   `XAdvance=-500` yakumono records, that means palt-off gets `-170` baked
-   into the base advance and enabling `ss09` applies the remaining `-330`
-   before UPM scaling. Runtime `vpal` is not reinstalled as a feature; its
+   `XAdvance=-500` yakumono records at the 1000-UPM source scale, the
+   equivalent 2048-UPM record is `-1024`; palt-off gets `-348` baked into
+   the base advance and enabling `ss09` applies the remaining `-676`.
+   Runtime `vpal` is not reinstalled as a feature; its
    selected yakumono records are kept as source data for vertical `.ss09`
    alternates whose `vmtx` carries the vertical placement / advance delta.
    Final fonts strip `palt`, `vpal`, `halt`, and `vhal` so optional yakumono
@@ -279,8 +280,8 @@ is disabled so the residual is not exposed as live `palt`; instead it is
 captured by codepoint and later reinstalled as yakumono-only `ss09` after the
 Inter merge. The project uses
 `RUNTIME_PALT_BASE_SCALE = 0.34`, so palt-off yakumono is already partially
-tightened (`-170` for the common `-500` palt advance before UPM scaling) while
-enabling `ss09` reaches the former full Noto palt target.
+tightened (`-348` for the common `-1024` palt advance on the 2048-UPM build
+grid) while enabling `ss09` reaches the former full Noto palt target.
 The production build uses `PALT_FEATURE_CHARS` (48 chars) for horizontal
 `ss09` targets and `SS09_VERTICAL_FEATURE_CHARS` plus
 `SS09_VERTICAL_FEATURE_GLYPHS` for vertical `ss09` targets. The latter uses
@@ -476,8 +477,8 @@ Tests live under `tests/`, split by surface:
   `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
   `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
   `_apply_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
-  `_split_cmap_codepoint_glyph`, `_get_variable_palt`,
-  explicit palt/ss09 spacing policy, and InterVariable edge-instance
+  `_split_cmap_codepoint_glyph`, explicit palt/ss09 spacing policy, vendor
+  palt/vpal policy checks, and InterVariable edge-instance
   source selection for Thin / ExtraBold.
 - **`src/font/verify_edge_instances.py`** — post-build verification for
   Thin / ExtraBold edge outputs. Confirms the generated InterVariable static
@@ -502,7 +503,7 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 108 | UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
+| `test_font_build.py` | 102 | UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
 | `test_proportional.py` | 36 | palt/vpal extraction, glyph translation, GPOS feature removal, runtime-palt/vpal helper coverage + base/residual split + optional squeeze helper, ss09 construction + shaping |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |
@@ -534,7 +535,7 @@ flow.
 
 ### Python
 
-- `ofl-font-baker` (>= 0.4.5) — Composite font merge engine. Inherits
+- `ofl-font-baker` (>= 0.4.6) — Composite font merge engine. Inherits
   base/sub identity records via `metadataMode`. Drives Stage 1 (bake)
   and Stage 3 (merge) of the build pipeline. 0.4.0 added
   `subFont.excludeCodepoints` and glyph-name collision rename, used by
@@ -544,7 +545,9 @@ flow.
   so vertical typesetting of overridden glyphs continues to land at the
   base font's intended position. 0.4.5 adds `output.upm`, used by both
   the Noto bake and final merge stages to keep the pipeline on the 2048 UPM
-  Inter grid.
+  Inter grid. 0.4.6 scales layout tables when `output.upm` is applied, so
+  the proportional and vertical positioning data consumed by this pipeline
+  stays on the active build grid.
 - `fonttools` (>= 4.47.0) — Font parsing, instancer, subsetter, GPOS / GSUB
   table editing.
 - `freetype-py` — Used by tooling around metrics inspection.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.9"
 dependencies = [
-    "ofl-font-baker>=0.4.5",
+    "ofl-font-baker>=0.4.6",
     "freetype-py>=2.4.0",
 ]
 

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -168,6 +168,11 @@ PALT_FEATURE_CHARS = (
 # remaining palt delta through ss09 alternates.
 RUNTIME_PALT_BASE_SCALE = 0.34
 
+# Noto's weight-dependent palt FeatureVariation adds these two fullwidth Latin
+# glyphs only for heavy weights. In this UI family they should stay on the
+# tracking-only path instead of suddenly tightening in Bold / ExtraBold.
+PALT_EXCLUDE_CHARS = ("Ｍ", "ｗ")
+
 # Vertical yakumono glyphs also live under the ss09 "約物半角" feature. The
 # build uses Noto's vpal records as source data but bakes them into .ss09 vmtx
 # alternates instead of exposing a runtime vpal feature.
@@ -901,6 +906,12 @@ def _feature_adjustments_for_codepoints(
     }
 
 
+def _remove_palt_exclusions(font: TTFont, adjustments: dict[str, tuple[int, int]]) -> None:
+    """Drop project-owned palt exclusions from a mutable adjustment map."""
+    for glyph_name in _glyphs_for_codepoints(font, PALT_EXCLUDE_CHARS):
+        adjustments.pop(glyph_name, None)
+
+
 def _runtime_palt_residual_adjustment(
     adjustment: tuple[int, int],
 ) -> tuple[int, int]:
@@ -1253,6 +1264,7 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     palt_data = dict(_read_palt(font))
     if split_source in palt_data:
         palt_data["uni30FB"] = palt_data[split_source]
+    _remove_palt_exclusions(font, palt_data)
     vpal_data = dict(_read_vpal(font))
     if split_source in vpal_data:
         vpal_data["uni30FB"] = vpal_data[split_source]

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -35,6 +35,8 @@ from merge_fonts import merge_fonts, parse_codepoint_list
 from project_metadata import project_version as read_project_version
 from .proportional import (
     _install_ss09_punctuation_feature,
+    _read_palt,
+    _read_vpal,
     _remove_prop_features,
     _scale_position_adjustment,
     make_proportional,
@@ -480,48 +482,6 @@ SUB_EXCLUDE_CODEPOINTS = [
 # Latin/CJK pairing where CJK is slightly down-scaled to feel proportionate.
 BASELINE_OFFSET = 25
 SCALE = 0.925
-
-
-# ---------------------------------------------------------------------------
-# Variable-font palt cache
-# ---------------------------------------------------------------------------
-
-_variable_palt_cache: dict | None = None
-_variable_vpal_cache: dict | None = None
-
-
-def _get_variable_palt() -> dict[str, tuple[int, int]]:
-    """Read palt adjustments from the original Noto variable font (cached).
-
-    The variable font's palt values are used as the source of truth across
-    all weights instead of reading palt from each statically-instantiated
-    inst.ttf. Reason: variable-font instantiation can quietly corrupt
-    GPOS ValueRecords at non-default axis positions (some XPlacement /
-    XAdvance pairs end up zeroed or shifted). The variable font itself
-    carries the canonical palt definition, so we read it once and reuse.
-    """
-    global _variable_palt_cache
-    if _variable_palt_cache is None:
-        from .proportional import _read_palt
-
-        font = TTFont(NOTO_VARIABLE)
-        _variable_palt_cache = _read_palt(font)
-    return _variable_palt_cache
-
-
-def _get_variable_vpal() -> dict[str, tuple[int, int]]:
-    """Read vpal adjustments from the original Noto variable font (cached).
-
-    The production build does not expose runtime vpal. These records are only
-    used as source data for vertical ss09 metric alternates.
-    """
-    global _variable_vpal_cache
-    if _variable_vpal_cache is None:
-        from .proportional import _read_vpal
-
-        font = TTFont(NOTO_VARIABLE)
-        _variable_vpal_cache = _read_vpal(font)
-    return _variable_vpal_cache
 
 
 # ---------------------------------------------------------------------------
@@ -1203,8 +1163,8 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     1. **Bake** Noto variable → static TTF at the chosen wght axis location,
        passed through font-baker with ``metadataMode: inheritBase`` and
        ``output.upm = 2048`` so the Noto identity records survive into the inst.
-    2. **Proportionalise** the inst — read palt from the variable cache
-       (variable instantiation can corrupt palt), bake those adjustments
+    2. **Proportionalise** the inst — read palt/vpal from that 2048-UPM
+       baked output, bake those adjustments
        into hmtx except selected ss09 yakumono, apply tracking,
        apply per-glyph sidebearing tweaks from ``family["glyphSpacing"]``,
        strip extreme bbox glyphs, optionally apply x-scale.
@@ -1287,14 +1247,13 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     split_source = _split_cmap_codepoint_glyph(font, 0x30FB, "uni30FB")
     ss09_punctuation_glyphs = _glyphs_for_codepoints(font, ss09_punctuation_chars)
 
-    # Read palt/vpal from the variable source rather than the freshly-baked inst:
-    # variable instantiation can leave proportional ValueRecords with zeroed
-    # or otherwise stale placement/advance pairs. The cached variable read is
-    # canonical across all weights.
-    palt_data = _scale_design_adjustments(dict(_get_variable_palt()), font_upm)
+    # Read palt/vpal from the freshly baked 2048-UPM inst. font-baker owns the
+    # variable instantiation and UPM conversion here, so proportional records
+    # are already on the active build grid.
+    palt_data = dict(_read_palt(font))
     if split_source in palt_data:
         palt_data["uni30FB"] = palt_data[split_source]
-    vpal_data = _scale_design_adjustments(dict(_get_variable_vpal()), font_upm)
+    vpal_data = dict(_read_vpal(font))
     if split_source in vpal_data:
         vpal_data["uni30FB"] = vpal_data[split_source]
     synthetic_vertical_adjustments = _scale_design_adjustments(

--- a/src/font/proportional.py
+++ b/src/font/proportional.py
@@ -259,7 +259,12 @@ def _read_single_pos_feature(
     placement_attr: str,
     advance_attr: str,
 ) -> dict[str, tuple[int, int]]:
-    """Read a SinglePos feature as ``{glyph_name: (placement, advance)}``."""
+    """Read a SinglePos feature as ``{glyph_name: (placement, advance)}``.
+
+    Multiple lookups in the same OpenType feature are applied sequentially by
+    shaping engines, so records covering the same glyph must be summed rather
+    than replaced by the later lookup.
+    """
     gpos = font.get("GPOS")
     if gpos is None or gpos.table is None:
         return {}
@@ -303,7 +308,11 @@ def _read_single_pos_feature(
 
                 placement = getattr(v, placement_attr, 0) or 0
                 advance = getattr(v, advance_attr, 0) or 0
-                adjustments[glyph_name] = (placement, advance)
+                prev_placement, prev_advance = adjustments.get(glyph_name, (0, 0))
+                adjustments[glyph_name] = (
+                    prev_placement + placement,
+                    prev_advance + advance,
+                )
 
     return adjustments
 

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -33,6 +33,7 @@ from font.build import (
     _project_version,
     _retarget_feature_adjustments,
     _retarget_named_adjustments,
+    _remove_palt_exclusions,
     _runtime_palt_residual_adjustment,
     _scale_design_adjustment,
     _scale_design_adjustments,
@@ -50,6 +51,7 @@ from font.build import (
     INTER_VARIABLE_EDGE_WEIGHTS,
     NOTO_VARIABLE,
     NORMAL_PALT_SPACE_ADJUSTMENTS,
+    PALT_EXCLUDE_CHARS,
     PALT_FEATURE_CHARS,
     PALT_SPACE_ADJUSTMENTS,
     RUNTIME_PALT_BASE_SCALE,
@@ -806,6 +808,23 @@ class TestPaltSymbolPolicy:
         assert "uniFF2D" not in palt  # Ｍ
         assert "uniFF57" not in palt  # ｗ
         assert "uniFF40" not in palt  # ｀
+
+    def test_fullwidth_m_w_stay_on_tracking_only_path(self):
+        assert PALT_EXCLUDE_CHARS == ("Ｍ", "ｗ")
+
+        font = TTFont(NOTO_VARIABLE)
+        try:
+            palt = {
+                "uniFF2D": (-142, -326),
+                "uniFF57": (-151, -302),
+                "uniFF21": (-107, -212),
+            }
+
+            _remove_palt_exclusions(font, palt)
+        finally:
+            font.close()
+
+        assert palt == {"uniFF21": (-107, -212)}
 
     def test_yakumono_uses_ss09_targets_not_spacing(self):
         assert len(PALT_FEATURE_CHARS) == 48

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -5,6 +5,8 @@ glyph-name codepoint parsing, kana / CJK classification, GSUB feature
 inspection, horizontal scaling, bbox stripping, and tracking.
 """
 
+from __future__ import annotations
+
 import copy
 import re
 from pathlib import Path
@@ -22,8 +24,6 @@ from font.build import (
     _feature_adjustments_for_codepoints,
     _final_output_metadata,
     _get_cjk_glyphs,
-    _get_variable_palt,
-    _get_variable_vpal,
     _get_vert_alternates,
     _glyphs_for_codepoints,
     _glyph_codepoint,
@@ -48,6 +48,7 @@ from font.build import (
     FAMILIES,
     INTER_VARIABLE,
     INTER_VARIABLE_EDGE_WEIGHTS,
+    NOTO_VARIABLE,
     NORMAL_PALT_SPACE_ADJUSTMENTS,
     PALT_FEATURE_CHARS,
     PALT_SPACE_ADJUSTMENTS,
@@ -61,8 +62,40 @@ from font.build import (
     TARGET_UPM,
     TRACKING_IGNORE_CODEPOINTS,
 )
-from font.proportional import _install_ss09_punctuation_feature
+from font.proportional import (
+    _install_ss09_punctuation_feature,
+    _read_palt,
+    _read_vpal,
+)
 from merge_fonts import parse_codepoint_list
+
+
+_vendor_palt_cache: dict[str, tuple[int, int]] | None = None
+_vendor_vpal_cache: dict[str, tuple[int, int]] | None = None
+
+
+def _vendor_palt() -> dict[str, tuple[int, int]]:
+    """Read full vendor Noto palt data for policy assertions."""
+    global _vendor_palt_cache
+    if _vendor_palt_cache is None:
+        font = TTFont(NOTO_VARIABLE)
+        try:
+            _vendor_palt_cache = _read_palt(font)
+        finally:
+            font.close()
+    return _vendor_palt_cache
+
+
+def _vendor_vpal() -> dict[str, tuple[int, int]]:
+    """Read full vendor Noto vpal data for policy assertions."""
+    global _vendor_vpal_cache
+    if _vendor_vpal_cache is None:
+        font = TTFont(NOTO_VARIABLE)
+        try:
+            _vendor_vpal_cache = _read_vpal(font)
+        finally:
+            font.close()
+    return _vendor_vpal_cache
 
 
 def _layout_feature_tags(font: TTFont, table_tag: str) -> set[str]:
@@ -752,7 +785,7 @@ class TestPaltSymbolPolicy:
     """Full palt is baked by default; selected yakumono keeps an ss09 residual."""
 
     def test_tracking_only_symbols_are_implicit_palt_entries(self):
-        palt = _get_variable_palt()
+        palt = _vendor_palt()
 
         for glyph_name in (
             "uni3012", "uni3005", "uni3006",
@@ -811,7 +844,7 @@ class TestPaltSymbolPolicy:
             assert "runtimeVpal" not in family
 
     def test_vertical_yakumono_uses_ss09_targets_not_runtime_vpal(self):
-        vpal = _get_variable_vpal()
+        vpal = _vendor_vpal()
         assert "glyph17071" in SS09_VERTICAL_FEATURE_GLYPHS
         assert SS09_SYNTHETIC_VERTICAL_ADJUSTMENTS == {
             "uniFF1B": (250, -500),
@@ -1083,56 +1116,3 @@ class TestApplyGlyphSpacing:
         assert after_glyph.xMin == before_glyph.xMin
         assert after_glyph.xMax == before_glyph.xMax
         assert list(after_glyph.coordinates) == list(before_glyph.coordinates)
-
-
-# ---------------------------------------------------------------------------
-# _get_variable_palt
-# ---------------------------------------------------------------------------
-
-class TestGetVariablePalt:
-    """Cached read of palt from the vendor Noto Variable."""
-
-    def test_returns_dict(self):
-        palt = _get_variable_palt()
-        assert isinstance(palt, dict)
-        assert len(palt) > 0
-
-    def test_returns_xplacement_xadvance_tuples(self):
-        palt = _get_variable_palt()
-        for gname, value in list(palt.items())[:5]:
-            assert isinstance(gname, str)
-            assert isinstance(value, tuple)
-            assert len(value) == 2
-            assert all(isinstance(v, int) for v in value)
-
-    def test_cached_returns_same_instance(self):
-        # Two calls return the same cached dict — module-level cache.
-        first = _get_variable_palt()
-        second = _get_variable_palt()
-        assert first is second
-
-
-# ---------------------------------------------------------------------------
-# _get_variable_vpal
-# ---------------------------------------------------------------------------
-
-class TestGetVariableVpal:
-    """Cached vpal source data for vertical ss09 alternates."""
-
-    def test_returns_dict(self):
-        vpal = _get_variable_vpal()
-        assert isinstance(vpal, dict)
-        assert len(vpal) > 0
-
-    def test_returns_yplacement_yadvance_tuples(self):
-        vpal = _get_variable_vpal()
-        for gname, value in list(vpal.items())[:5]:
-            assert isinstance(gname, str)
-            assert isinstance(value, tuple)
-            assert len(value) == 2
-            assert all(isinstance(v, int) for v in value)
-
-    def test_cached_returns_same_instance(self):
-        first = _get_variable_vpal()
-        second = _get_variable_vpal()
-        assert first is second

--- a/tests/test_proportional.py
+++ b/tests/test_proportional.py
@@ -108,6 +108,84 @@ def _install_synthetic_pairpos_kern(
     gpos.table.FeatureList.FeatureCount = 1
 
 
+def _install_synthetic_singlepos_feature(
+    font,
+    feature_tag: str,
+    lookup_adjustments: list[dict[str, tuple[int, int]]],
+    placement_attr: str = "XPlacement",
+    advance_attr: str = "XAdvance",
+    value_format: int = 0x0005,
+) -> None:
+    gpos = newTable("GPOS")
+    font["GPOS"] = gpos
+    gpos.table = otTables.GPOS()
+    gpos.table.Version = 0x00010000
+
+    langsys = otTables.LangSys()
+    langsys.LookupOrder = None
+    langsys.ReqFeatureIndex = 0xFFFF
+    langsys.FeatureIndex = [0]
+    langsys.FeatureCount = 1
+
+    script = otTables.Script()
+    script.DefaultLangSys = langsys
+    script.LangSysRecord = []
+    script.LangSysCount = 0
+
+    script_record = otTables.ScriptRecord()
+    script_record.ScriptTag = "DFLT"
+    script_record.Script = script
+
+    gpos.table.ScriptList = otTables.ScriptList()
+    gpos.table.ScriptList.ScriptRecord = [script_record]
+    gpos.table.ScriptList.ScriptCount = 1
+
+    glyph_order = {glyph_name: i for i, glyph_name in enumerate(font.getGlyphOrder())}
+    lookups = []
+    for adjustments in lookup_adjustments:
+        glyphs = sorted(adjustments, key=glyph_order.__getitem__)
+
+        coverage = otTables.Coverage()
+        coverage.glyphs = glyphs
+
+        subtable = otTables.SinglePos()
+        subtable.Format = 2
+        subtable.Coverage = coverage
+        subtable.ValueFormat = value_format
+        subtable.Value = []
+        for glyph_name in glyphs:
+            placement, advance = adjustments[glyph_name]
+            value = otTables.ValueRecord()
+            setattr(value, placement_attr, placement)
+            setattr(value, advance_attr, advance)
+            subtable.Value.append(value)
+        subtable.ValueCount = len(subtable.Value)
+
+        lookup = otTables.Lookup()
+        lookup.LookupType = 1
+        lookup.LookupFlag = 0
+        lookup.SubTable = [subtable]
+        lookup.SubTableCount = 1
+        lookups.append(lookup)
+
+    gpos.table.LookupList = otTables.LookupList()
+    gpos.table.LookupList.Lookup = lookups
+    gpos.table.LookupList.LookupCount = len(lookups)
+
+    feature = otTables.Feature()
+    feature.FeatureParams = None
+    feature.LookupListIndex = list(range(len(lookups)))
+    feature.LookupCount = len(lookups)
+
+    feature_record = otTables.FeatureRecord()
+    feature_record.FeatureTag = feature_tag
+    feature_record.Feature = feature
+
+    gpos.table.FeatureList = otTables.FeatureList()
+    gpos.table.FeatureList.FeatureRecord = [feature_record]
+    gpos.table.FeatureList.FeatureCount = 1
+
+
 def _install_synthetic_gsub_single_subst_feature(
     font,
     feature_tag: str,
@@ -200,6 +278,21 @@ class TestReadPalt:
     def test_empty_when_no_gsub_palt(self, synthetic_ttf):
         # synthetic_ttf has no GPOS at all
         assert _read_palt(synthetic_ttf) == {}
+
+    def test_accumulates_multiple_palt_lookups_for_same_glyph(self, synthetic_ttf):
+        _install_synthetic_singlepos_feature(
+            synthetic_ttf,
+            "palt",
+            [
+                {"uni3042": (-20, -100), "uni3001": (-10, -500)},
+                {"uni3042": (5, 25), "uni3001": (3, 0)},
+            ],
+        )
+
+        assert _read_palt(synthetic_ttf) == {
+            "uni3042": (-15, -75),
+            "uni3001": (-7, -500),
+        }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Require `ofl-font-baker>=0.4.6` so Stage 1 `output.upm=2048` layout values are sourced from Font Baker's scaled output.
- Remove the project-side cached Noto Variable `palt/vpal` fallback and read `palt/vpal` from the freshly baked 2048 UPM inst TTF.
- Accumulate repeated SinglePos adjustments in the same feature, matching OpenType lookup order. This preserves Noto's weight-dependent `palt` FeatureVariation deltas for Bold and ExtraBold instead of replacing the base `palt` lookup.
- Update tests and architecture docs for the Font Baker-owned layout scaling path.

## Validation

- Installed `ofl-font-baker 0.4.6` from PyPI in a clean temporary venv.
- Built `normal Regular` with that venv: `PYTHONPATH=src /private/tmp/gen-interface-jp-fb-latest-venv/bin/python -m font.build normal Regular`.
- Built all 16 TTF outputs with that venv: `PYTHONPATH=src /private/tmp/gen-interface-jp-fb-latest-venv/bin/python -m font.build`.
- Rebuilt affected Bold and ExtraBold outputs after the SinglePos accumulation fix: `PYTHONPATH=src /private/tmp/gen-interface-jp-fb-latest-venv/bin/python -m font.build all Bold ExtraBold`.
- Compared the regenerated Regular against the previous local Regular: glyph order, cmap, hhea, OS/2 vertical metrics, hmtx, and vmtx are unchanged. Expected layout-table differences are present: BASE is on the 2048 UPM grid and the base-origin `vert` GPOS values include the configured Noto scale.
- Compared Bold/ExtraBold against the previous `main` behavior: yakumono and fullwidth digits are no longer near-fullwidth; Noto's Bold/ExtraBold FeatureVariation deltas are included cumulatively.
- `PYTHONPATH=src /private/tmp/gen-interface-jp-fb-latest-venv/bin/python -m pytest tests/test_proportional.py tests/test_font_build.py -q` -> 136 passed, 3 skipped.
- `git diff --check` -> passed.