### PR TITLE
Build TTF matrix in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PYTHONPATH := src
 PY := PYTHONPATH=$(PYTHONPATH) $(PYTHON)
 
 WEBFONT_JOBS ?= 8
+FONT_JOBS ?= 16
 NPM_PACKAGE_DIR := dist/release/npm
 NPM_PUBLISH_FLAGS ?= --access public
 NPM_CACHE ?= $(CURDIR)/.npm-cache
@@ -27,10 +28,10 @@ all: release
 # Outputs land under dist/ttf/<Family>/. Web delivery goes through
 # `make webfont` (subset WOFF2 served via unicode-range), not full WOFF2.
 font:
-	$(PY) -m font.build
+	$(PY) -m font.build --jobs $(FONT_JOBS)
 
 verify-edge-instances:
-	$(PY) -m font.build all Thin ExtraBold
+	$(PY) -m font.build --jobs $(FONT_JOBS) all Thin ExtraBold
 	$(PY) -m font.verify_edge_instances
 
 

--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -108,6 +108,11 @@ FAMILIES × WEIGHTS の各組合せに対して:
     約物挙動が残るよう、final cmap / glyph 名に対して yakumono-only ss09 を生成
 ```
 
+`font.build --jobs N` は family/weight ごとに独立した job を並列実行する。
+Makefile は `FONT_JOBS ?= 16` を使うため、`make font` はデフォルトで
+2 ファミリー × 8 ウェイトの TTF matrix を並列ビルドする。parallel job 同士が
+同じ path を共有しないよう、Noto intermediate は family と weight ごとに分ける。
+
 ### 2. Web 用サブセット化 (`webfont.build`)
 
 ```
@@ -459,7 +464,8 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
   が必要なテスト用に Noto Variable のサブセットをセッション単位でキャッシュ;
   全グリフ走査が必要な mutation テスト用には `FontBuilder` で組み立てた
   最小 TrueType (Noto 17000 グリフを毎回触るのは無駄)。
-- **`tests/test_font_build.py`** — UPM 設計値換算、project-version metadata
+- **`tests/test_font_build.py`** — CLI build selection / parallel intermediate
+  path separation、UPM 設計値換算、project-version metadata
   forwarding
   (`SOURCE_UPM = 1000`, `TARGET_UPM = 2048`)、`_glyph_codepoint`, `_is_kana_or_punct`,
   `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
@@ -491,7 +497,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 103 | UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、baseline palt 方針、x-scale、bbox 除去、tracking、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
+| `test_font_build.py` | 110 | CLI build selection / parallel intermediate path separation、UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、baseline palt 方針、x-scale、bbox 除去、tracking、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
 | `test_proportional.py` | 37 | palt/vpal 抽出、SinglePos lookup の加算読み取り、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal helper coverage + base/residual 分割 + optional squeeze helper、ss09 生成 + shaping |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |
@@ -500,7 +506,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
 
 | コマンド | 用途 |
 |---|---|
-| `make font` | 全ファミリー × 全ウェイトの TTF を生成 |
+| `make font` | `FONT_JOBS ?= 16` で全ファミリー × 全ウェイトの TTF を生成 |
 | `make verify-edge-instances` | Thin / ExtraBold をビルドし、InterVariable edge instance と final TTF metadata を検証 |
 | `make webfont` | unicode-range サブセットを生成 (`font` 依存) |
 | `make release` | GitHub zip + npm + Pages パッケージ生成 (`webfont` 依存) |
@@ -510,7 +516,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
 | `make site` | デモサイトのビルド (`site/dist/` がそのまま GitHub Pages artifact) |
 | `make serve` | サイトのローカル Vite 開発サーバー |
 | `make clean` | `dist/` と `site/dist/` を削除 |
-| `python3 -m font.build [family] [weight ...]` | 部分ビルド (例: `normal Regular`) |
+| `python3 -m font.build --jobs 16 [family] [weight ...]` | 全 matrix または部分ビルドを並列実行 (例: `normal Regular`) |
 | `python3 -m font.verify_edge_instances` | ビルド済み Thin / ExtraBold edge output を検証 |
 | `python3 -m pytest` | テスト実行 |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -109,6 +109,11 @@ For each (family, weight) in FAMILIES × WEIGHTS:
     horizontal and vertical glyphs
 ```
 
+`font.build --jobs N` dispatches independent family/weight jobs in parallel.
+The Makefile uses `FONT_JOBS ?= 16`, so `make font` builds the full
+2-family × 8-weight TTF matrix concurrently by default. Intermediate Noto
+files are scoped by family and weight to keep parallel jobs from sharing paths.
+
 ### 2. Subset for the Web (`webfont.build`)
 
 ```
@@ -474,7 +479,8 @@ Tests live under `tests/`, split by surface:
   Noto Variable for tests that need real palt / vpal / vert / cmap data, and a
   hand-built minimal TrueType (`FontBuilder`) for whole-font mutation
   tests where 17 000 Noto glyphs would be wasteful.
-- **`tests/test_font_build.py`** — UPM design-unit scaling, project-version
+- **`tests/test_font_build.py`** — CLI build selection / parallel intermediate
+  path separation, UPM design-unit scaling, project-version
   metadata forwarding
   (`SOURCE_UPM = 1000`, `TARGET_UPM = 2048`), `_glyph_codepoint`, `_is_kana_or_punct`,
   `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
@@ -506,7 +512,7 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 103 | UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, baseline palt policy, x-scale, bbox strip, tracking, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
+| `test_font_build.py` | 110 | CLI build selection and parallel intermediate path separation, UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, baseline palt policy, x-scale, bbox strip, tracking, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
 | `test_proportional.py` | 37 | palt/vpal extraction, cumulative SinglePos lookup reading, glyph translation, GPOS feature removal, runtime-palt/vpal helper coverage + base/residual split + optional squeeze helper, ss09 construction + shaping |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |
@@ -515,7 +521,7 @@ Tests live under `tests/`, split by surface:
 
 | Command | Purpose |
 |---|---|
-| `make font` | Build TTF for both families × all weights |
+| `make font` | Build TTF for both families × all weights with `FONT_JOBS ?= 16` |
 | `make verify-edge-instances` | Build Thin / ExtraBold and verify InterVariable edge instance + final TTF metadata |
 | `make webfont` | Build unicode-range subsets (depends on `font`) |
 | `make release` | Build GitHub zips + npm + Pages package (depends on `webfont`) |
@@ -525,7 +531,7 @@ Tests live under `tests/`, split by surface:
 | `make site` | Build the demo site (`site/dist/` doubles as the GitHub Pages artifact) |
 | `make serve` | Local Vite dev server for the site |
 | `make clean` | Remove `dist/` and `site/dist/` |
-| `python3 -m font.build [family] [weight ...]` | Build a slice (e.g. `normal Regular`) |
+| `python3 -m font.build --jobs 16 [family] [weight ...]` | Build the full matrix or a slice in parallel (e.g. `normal Regular`) |
 | `python3 -m font.verify_edge_instances` | Verify built Thin / ExtraBold edge outputs |
 | `python3 -m pytest` | Run the test suite |
 

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -22,11 +22,14 @@ TTF outputs — see src/webfont/.
 
 from __future__ import annotations
 
+import argparse
 import copy
 from contextlib import contextmanager
 import logging
 import os
+import subprocess
 import sys
+import time
 
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.reorderGlyphs import reorderGlyphs
@@ -1172,6 +1175,21 @@ def _normalize_layout_coverage_order(font_path: str) -> None:
 # Pipeline
 # ---------------------------------------------------------------------------
 
+def _intermediate_paths(family: dict, weight_name: str) -> tuple[str, str]:
+    """Return family-scoped intermediates so parallel builds never collide."""
+    prefix = family["folderPrefix"]
+    return (
+        os.path.join(INTERMEDIATE, f"{prefix}-{weight_name}-NotoSansJP-Inst.ttf"),
+        os.path.join(INTERMEDIATE, f"{prefix}-{weight_name}-NotoSansJP-Prop.ttf"),
+    )
+
+
+def _final_ttf_path(family: dict, weight_name: str) -> str:
+    family_name = family["familyName"]
+    file_name = f"{family['folderPrefix']}-{weight_name}"
+    return os.path.join(DIST_TTF, family_name, f"{file_name}.ttf")
+
+
 def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -> dict:
     """Build a single weight of a Gen Interface JP family.
 
@@ -1180,8 +1198,8 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     1. **Bake** Noto variable → static TTF at the chosen wght axis location,
        passed through font-baker with ``metadataMode: inheritBase`` and
        ``output.upm = 2048`` so the Noto identity records survive into the inst.
-    2. **Proportionalise** the inst — read palt/vpal from that 2048-UPM
-       baked output, bake those adjustments
+    2. **Proportionalise** the inst — read baseline palt from Noto Variable,
+       read vpal from the 2048-UPM baked output, bake those adjustments
        into hmtx except selected ss09 yakumono, apply tracking,
        apply per-glyph sidebearing tweaks from ``family["glyphSpacing"]``,
        strip extreme bbox glyphs, optionally apply x-scale.
@@ -1201,8 +1219,7 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     if not os.path.isfile(inter_path):
         raise FileNotFoundError(f"Inter font not found: {inter_path}")
 
-    inst_path = os.path.join(INTERMEDIATE, f"NotoSansJP-{weight_name}-Inst.ttf")
-    prop_path = os.path.join(INTERMEDIATE, f"NotoSansJP-{weight_name}-Prop.ttf")
+    inst_path, prop_path = _intermediate_paths(family, weight_name)
 
     # ── Step 1: Bake Noto variable → static (font-baker, base-only) ──
     # `metadataMode: inheritBase` keeps Noto's name/OS2 records intact so
@@ -1326,9 +1343,7 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
 
     # ── Step 3: Merge Inter + proportional Noto ──
     family_name = family["familyName"]
-    file_name = f"{family['folderPrefix']}-{weight_name}"
-    ttf_dir = os.path.join(DIST_TTF, family_name)
-    final_path = os.path.join(ttf_dir, f"{file_name}.ttf")
+    final_path = _final_ttf_path(family, weight_name)
     print(f"    [3/3] Merging {family['interPrefix']} + proportional Noto...")
     baseline_offset = _scale_design_unit(BASELINE_OFFSET, TARGET_UPM)
     merge_config = {
@@ -1377,12 +1392,195 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
 # CLI entrypoint
 # ---------------------------------------------------------------------------
 
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="python -m font.build",
+        description="Build Gen Interface JP TTFs.",
+    )
+    parser.add_argument(
+        "selection",
+        nargs="*",
+        help=(
+            "Optional family key followed by weight filters. Examples: "
+            "normal Regular Bold, all 400 700"
+        ),
+    )
+    parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=int(os.environ.get("FONT_BUILD_JOBS", "1")),
+        help="Number of parallel family/weight jobs. Use 16 for the full TTF matrix.",
+    )
+    args = parser.parse_args(argv)
+    if args.jobs < 1:
+        parser.error("--jobs must be 1 or greater")
+    return args
+
+
+def _select_build_matrix(selection: list[str]) -> tuple[list[str], list[tuple[int, str, int]]]:
+    families_to_build = list(FAMILIES.keys())
+    weights_to_build = WEIGHTS
+
+    args = list(selection)
+    if args:
+        first = args[0].lower()
+        if first in FAMILIES or first == "all":
+            if first != "all":
+                families_to_build = [first]
+            args = args[1:]
+
+        if args:
+            requested = {s.strip() for s in args}
+            weights_to_build = [
+                (n, name, nw) for n, name, nw in WEIGHTS
+                if name in requested or str(n) in requested
+            ]
+            if not weights_to_build:
+                raise ValueError(
+                    f"No matching weights. Available: {[n for _, n, _ in WEIGHTS]}"
+                )
+
+    return families_to_build, weights_to_build
+
+
+def _build_task(task: tuple[str, int, str, int, int, int]) -> dict:
+    family_key, weight_num, weight_name, noto_wght, index, total = task
+    family = FAMILIES[family_key]
+    family_name = family["familyName"]
+    print(f"\n[{index}/{total}] {family_name} {weight_name} ({weight_num})...")
+    manifest = build_one(family, weight_num, weight_name, noto_wght)
+    return {
+        **manifest,
+        "familyKey": family_key,
+        "familyName": family_name,
+        "weightNum": weight_num,
+        "weightName": weight_name,
+        "index": index,
+        "total": total,
+    }
+
+
+def _task_manifest(task: tuple[str, int, str, int, int, int]) -> dict:
+    family_key, weight_num, weight_name, _noto_wght, index, total = task
+    family = FAMILIES[family_key]
+    return {
+        "fontPath": _final_ttf_path(family, weight_name),
+        "familyKey": family_key,
+        "familyName": family["familyName"],
+        "weightNum": weight_num,
+        "weightName": weight_name,
+        "index": index,
+        "total": total,
+    }
+
+
+def _child_pythonpath() -> str:
+    src_path = os.path.join(ROOT, "src")
+    existing = os.environ.get("PYTHONPATH")
+    if existing:
+        paths = existing.split(os.pathsep)
+        if src_path in paths:
+            return existing
+        return os.pathsep.join([src_path, existing])
+    return src_path
+
+
+def _parallel_task_command(task: tuple[str, int, str, int, int, int]) -> list[str]:
+    family_key, _weight_num, weight_name, _noto_wght, _index, _total = task
+    return [
+        sys.executable,
+        "-m",
+        "font.build",
+        "--jobs",
+        "1",
+        family_key,
+        weight_name,
+    ]
+
+
+def _run_parallel_build_tasks(
+    tasks: list[tuple[str, int, str, int, int, int]],
+    jobs: int,
+) -> list[dict]:
+    worker_count = min(jobs, len(tasks))
+    print(
+        f"\nRunning {len(tasks)} TTF build job(s) with {worker_count} worker(s).",
+        flush=True,
+    )
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = _child_pythonpath()
+    pending = list(tasks)
+    active: list[tuple[tuple[str, int, str, int, int, int], subprocess.Popen]] = []
+    results: list[dict] = []
+
+    try:
+        while pending or active:
+            while pending and len(active) < worker_count:
+                task = pending.pop(0)
+                manifest = _task_manifest(task)
+                print(
+                    f"  -> starting [{manifest['index']}/{manifest['total']}] "
+                    f"{manifest['familyName']} {manifest['weightName']}",
+                    flush=True,
+                )
+                process = subprocess.Popen(
+                    _parallel_task_command(task),
+                    cwd=ROOT,
+                    env=env,
+                )
+                active.append((task, process))
+
+            for task, process in list(active):
+                returncode = process.poll()
+                if returncode is None:
+                    continue
+
+                active.remove((task, process))
+                command = _parallel_task_command(task)
+                if returncode != 0:
+                    for _active_task, active_process in active:
+                        active_process.terminate()
+                    for _active_task, active_process in active:
+                        active_process.wait()
+                    raise subprocess.CalledProcessError(returncode, command)
+
+                manifest = _task_manifest(task)
+                results.append(manifest)
+                print(
+                    f"  -> done [{manifest['index']}/{manifest['total']}] "
+                    f"{manifest['fontPath']}",
+                    flush=True,
+                )
+
+            if pending or active:
+                time.sleep(0.5)
+    except KeyboardInterrupt:
+        for _task, process in active:
+            process.terminate()
+        raise
+
+    return sorted(results, key=lambda manifest: manifest["index"])
+
+
+def _run_build_tasks(
+    tasks: list[tuple[str, int, str, int, int, int]],
+    jobs: int,
+) -> list[dict]:
+    if jobs == 1 or len(tasks) <= 1:
+        return [_build_task(task) for task in tasks]
+
+    return _run_parallel_build_tasks(tasks, jobs)
+
+
 def main():
     """Drive the family/weight matrix from argv.
 
     Usage::
 
         python -m font.build                       # everything
+        python -m font.build --jobs 16             # everything in parallel
         python -m font.build normal                # all weights of one family
         python -m font.build normal Regular Bold   # a slice
         python -m font.build all 400 700           # by weight, both families
@@ -1393,46 +1591,36 @@ def main():
     either by name (``Regular``) or by usWeightClass (``400``).
     """
     os.makedirs(DIST_TTF, exist_ok=True)
+    cli_args = _parse_args(sys.argv[1:])
+    try:
+        families_to_build, weights_to_build = _select_build_matrix(cli_args.selection)
+    except ValueError as exc:
+        print(exc)
+        sys.exit(1)
 
-    # Parse arguments: [family] [weight ...]
-    # family: normal, display, all (default: all)
-    args = sys.argv[1:]
-
-    families_to_build = list(FAMILIES.keys())
-    weights_to_build = WEIGHTS
-
-    if args:
-        # First arg might be a family name
-        first = args[0].lower()
-        if first in FAMILIES or first == "all":
-            if first != "all":
-                families_to_build = [first]
-            args = args[1:]
-
-        # Remaining args are weight filters
-        if args:
-            requested = {s.strip() for s in args}
-            weights_to_build = [
-                (n, name, nw) for n, name, nw in WEIGHTS
-                if name in requested or str(n) in requested
-            ]
-            if not weights_to_build:
-                print(f"No matching weights. Available: {[n for _, n, _ in WEIGHTS]}")
-                sys.exit(1)
+    tasks: list[tuple[str, int, str, int, int, int]] = []
+    total_tasks = len(families_to_build) * len(weights_to_build)
+    index = 1
+    for family_key in families_to_build:
+        for weight_num, weight_name, noto_wght in weights_to_build:
+            tasks.append((family_key, weight_num, weight_name, noto_wght, index, total_tasks))
+            index += 1
 
     for family_key in families_to_build:
         family = FAMILIES[family_key]
         family_name = family["familyName"]
-        total = len(weights_to_build)
         print(f"\n{'='*60}")
         print(f"  {family_name}  (tracking +{family['tracking']})")
         print(f"{'='*60}")
 
-        for i, (weight_num, weight_name, noto_wght) in enumerate(weights_to_build, 1):
-            print(f"\n[{i}/{total}] {family_name} {weight_name} ({weight_num})...")
-            manifest = build_one(family, weight_num, weight_name, noto_wght)
+    manifests = _run_build_tasks(tasks, cli_args.jobs)
+    if cli_args.jobs == 1:
+        for manifest in manifests:
             print(f"  -> {manifest['fontPath']}")
 
+    for family_key in families_to_build:
+        total = sum(1 for manifest in manifests if manifest["familyKey"] == family_key)
+        family_name = FAMILIES[family_key]["familyName"]
         print(f"\n  Done. {total} weight(s) of {family_name}")
 
     print(f"\nAll done. Output in {DIST_TTF}")

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -22,15 +22,19 @@ from font.build import (
     _EXTREME_YMIN,
     _VERTICAL_REPEAT_MARK_CODEPOINTS,
     _feature_adjustments_for_codepoints,
+    _final_ttf_path,
     _final_output_metadata,
     _get_cjk_glyphs,
     _get_vert_alternates,
     _get_baseline_palt,
     _glyphs_for_codepoints,
     _glyph_codepoint,
+    _intermediate_paths,
     _is_cjk_codepoint,
     _is_kana_letter,
     _is_kana_or_punct,
+    _parallel_task_command,
+    _parse_args,
     _project_version,
     _retarget_feature_adjustments,
     _retarget_named_adjustments,
@@ -40,6 +44,7 @@ from font.build import (
     _scale_feature_adjustments,
     _scale_design_unit,
     _scale_glyph_spacing,
+    _select_build_matrix,
     _split_cmap_codepoint_glyph,
     _strip_extreme_glyphs,
     _build_inter_variable_instance,
@@ -107,6 +112,61 @@ def _layout_feature_tags(font: TTFont, table_tag: str) -> set[str]:
     if feature_list is None:
         return set()
     return {record.FeatureTag for record in feature_list.FeatureRecord}
+
+
+# ---------------------------------------------------------------------------
+# CLI build selection
+# ---------------------------------------------------------------------------
+
+class TestBuildCli:
+    """The CLI keeps legacy positional selection while adding parallel jobs."""
+
+    def test_parse_jobs_with_family_and_weight(self):
+        args = _parse_args(["--jobs", "4", "normal", "Regular"])
+
+        assert args.jobs == 4
+        assert args.selection == ["normal", "Regular"]
+
+    def test_selects_family_and_named_weight(self):
+        families, weights = _select_build_matrix(["display", "Bold"])
+
+        assert families == ["display"]
+        assert weights == [(700, "Bold", 800)]
+
+    def test_selects_weight_class_across_all_families(self):
+        families, weights = _select_build_matrix(["all", "400", "700"])
+
+        assert families == ["normal", "display"]
+        assert weights == [(400, "Regular", 465), (700, "Bold", 800)]
+
+    def test_rejects_zero_jobs(self):
+        with pytest.raises(SystemExit):
+            _parse_args(["--jobs", "0"])
+
+    def test_parallel_intermediates_are_family_scoped(self):
+        normal_inst, normal_prop = _intermediate_paths(FAMILIES["normal"], "Bold")
+        display_inst, display_prop = _intermediate_paths(FAMILIES["display"], "Bold")
+
+        assert normal_inst != display_inst
+        assert normal_prop != display_prop
+        assert "GenInterfaceJP-Bold" in normal_inst
+        assert "GenInterfaceJPDisplay-Bold" in display_inst
+
+    def test_parallel_subprocess_forces_serial_child_build(self):
+        command = _parallel_task_command(("normal", 400, "Regular", 465, 1, 16))
+
+        assert command[1:5] == ["-m", "font.build", "--jobs", "1"]
+        assert command[-2:] == ["normal", "Regular"]
+
+    def test_final_ttf_path_is_family_scoped(self):
+        normal_path = _final_ttf_path(FAMILIES["normal"], "Regular")
+        display_path = _final_ttf_path(FAMILIES["display"], "Regular")
+
+        assert normal_path != display_path
+        assert normal_path.endswith("Gen Interface JP/GenInterfaceJP-Regular.ttf")
+        assert display_path.endswith(
+            "Gen Interface JP Display/GenInterfaceJPDisplay-Regular.ttf"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add `--jobs` support to `font.build` and run each family/weight TTF job in its own serial child process
- default `make font` and `make verify-edge-instances` to `FONT_JOBS ?= 16`
- scope Noto intermediate filenames by family and weight so parallel jobs do not share paths
- document the parallel TTF build path and cover CLI selection / path separation in tests

## Validation

- built the current serial 16-weight TTF matrix and saved it as a baseline under `/private/tmp/gen-interface-jp-ttf-baseline.tUMdvx/ttf`
- `PYTHONPATH=src /private/tmp/gen-interface-jp-fb-latest-venv/bin/python -m font.build --jobs 16` -> passed
- compared the 16 parallel-built TTFs against the serial baseline: raw `glyf`, `loca`, `cmap`, `hmtx`, `vmtx`, `GSUB`, `GPOS`, `name`, and core table bytes match; logical glyph order, cmap, hmtx/vmtx metrics, and selected head metrics also match
- `PYTHONPATH=src /private/tmp/gen-interface-jp-fb-latest-venv/bin/python -m pytest tests/test_font_build.py -q` -> 110 passed
- `PYTHONPATH=src /private/tmp/gen-interface-jp-fb-latest-venv/bin/python -m font.verify_edge_instances` -> passed
- `git diff --check` -> passed
