### PR TITLE
[codex] Scale Japanese vertical body metrics

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -249,7 +249,10 @@ advanceHeight は `SCALE` で縮小し、top sidebearing は merge 前の縦 ori
 掛けた位置から逆算する。これにより、アウトラインだけが縮小されているのに
 縦組みの仮想ボディが元の 2048 正方のまま残る状態を避ける。ASCII Latin は
 元の vertical metrics を維持し、かな / CJK / 全角 / 和文約物 / vertical-form
-alternate だけが Noto scale に追従する。
+alternate だけが Noto scale に追従する。font-baker が merge 時に Noto/base
+glyph を rename した場合は、final glyph と source glyph を共有 Unicode
+codepoint 経由で対応付け、source 側の値から計算した metric を final の
+renamed glyph に書き戻す。
 
 `output.version` は共有 helper `project_metadata.project_version()` 経由で
 `pyproject.toml` から読み、final TTF の nameID 5 と nameID 3 に
@@ -505,7 +508,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 112 | CLI build selection / parallel intermediate path separation、和文 vertical body scaling、UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、baseline palt 方針、x-scale、bbox 除去、tracking、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
+| `test_font_build.py` | 113 | CLI build selection / parallel intermediate path separation、和文 vertical body scaling、UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、baseline palt 方針、x-scale、bbox 除去、tracking、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
 | `test_proportional.py` | 37 | palt/vpal 抽出、SinglePos lookup の加算読み取り、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal helper coverage + base/residual 分割 + optional squeeze helper、ss09 生成 + shaping |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |

--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -243,6 +243,14 @@ UPM 変換ではなく光学的な CJK デザインスケールとして残し�
 Inter の cap-height と揃うように Noto を縮める — 欧文/CJK 混植で CJK を少し
 小さくして釣り合いを取る、という慣例的な配分。
 
+merge 後は和文の縦書き body metrics も再計算する。Noto 由来の `vmtx`
+advanceHeight は `SCALE` で縮小し、top sidebearing は merge 前の縦 origin に
+同じベースライン基準の transform (`originY * SCALE + BASELINE_OFFSET`) を
+掛けた位置から逆算する。これにより、アウトラインだけが縮小されているのに
+縦組みの仮想ボディが元の 2048 正方のまま残る状態を避ける。ASCII Latin は
+元の vertical metrics を維持し、かな / CJK / 全角 / 和文約物 / vertical-form
+alternate だけが Noto scale に追従する。
+
 `output.version` は共有 helper `project_metadata.project_version()` 経由で
 `pyproject.toml` から読み、final TTF の nameID 5 と nameID 3 に
 release zip / npm package / site metadata と同じ project/release version を
@@ -465,7 +473,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
   全グリフ走査が必要な mutation テスト用には `FontBuilder` で組み立てた
   最小 TrueType (Noto 17000 グリフを毎回触るのは無駄)。
 - **`tests/test_font_build.py`** — CLI build selection / parallel intermediate
-  path separation、UPM 設計値換算、project-version metadata
+  path separation、和文 vertical body scaling、UPM 設計値換算、project-version metadata
   forwarding
   (`SOURCE_UPM = 1000`, `TARGET_UPM = 2048`)、`_glyph_codepoint`, `_is_kana_or_punct`,
   `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
@@ -497,7 +505,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 110 | CLI build selection / parallel intermediate path separation、UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、baseline palt 方針、x-scale、bbox 除去、tracking、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
+| `test_font_build.py` | 112 | CLI build selection / parallel intermediate path separation、和文 vertical body scaling、UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、baseline palt 方針、x-scale、bbox 除去、tracking、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
 | `test_proportional.py` | 37 | palt/vpal 抽出、SinglePos lookup の加算読み取り、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal helper coverage + base/residual 分割 + optional squeeze helper、ss09 生成 + shaping |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -258,7 +258,9 @@ baseline-based transform (`originY * SCALE + BASELINE_OFFSET`). This keeps the
 vertical writing body from staying at the original 2048-square while the
 outline has been optically scaled down. ASCII Latin keeps its original vertical
 metrics; kana, CJK, fullwidth forms, Japanese punctuation, and vertical-form
-alternates follow the Noto scale.
+alternates follow the Noto scale. If font-baker renamed a Noto/base glyph
+during merge, the metric pass resolves the source glyph through the shared
+Unicode codepoint and writes the scaled metric back to the final renamed glyph.
 
 `output.version` is read from `pyproject.toml` via the shared
 `project_metadata.project_version()` helper, so final TTF nameID 5 and
@@ -522,7 +524,7 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 112 | CLI build selection and parallel intermediate path separation, Japanese vertical body scaling, UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, baseline palt policy, x-scale, bbox strip, tracking, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
+| `test_font_build.py` | 113 | CLI build selection and parallel intermediate path separation, Japanese vertical body scaling, UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, baseline palt policy, x-scale, bbox strip, tracking, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
 | `test_proportional.py` | 37 | palt/vpal extraction, cumulative SinglePos lookup reading, glyph translation, GPOS feature removal, runtime-palt/vpal helper coverage + base/residual split + optional squeeze helper, ss09 construction + shaping |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -251,6 +251,15 @@ lines up in width with Inter's cap-height — a
 typographic convention for Latin/CJK pairing where CJK is slightly down-scaled
 to feel proportionate.
 
+After the merge, Japanese vertical body metrics are recomputed as well:
+Noto-source `vmtx` advance heights are scaled by `SCALE`, and top sidebearings
+are derived from the pre-merge vertical origin after applying the same
+baseline-based transform (`originY * SCALE + BASELINE_OFFSET`). This keeps the
+vertical writing body from staying at the original 2048-square while the
+outline has been optically scaled down. ASCII Latin keeps its original vertical
+metrics; kana, CJK, fullwidth forms, Japanese punctuation, and vertical-form
+alternates follow the Noto scale.
+
 `output.version` is read from `pyproject.toml` via the shared
 `project_metadata.project_version()` helper, so final TTF nameID 5 and
 nameID 3 carry the same project/release version as the release zip / npm
@@ -480,7 +489,8 @@ Tests live under `tests/`, split by surface:
   hand-built minimal TrueType (`FontBuilder`) for whole-font mutation
   tests where 17 000 Noto glyphs would be wasteful.
 - **`tests/test_font_build.py`** — CLI build selection / parallel intermediate
-  path separation, UPM design-unit scaling, project-version
+  path separation, Japanese vertical body scaling, UPM design-unit scaling,
+  project-version
   metadata forwarding
   (`SOURCE_UPM = 1000`, `TARGET_UPM = 2048`), `_glyph_codepoint`, `_is_kana_or_punct`,
   `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
@@ -512,7 +522,7 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 110 | CLI build selection and parallel intermediate path separation, UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, baseline palt policy, x-scale, bbox strip, tracking, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
+| `test_font_build.py` | 112 | CLI build selection and parallel intermediate path separation, Japanese vertical body scaling, UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, baseline palt policy, x-scale, bbox strip, tracking, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
 | `test_proportional.py` | 37 | palt/vpal extraction, cumulative SinglePos lookup reading, glyph translation, GPOS feature removal, runtime-palt/vpal helper coverage + base/residual split + optional squeeze helper, ss09 construction + shaping |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -934,6 +934,22 @@ def _glyph_y_max(font: TTFont, glyph_name: str) -> int:
     return getattr(glyph, "yMax", 0) or 0
 
 
+def _source_glyphs_by_final_glyph(
+    final_font: TTFont,
+    source_font: TTFont,
+) -> dict[str, str]:
+    """Map final cmap glyphs back to source cmap glyphs by codepoint."""
+    final_cmap = final_font.getBestCmap() or {}
+    source_cmap = source_font.getBestCmap() or {}
+    source_order = set(source_font.getGlyphOrder())
+    mapping = {}
+    for cp, final_glyph in final_cmap.items():
+        source_glyph = source_cmap.get(cp)
+        if source_glyph in source_order:
+            mapping[final_glyph] = source_glyph
+    return mapping
+
+
 def _scale_vertical_body_metrics(
     font: TTFont,
     source_font: TTFont,
@@ -955,19 +971,26 @@ def _scale_vertical_body_metrics(
 
     final_order = set(font.getGlyphOrder())
     source_order = set(source_font.getGlyphOrder())
+    final_to_source = _source_glyphs_by_final_glyph(font, source_font)
     targets = glyph_names if glyph_names is not None else _vertical_body_glyphs(font)
     adjusted = 0
 
     for glyph_name in sorted(targets):
-        if glyph_name not in final_order or glyph_name not in source_order:
+        if glyph_name not in final_order:
             continue
         if glyph_name not in font["vmtx"].metrics:
             continue
-        if glyph_name not in source_font["vmtx"].metrics:
+
+        source_glyph_name = glyph_name
+        if source_glyph_name not in source_order:
+            source_glyph_name = final_to_source.get(glyph_name)
+        if source_glyph_name is None or source_glyph_name not in source_order:
+            continue
+        if source_glyph_name not in source_font["vmtx"].metrics:
             continue
 
-        source_advance, source_tsb = source_font["vmtx"][glyph_name]
-        source_origin_y = _glyph_y_max(source_font, glyph_name) + source_tsb
+        source_advance, source_tsb = source_font["vmtx"][source_glyph_name]
+        source_origin_y = _glyph_y_max(source_font, source_glyph_name) + source_tsb
         final_origin_y = round(source_origin_y * scale + baseline_offset)
         final_advance = round(source_advance * scale)
         final_tsb = final_origin_y - _glyph_y_max(font, glyph_name)

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -885,6 +885,125 @@ def _codepoints_for_entries(codepoint_entries: list | tuple | set | None) -> set
     return codepoints
 
 
+def _is_japanese_vertical_body_codepoint(cp: int) -> bool:
+    """Return True for glyphs whose vertical body should follow Noto scale."""
+    return (
+        _is_cjk_codepoint(cp)
+        or 0x3000 <= cp <= 0x303F    # CJK Symbols and Punctuation
+        or 0x3040 <= cp <= 0x309F    # Hiragana
+        or 0x30A0 <= cp <= 0x30FF    # Katakana
+        or 0x31F0 <= cp <= 0x31FF    # Katakana Phonetic Extensions
+        or 0xFE10 <= cp <= 0xFE4F    # Vertical forms / CJK compatibility forms
+        or 0xFF00 <= cp <= 0xFFEF    # Halfwidth and Fullwidth Forms
+    )
+
+
+def _vertical_body_extra_codepoints() -> set[int]:
+    """Return configured Japanese punctuation/symbol codepoints outside blocks."""
+    return _codepoints_for_entries(
+        (
+            *TRACKING_IGNORE_CODEPOINTS,
+            *PALT_FEATURE_CHARS,
+            *SS09_VERTICAL_FEATURE_CHARS,
+            *PALT_SPACE_ADJUSTMENTS.keys(),
+        )
+    )
+
+
+def _vertical_body_glyphs(font: TTFont) -> set[str]:
+    """Resolve final glyphs whose vertical advance should match Noto scale."""
+    cmap = font.getBestCmap() or {}
+    extra_codepoints = _vertical_body_extra_codepoints()
+    glyphs = {
+        glyph_name
+        for cp, glyph_name in cmap.items()
+        if _is_japanese_vertical_body_codepoint(cp) or cp in extra_codepoints
+    }
+    glyphs.update(_get_vert_alternates(font))
+    glyphs.update(SS09_VERTICAL_FEATURE_GLYPHS)
+    return glyphs
+
+
+def _glyph_y_max(font: TTFont, glyph_name: str) -> int:
+    """Return a glyph's yMax, treating empty glyphs as origin-height."""
+    glyph = font["glyf"][glyph_name]
+    if glyph.isComposite():
+        glyph.recalcBounds(font["glyf"])
+    if getattr(glyph, "numberOfContours", 0) == 0:
+        return 0
+    return getattr(glyph, "yMax", 0) or 0
+
+
+def _scale_vertical_body_metrics(
+    font: TTFont,
+    source_font: TTFont,
+    scale: float,
+    baseline_offset: int,
+    glyph_names: set[str] | None = None,
+) -> int:
+    """Scale Japanese vertical body metrics after Noto outline scaling.
+
+    font-baker scales Noto outlines and applies the baseline offset during the
+    final merge, but leaves vmtx advances/top sidebearings on the original
+    2048-UPM body. Recompute vmtx from the pre-merge Noto source origin so the
+    vertical advance box follows the same baseline-based transform as outlines.
+    """
+    if "vmtx" not in font or "vmtx" not in source_font:
+        return 0
+    if "glyf" not in font or "glyf" not in source_font:
+        return 0
+
+    final_order = set(font.getGlyphOrder())
+    source_order = set(source_font.getGlyphOrder())
+    targets = glyph_names if glyph_names is not None else _vertical_body_glyphs(font)
+    adjusted = 0
+
+    for glyph_name in sorted(targets):
+        if glyph_name not in final_order or glyph_name not in source_order:
+            continue
+        if glyph_name not in font["vmtx"].metrics:
+            continue
+        if glyph_name not in source_font["vmtx"].metrics:
+            continue
+
+        source_advance, source_tsb = source_font["vmtx"][glyph_name]
+        source_origin_y = _glyph_y_max(source_font, glyph_name) + source_tsb
+        final_origin_y = round(source_origin_y * scale + baseline_offset)
+        final_advance = round(source_advance * scale)
+        final_tsb = final_origin_y - _glyph_y_max(font, glyph_name)
+        next_metric = (final_advance, final_tsb)
+
+        if font["vmtx"][glyph_name] != next_metric:
+            font["vmtx"][glyph_name] = next_metric
+            adjusted += 1
+
+    return adjusted
+
+
+def _scale_vertical_body_metrics_after_merge(
+    final_path: str,
+    source_path: str,
+    scale: float,
+    baseline_offset: int,
+) -> int:
+    """Apply Japanese vmtx body scaling to a merged final font on disk."""
+    font = TTFont(final_path)
+    source_font = TTFont(source_path)
+    try:
+        adjusted = _scale_vertical_body_metrics(
+            font,
+            source_font,
+            scale,
+            baseline_offset,
+        )
+        if adjusted:
+            font.save(final_path)
+        return adjusted
+    finally:
+        font.close()
+        source_font.close()
+
+
 def _feature_adjustments_for_codepoints(
     font: TTFont,
     codepoint_entries: list | tuple | set | None,
@@ -1377,6 +1496,14 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     _assert_target_upm(final_font, final_path)
     final_font.close()
     _normalize_layout_coverage_order(final_path)
+    vertical_body_adjusted = _scale_vertical_body_metrics_after_merge(
+        final_path,
+        prop_path,
+        SCALE,
+        baseline_offset,
+    )
+    if vertical_body_adjusted:
+        print(f"          Vertical body metrics: {vertical_body_adjusted} glyph(s) adjusted")
     _refresh_ss09_feature_after_merge(
         final_path,
         _scale_feature_adjustments(ss09_punctuation_by_codepoint, SCALE),

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -953,6 +953,11 @@ class TestPaltSymbolPolicy:
         }
         font["vmtx"] = vmtx
 
+    def _add_glyph_copy(self, font: TTFont, source_glyph: str, new_glyph: str) -> None:
+        font.setGlyphOrder([*font.getGlyphOrder(), new_glyph])
+        font["glyf"][new_glyph] = copy.deepcopy(font["glyf"][source_glyph])
+        font["hmtx"].metrics[new_glyph] = font["hmtx"][source_glyph]
+
     def _transform_y(self, font: TTFont, scale: float, offset: int) -> None:
         glyf = font["glyf"]
         for glyph_name in font.getGlyphOrder():
@@ -999,6 +1004,37 @@ class TestPaltSymbolPolicy:
         assert final["vmtx"]["uni3042"] == (800, 80)
         assert final["vmtx"]["uni4E00"] == (800, 96)
         assert final["vmtx"]["uni3001"] == (800, 80)
+        assert final["vmtx"]["A"] == (1000, 100)
+
+    def test_vertical_body_metrics_retargets_renamed_final_glyph_by_codepoint(self, synthetic_ttf):
+        source = copy.deepcopy(synthetic_ttf)
+        final = copy.deepcopy(synthetic_ttf)
+        self._add_glyph_copy(source, "A", "uni2035")
+        self._add_glyph_copy(final, "A", "uni2035.orig")
+        for table in source["cmap"].tables:
+            table.cmap[0xFF40] = "uni2035"
+        for table in final["cmap"].tables:
+            table.cmap[0xFF40] = "uni2035.orig"
+        self._add_vmtx(source, {"A": (1000, 100), "uni2035": (1000, 100)})
+        self._add_vmtx(final, {"A": (1000, 100), "uni2035.orig": (1000, 100)})
+        self._transform_y(final, scale=0.8, offset=20)
+
+        adjusted = _scale_vertical_body_metrics(
+            final,
+            source,
+            scale=0.8,
+            baseline_offset=20,
+        )
+
+        assert adjusted >= 1
+        assert "uni2035.orig" not in source.getGlyphOrder()
+        source_origin_y = source["glyf"]["uni2035"].yMax + source["vmtx"]["uni2035"][1]
+        final_origin_y = round(source_origin_y * 0.8 + 20)
+        expected_metric = (
+            round(source["vmtx"]["uni2035"][0] * 0.8),
+            final_origin_y - final["glyf"]["uni2035.orig"].yMax,
+        )
+        assert final["vmtx"]["uni2035.orig"] == expected_metric
         assert final["vmtx"]["A"] == (1000, 100)
 
     def test_scales_final_runtime_feature_adjustments_by_optical_scale(self):

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -12,7 +12,7 @@ import re
 from pathlib import Path
 
 import pytest
-from fontTools.ttLib import TTFont
+from fontTools.ttLib import TTFont, newTable
 
 from font.build import (
     _apply_glyph_spacing,
@@ -44,9 +44,11 @@ from font.build import (
     _scale_feature_adjustments,
     _scale_design_unit,
     _scale_glyph_spacing,
+    _scale_vertical_body_metrics,
     _select_build_matrix,
     _split_cmap_codepoint_glyph,
     _strip_extreme_glyphs,
+    _vertical_body_glyphs,
     _build_inter_variable_instance,
     _default_inter_static_path,
     _inter_source_path,
@@ -942,6 +944,62 @@ class TestPaltSymbolPolicy:
         }
 
         assert expected_glyphs <= set(vpal)
+
+    def _add_vmtx(self, font: TTFont, metrics: dict[str, tuple[int, int]]) -> None:
+        vmtx = newTable("vmtx")
+        vmtx.metrics = {
+            glyph_name: metrics.get(glyph_name, (1000, 100))
+            for glyph_name in font.getGlyphOrder()
+        }
+        font["vmtx"] = vmtx
+
+    def _transform_y(self, font: TTFont, scale: float, offset: int) -> None:
+        glyf = font["glyf"]
+        for glyph_name in font.getGlyphOrder():
+            glyph = glyf[glyph_name]
+            if glyph.isComposite():
+                for component in glyph.components:
+                    component.y = round(component.y * scale + offset)
+                continue
+            if glyph.numberOfContours <= 0:
+                continue
+            for i, (x, y) in enumerate(glyph.coordinates):
+                glyph.coordinates[i] = (x, round(y * scale + offset))
+            glyph.recalcBounds(glyf)
+
+    def test_vertical_body_glyphs_include_japanese_not_latin(self, synthetic_ttf):
+        glyphs = _vertical_body_glyphs(synthetic_ttf)
+
+        assert "uni3042" in glyphs
+        assert "uni4E00" in glyphs
+        assert "uni3001" in glyphs
+        assert "A" not in glyphs
+
+    def test_vertical_body_metrics_scale_advance_and_origin(self, synthetic_ttf):
+        source = synthetic_ttf
+        final = copy.deepcopy(synthetic_ttf)
+        metrics = {
+            "A": (1000, 100),
+            "uni3042": (1000, 100),
+            "uni4E00": (1000, 120),
+            "uni3001": (1000, 100),
+        }
+        self._add_vmtx(source, metrics)
+        self._add_vmtx(final, metrics)
+        self._transform_y(final, scale=0.8, offset=20)
+
+        adjusted = _scale_vertical_body_metrics(
+            final,
+            source,
+            scale=0.8,
+            baseline_offset=20,
+        )
+
+        assert adjusted >= 3
+        assert final["vmtx"]["uni3042"] == (800, 80)
+        assert final["vmtx"]["uni4E00"] == (800, 96)
+        assert final["vmtx"]["uni3001"] == (800, 80)
+        assert final["vmtx"]["A"] == (1000, 100)
 
     def test_scales_final_runtime_feature_adjustments_by_optical_scale(self):
         adjustments = {


### PR DESCRIPTION
## Summary

- Recompute Japanese vertical body metrics after the final font-baker merge so CJK vertical advance follows the same optical scale used for the Noto outlines.
- Keep Latin vertical metrics unchanged while applying the scaled body to kana, CJK, fullwidth, punctuation, and vertical-form glyphs.
- Document the vertical body metric policy and add regression coverage for glyph targeting and metric recomputation.

## Why

Noto-sourced Japanese outlines are scaled during the merge, but their default vertical advance box remained on the original 2048-unit body. In vertical writing this left extra top/bottom margin around Japanese glyphs. The new pass derives the final vertical origin from the pre-merge Noto source and applies the same scale and baseline offset as the outline transform.

## Validation

- `PYTHONPATH=src /private/tmp/gen-interface-jp-fb-latest-venv/bin/python -m pytest tests/test_font_build.py -q` -> 112 passed
- `PYTHONPATH=src /private/tmp/gen-interface-jp-fb-latest-venv/bin/python -m font.build --jobs 16` -> passed
- Compared all 16 current TTFs against the previous baseline: glyph order, cmap, hmtx, glyf/loca, GSUB/GPOS, and core raw tables were unchanged; expected changes were limited to Japanese `vmtx` records and derived `vhea.minBottomSideBearing` values.