### PR TITLE
Use baseline Noto palt across weights

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -79,8 +79,8 @@ FAMILIES × WEIGHTS の各組合せに対して:
   → font-baker bake: variable Noto → static TTF
                     inheritBase で designer/OFL/version を継承
                     weight だけを上書き
-  → inst を再読込し、font-baker が 2048-UPM で bake した出力から
-    palt/vpal 取得 (record はすでに active build grid 上)
+  → inst を再読込し、Noto Variable の baseline palt を active 2048-UPM
+    build grid へ scale して使う; vpal は font-baker が bake した出力から取得
   → ss09 約物を除き Noto の palt エントリを全量で焼き込み
     ss09 約物は 34% を base に焼き、66% を ss09 残差として保持
     (palt なしグリフはメトリクス維持)
@@ -161,14 +161,12 @@ palt record を持ちうるため対象に含める。
 inst に対して 4 つのサブパスを in-place で実行:
 
 1. **palt のベイク / 約物 ss09** (`proportional.make_proportional`) — palt 値は
-   font-baker が作った freshly baked inst TTF から読む。Stage 1 は
-   `output.upm = 2048` で実行済みなので、GPOS ValueRecord はすでに active
-   build grid 上にあり、このプロジェクト側では再スケールしない。同じ glyph に
-   複数の SinglePos lookup が掛かる場合 (Noto の weight-dependent
-   FeatureVariations 適用後など) は、lookup 順に placement / advance delta を
-   加算して読む。Noto の太ウェイト用 FeatureVariation は全角 `Ｍ` と `ｗ` の
-   palt record を追加するが、この 2 glyph は明示的に bake 対象から外し、
-   project 側の tracking-only な全角 Latin spacing 方針を維持する。
+   Noto Variable の baseline vendor palt から読み、Noto の 1000-UPM source
+   grid から active 2048-UPM build grid へ scale する。Noto の Thin から
+   SemiBold までは palt record が同一だが、Bold / ExtraBold では太ウェイト用
+   FeatureVariation に切り替わる。Gen Interface JP では全 output weight で
+   baseline palt の coverage と値を維持し、太ウェイトだけ kana / fullwidth
+   Latin が急に詰まらないようにする。
    XPlacement / XAdvance を LSB / advance に加算しアウトラインをシフト。
    Noto の palt エントリは
    原則として全量で焼き込むが、`PALT_FEATURE_CHARS` の約物は分割する。
@@ -493,7 +491,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 102 | UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、x-scale、bbox 除去、tracking、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
+| `test_font_build.py` | 103 | UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、baseline palt 方針、x-scale、bbox 除去、tracking、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
 | `test_proportional.py` | 37 | palt/vpal 抽出、SinglePos lookup の加算読み取り、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal helper coverage + base/residual 分割 + optional squeeze helper、ss09 生成 + shaping |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -79,8 +79,8 @@ For each (family, weight) in FAMILIES × WEIGHTS:
   → font-baker bake: variable Noto → static TTF
                     inheritBase passes designer/OFL/version
                     through; only weight is stamped
-  → reload inst, read palt/vpal from font-baker's 2048-UPM baked output
-    (records are already on the active build grid)
+  → reload inst, read baseline palt from Noto Variable and scale it to the
+    active 2048-UPM build grid; read vpal from font-baker's baked output
   → bake Noto palt at full strength except ss09 yakumono,
     whose palt is split into a 34% baked base + 66% ss09 residual
     (glyphs without palt keep metrics)
@@ -161,15 +161,12 @@ carry palt records.
 Four sub-passes, all in-place on the inst:
 
 1. **palt baking / yakumono ss09** (`proportional.make_proportional`) — palt values are
-   read from the freshly baked inst TTF produced by font-baker. Because
-   Stage 1 already runs with `output.upm = 2048`, the GPOS ValueRecords are
-   on the active build grid and are not scaled again by this project. When
-   a feature contains multiple SinglePos lookups for the same glyph (for
-   example after Noto's weight-dependent FeatureVariations are applied),
-   their placement / advance deltas are accumulated in lookup order. Noto's
-   heavy-weight FeatureVariation adds palt records for fullwidth `Ｍ` and `ｗ`;
-   those two glyphs are explicitly removed from the bake set so they keep the
-   project's tracking-only fullwidth Latin spacing policy.
+   read from Noto Variable's baseline vendor palt, then scaled from Noto's
+   1000-UPM source grid to the active 2048-UPM build grid. Noto's Thin
+   through SemiBold palt records are identical, but Bold / ExtraBold switch
+   to a heavier FeatureVariation set; Gen Interface JP intentionally keeps
+   the baseline palt coverage and values across every output weight so heavy
+   weights do not abruptly tighten kana / fullwidth Latin.
    XPlacement/XAdvance pairs are added to LSB / advance, outlines shifted.
    Most Noto palt entries are
    baked at full strength, but yakumono listed in `PALT_FEATURE_CHARS`
@@ -509,7 +506,7 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 102 | UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, x-scale, bbox strip, tracking, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
+| `test_font_build.py` | 103 | UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, baseline palt policy, x-scale, bbox strip, tracking, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
 | `test_proportional.py` | 37 | palt/vpal extraction, cumulative SinglePos lookup reading, glyph translation, GPOS feature removal, runtime-palt/vpal helper coverage + base/residual split + optional squeeze helper, ss09 construction + shaping |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -168,10 +168,10 @@ PALT_FEATURE_CHARS = (
 # remaining palt delta through ss09 alternates.
 RUNTIME_PALT_BASE_SCALE = 0.34
 
-# Noto's weight-dependent palt FeatureVariation adds these two fullwidth Latin
-# glyphs only for heavy weights. In this UI family they should stay on the
-# tracking-only path instead of suddenly tightening in Bold / ExtraBold.
-PALT_EXCLUDE_CHARS = ("Ｍ", "ｗ")
+# Noto's weight-dependent palt FeatureVariation changes Bold/ExtraBold spacing
+# abruptly. Use the baseline vendor palt as the source of truth for every
+# weight, matching the historical Gen Interface JP spacing policy.
+_baseline_palt_cache: dict[str, tuple[int, int]] | None = None
 
 # Vertical yakumono glyphs also live under the ss09 "約物半角" feature. The
 # build uses Noto's vpal records as source data but bakes them into .ss09 vmtx
@@ -906,10 +906,16 @@ def _feature_adjustments_for_codepoints(
     }
 
 
-def _remove_palt_exclusions(font: TTFont, adjustments: dict[str, tuple[int, int]]) -> None:
-    """Drop project-owned palt exclusions from a mutable adjustment map."""
-    for glyph_name in _glyphs_for_codepoints(font, PALT_EXCLUDE_CHARS):
-        adjustments.pop(glyph_name, None)
+def _get_baseline_palt() -> dict[str, tuple[int, int]]:
+    """Read Noto's baseline palt feature once and reuse it for every weight."""
+    global _baseline_palt_cache
+    if _baseline_palt_cache is None:
+        source = TTFont(NOTO_VARIABLE)
+        try:
+            _baseline_palt_cache = dict(_read_palt(source))
+        finally:
+            source.close()
+    return _baseline_palt_cache
 
 
 def _runtime_palt_residual_adjustment(
@@ -1258,13 +1264,15 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     split_source = _split_cmap_codepoint_glyph(font, 0x30FB, "uni30FB")
     ss09_punctuation_glyphs = _glyphs_for_codepoints(font, ss09_punctuation_chars)
 
-    # Read palt/vpal from the freshly baked 2048-UPM inst. font-baker owns the
-    # variable instantiation and UPM conversion here, so proportional records
-    # are already on the active build grid.
-    palt_data = dict(_read_palt(font))
+    # Use Noto's baseline palt for every weight. Thin through SemiBold carry
+    # identical vendor palt values, while Bold / ExtraBold switch to a heavier
+    # FeatureVariation set that looks too tight for this UI family.
+    palt_data = _scale_design_adjustments(dict(_get_baseline_palt()), font_upm)
     if split_source in palt_data:
         palt_data["uni30FB"] = palt_data[split_source]
-    _remove_palt_exclusions(font, palt_data)
+    # Read vpal from the freshly baked 2048-UPM inst. font-baker owns the
+    # variable instantiation and UPM conversion here, so vertical records are
+    # already on the active build grid.
     vpal_data = dict(_read_vpal(font))
     if split_source in vpal_data:
         vpal_data["uni30FB"] = vpal_data[split_source]

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -25,6 +25,7 @@ from font.build import (
     _final_output_metadata,
     _get_cjk_glyphs,
     _get_vert_alternates,
+    _get_baseline_palt,
     _glyphs_for_codepoints,
     _glyph_codepoint,
     _is_cjk_codepoint,
@@ -33,7 +34,6 @@ from font.build import (
     _project_version,
     _retarget_feature_adjustments,
     _retarget_named_adjustments,
-    _remove_palt_exclusions,
     _runtime_palt_residual_adjustment,
     _scale_design_adjustment,
     _scale_design_adjustments,
@@ -51,7 +51,6 @@ from font.build import (
     INTER_VARIABLE_EDGE_WEIGHTS,
     NOTO_VARIABLE,
     NORMAL_PALT_SPACE_ADJUSTMENTS,
-    PALT_EXCLUDE_CHARS,
     PALT_FEATURE_CHARS,
     PALT_SPACE_ADJUSTMENTS,
     RUNTIME_PALT_BASE_SCALE,
@@ -809,22 +808,15 @@ class TestPaltSymbolPolicy:
         assert "uniFF57" not in palt  # ｗ
         assert "uniFF40" not in palt  # ｀
 
-    def test_fullwidth_m_w_stay_on_tracking_only_path(self):
-        assert PALT_EXCLUDE_CHARS == ("Ｍ", "ｗ")
+    def test_baseline_palt_is_shared_across_weights(self):
+        palt = _get_baseline_palt()
 
-        font = TTFont(NOTO_VARIABLE)
-        try:
-            palt = {
-                "uniFF2D": (-142, -326),
-                "uniFF57": (-151, -302),
-                "uniFF21": (-107, -212),
-            }
-
-            _remove_palt_exclusions(font, palt)
-        finally:
-            font.close()
-
-        assert palt == {"uniFF21": (-107, -212)}
+        assert "uniFF21" in palt  # Ａ
+        assert "uni3042" in palt  # あ
+        assert "uniFF2D" not in palt  # Ｍ
+        assert "uniFF57" not in palt  # ｗ
+        assert "uni306C" not in palt  # ぬ
+        assert "uni306F" not in palt  # は
 
     def test_yakumono_uses_ss09_targets_not_spacing(self):
         assert len(PALT_FEATURE_CHARS) == 48


### PR DESCRIPTION
## Summary

- restore the historical spacing policy by reading Noto Variable baseline `palt` once and reusing it across every output weight
- remove the glyph-specific palt exclusion path for heavy weights
- update architecture docs and regression coverage for the baseline palt policy

## Validation

- `PYTHONPATH=src /private/tmp/gen-interface-jp-fb-latest-venv/bin/python -m pytest tests/test_font_build.py -q` -> 103 passed
- `git diff --check origin/main..HEAD` -> passed

## Notes

This is a follow-up to #22. It keeps Bold / ExtraBold from switching to Noto Sans JP heavy-weight FeatureVariation palt values, which caused abrupt kana and fullwidth Latin tightening compared with v0.5.0.
