### PR TITLE
[codex] Adjust vertical writing policy

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -90,7 +90,7 @@ FAMILIES × WEIGHTS の各組合せに対して:
   → _apply_tracking で advance を広げ LSB を半分シフト
     ただし family["trackingIgnore"] の連続・隙間なし記号は除外
   → normal family では Inter merge 前の Noto 中間 font に対し、
-    和文縦組み glyph の vmtx advance に +10 設計 units を加える;
+    和文縦組み glyph の vmtx advance に +9 設計 units を加える;
     Display は +0 のまま
   → _apply_glyph_spacing で family["glyphSpacing"] の個別調整を適用
   → _strip_extreme_glyphs で縦組み用繰り返し記号 〱-〵 を無効化

--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -26,7 +26,7 @@ Gen Interface JP はフォントビルドパイプライン (アプリ/UI なし
         │             ↓                                   │
         │   [2/3] Proportionalise — proportional.py       │
         │      palt → hmtx + 約物 ss09                    │
-        │         tracking (連続記号は除外)              │
+        │         tracking (hmtx + normal family vmtx)   │
         │         + 極端な bbox の除去                    │
         │             ↓                                   │
         │   [3/3] Merge — font-baker                      │
@@ -80,15 +80,18 @@ FAMILIES × WEIGHTS の各組合せに対して:
                     inheritBase で designer/OFL/version を継承
                     weight だけを上書き
   → inst を再読込し、Noto Variable の baseline palt を active 2048-UPM
-    build grid へ scale して使う; vpal は font-baker が bake した出力から取得
+    build grid へ scale して使う
   → ss09 約物を除き Noto の palt エントリを全量で焼き込み
     ss09 約物は 34% を base に焼き、66% を ss09 残差として保持
     (palt なしグリフはメトリクス維持)
   → make_proportional で palt → hmtx に焼き込み
-    palt/vpal/halt/vhal を削除; 横方向の palt 残差と縦方向の
-    vpal record は final ss09 用に保持
+    palt/vpal/halt/vhal/vkrn を削除; 横方向の palt 残差だけを
+    final ss09 用に保持し、縦方向の vpal/vkrn 挙動は公開しない
   → _apply_tracking で advance を広げ LSB を半分シフト
     ただし family["trackingIgnore"] の連続・隙間なし記号は除外
+  → normal family では Inter merge 前の Noto 中間 font に対し、
+    和文縦組み glyph の vmtx advance に +10 設計 units を加える;
+    Display は +0 のまま
   → _apply_glyph_spacing で family["glyphSpacing"] の個別調整を適用
   → _strip_extreme_glyphs で縦組み用繰り返し記号 〱-〵 を無効化
     (1000-UPM 設計値: yMax > 1200 / yMin < -400)
@@ -104,8 +107,9 @@ FAMILIES × WEIGHTS の各組合せに対して:
                      manufacturer / manufacturerURL を刻印
   → final TTF を一度 reload/save し、GSUB/GPOS coverage を
     merge 後の glyph ID 順に正規化
-  → merge 時の glyph rename 後も horizontal / vertical glyph に optional
-    約物挙動が残るよう、final cmap / glyph 名に対して yakumono-only ss09 を生成
+  → merge 時の glyph rename 後も横方向の optional 約物挙動が残るよう、
+    final cmap / glyph 名に対して horizontal yakumono-only ss09 を生成;
+    縦組みは基本の全角ベタ組フォールバックとして扱う
 ```
 
 `font.build --jobs N` は family/weight ごとに独立した job を並列実行する。
@@ -180,17 +184,17 @@ inst に対して 4 つのサブパスを in-place で実行:
    stylistic set「約物半角」用に保持する。Noto の典型的な 1000-UPM source
    scale の `XAdvance=-500` 約物は 2048-UPM では `-1024` 相当になり、
    palt-off で `-348` が base advance に焼かれ、`ss09` 有効時に残り
-   `-676` が適用される。runtime `vpal` は feature としては
-   再生成しないが、選択した約物 record は縦組み用 `.ss09` alternate の
-   source data として保持し、`vmtx` に縦方向の placement / advance delta を
-   焼き込む。final font では `palt`, `vpal`, `halt`, `vhal` を削除し、
-   optional 約物 spacing は `ss09` だけで公開する。palt なしグリフは自動的に
+   `-676` が適用される。runtime `vpal` は再生成せず、縦方向の `vkrn` も
+   削除する。production build では縦組み用 `.ss09` alternate も作らない。
+   縦組みは基本の全角ベタ組リズムを保つフォールバックとして扱う。
+   final font では `palt`, `vpal`, `halt`, `vhal`, `vkrn` を削除し、
+   optional 約物 spacing は横方向の `ss09` だけで公開する。palt なしグリフは自動的に
    sidebearing を詰めない; 後続の明示的な spacing ルールが触らない限り
    元の `hmtx` を維持する。
    `U+30FB` (・) は Noto では `U+2027` (‧) と同じ `uni2027` を共有して
    いるため、palt ベイク前に `uni30FB` として分離する。これにより `‧` と
    `・` は必要に応じて別々の optional spacing record を持てる。
-2. **トラッキング** (`_apply_tracking`) — advance を `tracking` 分広げ、
+2. **トラッキング** (`_apply_tracking`, `_apply_vertical_tracking`) — advance を `tracking` 分広げ、
    `tracking // 2` を LSB に加算してアウトラインを広がった枠の中央に
    配置。kana / 句読点はファミリー設定の `trackingKana` で別値。
    これらの値は 1000-UPM 設計値として持ち、normal family では `+30` / `+45`
@@ -216,6 +220,11 @@ inst に対して 4 つのサブパスを in-place で実行:
    小書き「ィ」「ャ」や、ひらがなの小書き「ょ」などは見え方に合わせて
    個別値を持つ。`U+30FB` (・) を含む約物はここでは扱わない: tracking は
    通常どおり通し、横方向の詰めは明示的な `ss09` feature に任せる。
+   normal family ではさらに `verticalTracking = 9` 設計 units を、merge 前の
+   Noto 中間 font 上の和文 vertical-body glyph に適用する。これは
+   `vmtx.advanceHeight` だけを増やし、top sidebearing / 縦 origin は動かさない。
+   縦組みの表示箱は維持したまま、縦方向の送りだけを少し広げる。Display
+   family は `verticalTracking = 0` のまま。
 4. **bbox 除去** (`_strip_extreme_glyphs`) — 下記 [垂直メトリクス] 参照。
 
 オプションの **横スケール** (`xScale` 設定、現在未使用) は上記の後に
@@ -247,7 +256,9 @@ merge 後は和文の縦書き body metrics も再計算する。Noto 由来の 
 advanceHeight は `SCALE` で縮小し、top sidebearing は merge 前の縦 origin に
 同じベースライン基準の transform (`originY * SCALE + BASELINE_OFFSET`) を
 掛けた位置から逆算する。これにより、アウトラインだけが縮小されているのに
-縦組みの仮想ボディが元の 2048 正方のまま残る状態を避ける。ASCII Latin は
+縦組みの仮想ボディが元の 2048 正方のまま残る状態を避ける。merge 前の
+source `vmtx` advance に入っている縦方向 tracking も同じ scale で引き継がれる。
+ASCII Latin は
 元の vertical metrics を維持し、かな / CJK / 全角 / 和文約物 / vertical-form
 alternate だけが Noto scale に追従する。font-baker が merge 時に Noto/base
 glyph を rename した場合は、final glyph と source glyph を共有 Unicode
@@ -264,8 +275,8 @@ release zip / npm package / site metadata と同じ project/release version を
 "https://yamatoiizuka.com"` でリリース TTF の nameID 8 / 11 を刻印。
 merge 後は final TTF を一度 fontTools で reload/save し、GSUB/GPOS coverage を
 最終 glyph order に合わせて正規化する。その後、merge 前に codepoint keyed で
-保持した横方向 record と codepoint / glyph keyed の縦方向 record から、
-最小 runtime `ss09` 挙動を final cmap / glyph order に対して生成する。
+保持した横方向 record から、最小 runtime `ss09` 挙動を final cmap /
+glyph order に対して生成する。
 これは `U+FF40` (｀) のように、Noto では `U+2035` と同じ `uni2035`
 を共有するが、Inter 側の `U+2035` と衝突して merge 後に
 `uni2035.orig` へ rename される glyph で必要になる。この final install は
@@ -291,19 +302,19 @@ yakumono-only `ss09` として再生成する。本プロジェクトでは
 詰まり (2048-UPM build grid 上の典型的な `-1024` palt advance なら `-348`)、
 `ss09` を有効にすると従来の Noto full palt 目標まで到達する。
 production build では横方向の `ss09` target に `PALT_FEATURE_CHARS`
-(48 文字)、縦方向の `ss09` target に `SS09_VERTICAL_FEATURE_CHARS` と
-`SS09_VERTICAL_FEATURE_GLYPHS` を使う。後者は Noto の `vpal` 値を
-source data として使うが、runtime `vpal` feature は公開せず alternate glyph
-metrics に焼き込む。これにより、焼き込み済みの kana / Latin に palt が
-二重適用されることを避けながら、optional 約物 spacing は `ss09` に集約する。
+(48 文字) を使う。縦方向の `ss09` target は意図的に空
+(`SS09_VERTICAL_FEATURE_CHARS = ()`, `SS09_VERTICAL_FEATURE_GLYPHS = ()`) にし、
+Noto の `vpal` / `vkrn` 挙動は final runtime surface へ持ち込まない。
+これにより、焼き込み済みの kana / Latin に palt が二重適用されることを
+避けながら、optional 約物 spacing は横方向の `ss09` に集約する。
 TrueType アウトラインのみ対応 (palt のベイクは `glyf` に書き戻すので
 CFF は対象外)。
 Inter との merge では base 側 glyph が rename されることがあるため、
-ビルドは merge 前に横方向の残差を codepoint 単位で、縦方向の調整を
-codepoint または glyph 名で保持し、merge 後の final cmap / glyph order に
-対して retarget する。final record には Noto optical scale (`SCALE = 0.925`)
-をこの時点でだけ掛ける。pre-merge の `palt_data` / `vpal_data` は active
-UPM grid のままにし、焼き込み base metrics は merge 時に一度だけ scale
+ビルドは merge 前に横方向の残差を codepoint 単位で保持し、merge 後の
+final cmap / glyph order に対して retarget する。final record には
+Noto optical scale (`SCALE = 0.925`) をこの時点でだけ掛ける。
+pre-merge の `palt_data` は active UPM grid のままにし、焼き込み
+base metrics は merge 時に一度だけ scale
 される。
 
 `_remove_prop_features` は GPOS を 2 段で歩く: FeatureRecord の削除と、
@@ -311,14 +322,15 @@ UPM grid のままにし、焼き込み base metrics は merge 時に一度だ�
 レコードのインデックスを動かすので、各 LangSys の `FeatureIndex` 配列を
 生き残ったレコードに対して再キーする必要がある。feature 削除後は、どの
 生存 feature からも参照されない lookup だけを pruning する; 共有 lookup は
-残す。`kern` は GPOS に残る。横方向の optional 約物は
+残す。横方向の `kern` は GPOS に残し、`vkrn` は削除するため、
+縦組みは基本ボディグリッド上で組まれる。横方向の optional 約物は
 GSUB 側で扱う: `_install_ss09_punctuation_feature` が従来の palt 残差から
 `.ss09` metric alternate を作り、UI 名「約物半角」の `ss09` stylistic set
-を生成する。縦組み用 glyph については、従来の vpal YPlacement / YAdvance を
-`vmtx` に焼き込んだ `.ss09` alternate を作る。既存の PairPos kerning は
-`.ss09` alternate にも拡張するため、substitution 後も `kern` は効き続ける。
-横方向のみの alternate は元 glyph の `vmtx` record もコピーするため、保存後の
-font でも vertical metrics table の長さが拡張後の glyph order と揃う。
+を生成する。既存の横方向 PairPos kerning は `.ss09` alternate にも拡張するため、
+substitution 後も `kern` は効き続ける。横方向のみの alternate は元 glyph の
+`vmtx` record もコピーするため、保存後の font でも vertical metrics table の
+長さが拡張後の glyph order と揃う。production build ではこの helper に
+縦方向の調整を渡さないので、`ss09` は縦組みでは効かない。
 `ss09` を追加した後は GSUB `FeatureList` を
 `FeatureTag` 順に戻し、LangSys の feature index を再マップする。lookup order
 は変更しない。
@@ -481,9 +493,9 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
   (`SOURCE_UPM = 1000`, `TARGET_UPM = 2048`)、`_glyph_codepoint`, `_is_kana_or_punct`,
   `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
   `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
-  `_apply_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
+  `_apply_tracking`, `_apply_vertical_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
   `_split_cmap_codepoint_glyph`、明示的な palt/ss09 spacing 方針、
-  vendor palt/vpal policy check、Thin / ExtraBold 用の
+  縦方向 ss09 無効化ポリシーの確認、Thin / ExtraBold 用の
   InterVariable edge instance source 選択。
 - **`src/font/verify_edge_instances.py`** — Thin / ExtraBold のビルド後検証。
   生成された InterVariable static instance が vendor static と同じ cmap /
@@ -508,8 +520,8 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 113 | CLI build selection / parallel intermediate path separation、和文 vertical body scaling、UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、baseline palt 方針、x-scale、bbox 除去、tracking、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
-| `test_proportional.py` | 37 | palt/vpal 抽出、SinglePos lookup の加算読み取り、グリフ平行移動、GPOS feature 削除、runtime-palt/vpal helper coverage + base/residual 分割 + optional squeeze helper、ss09 生成 + shaping |
+| `test_font_build.py` | 115 | CLI build selection / parallel intermediate path separation、和文 vertical body scaling/tracking、UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、kana / CJK 分類、GSUB/GPOS 走査、baseline palt 方針、x-scale、bbox 除去、tracking、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
+| `test_proportional.py` | 39 | palt/vpal 抽出、SinglePos lookup の加算読み取り、グリフ平行移動、vkrn を含む GPOS feature 削除、runtime-palt/vpal helper coverage + base/residual 分割 + optional squeeze helper、ss09 生成 + 縦方向 no-op を含む shaping |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,7 +26,7 @@ consumes the published webfont package.
         │             ↓                                   │
         │   [2/3] Proportionalise — proportional.py       │
         │      palt → hmtx + yakumono ss09                │
-        │         tracking (with repeatable skips)        │
+        │         tracking (hmtx + normal-family vmtx)    │
         │         + strip extreme bbox                    │
         │             ↓                                   │
         │   [3/3] Merge — font-baker                      │
@@ -80,15 +80,17 @@ For each (family, weight) in FAMILIES × WEIGHTS:
                     inheritBase passes designer/OFL/version
                     through; only weight is stamped
   → reload inst, read baseline palt from Noto Variable and scale it to the
-    active 2048-UPM build grid; read vpal from font-baker's baked output
+    active 2048-UPM build grid
   → bake Noto palt at full strength except ss09 yakumono,
     whose palt is split into a 34% baked base + 66% ss09 residual
     (glyphs without palt keep metrics)
-  → make_proportional bakes palt → hmtx and removes palt/vpal/halt/vhal;
-    horizontal palt residuals and vertical vpal records are held for
-    final ss09 alternates
+  → make_proportional bakes palt → hmtx and removes palt/vpal/halt/vhal/vkrn;
+    horizontal palt residuals are held for final ss09 alternates while
+    vertical vpal/vkrn behavior is not exposed
   → _apply_tracking widens advances + half-balances LSB
     except repeatable no-gap symbols in family["trackingIgnore"]
+  → normal-family vertical tracking adds +9 design units to Japanese
+    vmtx advances before the Inter merge; Display stays at +0
   → _apply_glyph_spacing applies family["glyphSpacing"] sidebearing tweaks
   → _strip_extreme_glyphs neutralises vertical iteration marks 〱-〵
     (1000-UPM design thresholds: yMax > 1200 / yMin < -400)
@@ -104,9 +106,9 @@ For each (family, weight) in FAMILIES × WEIGHTS:
                      manufacturer / manufacturerURL stamped
   → reload/save final TTF once so GSUB/GPOS coverage tables are ordered
     by the final merged glyph IDs
-  → install yakumono-only ss09 against the final cmap / glyph names so
-    merge-time glyph renames keep optional yakumono behavior on both
-    horizontal and vertical glyphs
+  → install horizontal yakumono-only ss09 against the final cmap / glyph names
+    so merge-time glyph renames keep optional horizontal yakumono behavior;
+    vertical writing remains a basic full-width fallback
 ```
 
 `font.build --jobs N` dispatches independent family/weight jobs in parallel.
@@ -181,17 +183,17 @@ Four sub-passes, all in-place on the inst:
    `XAdvance=-500` yakumono records at the 1000-UPM source scale, the
    equivalent 2048-UPM record is `-1024`; palt-off gets `-348` baked into
    the base advance and enabling `ss09` applies the remaining `-676`.
-   Runtime `vpal` is not reinstalled as a feature; its
-   selected yakumono records are kept as source data for vertical `.ss09`
-   alternates whose `vmtx` carries the vertical placement / advance delta.
-   Final fonts strip `palt`, `vpal`, `halt`, and `vhal` so optional yakumono
-   spacing is exposed through `ss09` only. Glyphs without palt entries are not
+   Runtime `vpal` is not reinstalled, vertical `vkrn` is stripped, and
+   production builds do not create vertical `.ss09` alternates. Vertical
+   writing is treated as a fallback path that should keep basic full-width
+   rhythm. Final fonts strip `palt`, `vpal`, `halt`, `vhal`, and `vkrn` so
+   optional yakumono spacing is exposed through horizontal `ss09` only. Glyphs without palt entries are not
    automatically sidebearing-squeezed; they keep their original
    `hmtx` unless a later explicit spacing rule touches them.
    `U+30FB` (・) is split from Noto's shared `uni2027` glyph before palt
    baking so `U+2027` (‧) and `U+30FB` (・) can carry separate optional
    spacing records when needed.
-2. **Tracking** (`_apply_tracking`) — advance grows by `tracking`;
+2. **Tracking** (`_apply_tracking`, `_apply_vertical_tracking`) — advance grows by `tracking`;
    `tracking // 2` is added to LSB so the outline sits centred in the
    wider slot. Kana / punctuation get a separate `trackingKana` value
    when set on the family. These constants are authored on the 1000-UPM
@@ -222,6 +224,11 @@ Four sub-passes, all in-place on the inst:
    including `U+30FB` (・), is intentionally not handled here: it passes
    through tracking and tightens only when the explicit `ss09` feature is
    enabled.
+   The normal family also applies `verticalTracking = 9` design units to
+   Japanese vertical-body glyphs on the pre-merge Noto intermediate. This
+   updates only `vmtx.advanceHeight`; top sidebearing / vertical origin stay
+   unchanged so the vertical display box is preserved while vertical text gets
+   a slightly looser rhythm. The Display family keeps `verticalTracking = 0`.
 4. **Bbox strip** (`_strip_extreme_glyphs`) — see [Vertical metrics]
    below.
 
@@ -256,7 +263,8 @@ Noto-source `vmtx` advance heights are scaled by `SCALE`, and top sidebearings
 are derived from the pre-merge vertical origin after applying the same
 baseline-based transform (`originY * SCALE + BASELINE_OFFSET`). This keeps the
 vertical writing body from staying at the original 2048-square while the
-outline has been optically scaled down. ASCII Latin keeps its original vertical
+outline has been optically scaled down. Any pre-merge vertical tracking already
+present in the source `vmtx` advance is carried through this same scale. ASCII Latin keeps its original vertical
 metrics; kana, CJK, fullwidth forms, Japanese punctuation, and vertical-form
 alternates follow the Noto scale. If font-baker renamed a Noto/base glyph
 during merge, the metric pass resolves the source glyph through the shared
@@ -273,8 +281,7 @@ prefix. `output.manufacturer = "Yamato Iizuka"`, `output.manufacturerURL =
 After the merge, the TTF is reloaded and saved once with fontTools so
 GSUB/GPOS coverage tables are sorted against the final merged glyph order.
 Then the minimal runtime `ss09` behavior is rebuilt from codepoint-keyed
-horizontal records and codepoint/glyph-keyed vertical records captured before
-the merge. This matters
+horizontal records captured before the merge. This matters
 for shared Noto glyphs such as `U+FF40` (｀), which uses Noto's `uni2035`
 before merge but may be renamed to `uni2035.orig` when Inter also provides
 `U+2035`. Because this final install happens after the merge, the saved
@@ -302,19 +309,17 @@ Inter merge. The project uses
 tightened (`-348` for the common `-1024` palt advance on the 2048-UPM build
 grid) while enabling `ss09` reaches the former full Noto palt target.
 The production build uses `PALT_FEATURE_CHARS` (48 chars) for horizontal
-`ss09` targets and `SS09_VERTICAL_FEATURE_CHARS` plus
-`SS09_VERTICAL_FEATURE_GLYPHS` for vertical `ss09` targets. The latter uses
-Noto's `vpal` values as source data but bakes them into alternate glyph
-metrics instead of exposing a runtime `vpal` feature. This avoids
-double-applying palt to baked kana / Latin while consolidating optional
-yakumono spacing under `ss09`. Only TrueType outlines are supported
+`ss09` targets. Vertical `ss09` targets are intentionally empty
+(`SS09_VERTICAL_FEATURE_CHARS = ()`, `SS09_VERTICAL_FEATURE_GLYPHS = ()`),
+and Noto `vpal` / `vkrn` behavior is not carried into the final runtime
+surface. This avoids double-applying palt to baked kana / Latin while keeping
+optional yakumono spacing under horizontal `ss09`. Only TrueType outlines are supported
 — palt baking writes back to `glyf`, not CFF.
 Because the Inter merge can rename colliding base glyphs, the build captures
-horizontal residuals by codepoint and vertical adjustments by codepoint or
-glyph name before the merge, then retargets them against the final cmap /
-glyph order afterward. Those final records are scaled by the final Noto
+horizontal residuals by codepoint before the merge, then retargets them
+against the final cmap / glyph order afterward. Those final records are scaled by the final Noto
 optical scale (`SCALE = 0.925`) at install time only; the pre-merge
-`palt_data` / `vpal_data` remain on the active UPM grid so baked base metrics
+`palt_data` remains on the active UPM grid so baked base metrics
 are scaled exactly once by the merge.
 
 `_remove_prop_features` walks GPOS in two coordinated passes:
@@ -322,16 +327,17 @@ FeatureRecord deletions and the corresponding LangSys index remap.
 Removing a record changes the indices of every later record, so each
 LangSys's `FeatureIndex` array is re-keyed against the surviving records.
 After feature removal, lookup indices are pruned only when no surviving
-feature references them; shared lookups stay intact. `kern` remains in GPOS,
-and horizontal optional yakumono is
+feature references them; shared lookups stay intact. Horizontal `kern`
+remains in GPOS, while `vkrn` is removed so vertical writing stays on the
+basic body grid. Horizontal optional yakumono is
 handled as GSUB: `_install_ss09_punctuation_feature` creates `.ss09` metric
 alternates from the former palt residual and installs an `ss09` stylistic set
-with the UI name "約物半角". For vertical glyphs, it creates `.ss09`
-alternates whose `vmtx` bakes the former vpal YPlacement/YAdvance. Existing
-PairPos kerning is extended to those alternates so `kern` continues to apply
-after substitution. Horizontal-only alternates copy their source glyphs'
-`vmtx` records so saved fonts keep vertical metrics table length in sync with
-the expanded glyph order. After `ss09` is
+with the UI name "約物半角". Existing horizontal PairPos kerning is extended
+to those alternates so `kern` continues to apply after substitution.
+Horizontal-only alternates copy their source glyphs' `vmtx` records so saved
+fonts keep vertical metrics table length in sync with the expanded glyph
+order. Production builds pass no vertical adjustments to this helper, so
+`ss09` has no vertical-writing effect. After `ss09` is
 appended, the GSUB `FeatureList` is sorted back into `FeatureTag` order and
 all LangSys feature indices are remapped; lookup order is left untouched.
 
@@ -497,9 +503,9 @@ Tests live under `tests/`, split by surface:
   (`SOURCE_UPM = 1000`, `TARGET_UPM = 2048`), `_glyph_codepoint`, `_is_kana_or_punct`,
   `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
   `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
-  `_apply_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
-  `_split_cmap_codepoint_glyph`, explicit palt/ss09 spacing policy, vendor
-  palt/vpal policy checks, and InterVariable edge-instance
+  `_apply_tracking`, `_apply_vertical_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
+  `_split_cmap_codepoint_glyph`, explicit palt/ss09 spacing policy, vertical
+  ss09-disabled policy checks, and InterVariable edge-instance
   source selection for Thin / ExtraBold.
 - **`src/font/verify_edge_instances.py`** — post-build verification for
   Thin / ExtraBold edge outputs. Confirms the generated InterVariable static
@@ -524,8 +530,8 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 113 | CLI build selection and parallel intermediate path separation, Japanese vertical body scaling, UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, baseline palt policy, x-scale, bbox strip, tracking, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
-| `test_proportional.py` | 37 | palt/vpal extraction, cumulative SinglePos lookup reading, glyph translation, GPOS feature removal, runtime-palt/vpal helper coverage + base/residual split + optional squeeze helper, ss09 construction + shaping |
+| `test_font_build.py` | 115 | CLI build selection and parallel intermediate path separation, Japanese vertical body scaling/tracking, UPM scaling policy, project-version metadata forwarding, glyph-name parsing, kana / CJK classification, GSUB/GPOS walk, baseline palt policy, x-scale, bbox strip, tracking, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
+| `test_proportional.py` | 39 | palt/vpal extraction, cumulative SinglePos lookup reading, glyph translation, GPOS feature removal including vkrn, runtime-palt/vpal helper coverage + base/residual split + optional squeeze helper, ss09 construction + shaping including vertical no-op coverage |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |
 

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -7,12 +7,12 @@ Shared pipeline per weight:
                                                 metadataMode=inheritBase,
                                                 output.upm=2048)
   2. Convert to proportional metrics           (palt-based, proportional.py)
-  3. Apply tracking                            (LSB +half, RSB +half)
+  3. Apply tracking                            (horizontal hmtx + vertical vmtx)
   4. Merge Inter/InterDisplay + proportional Noto  (font-baker, with
      subFont.excludeCodepoints to keep CJK-conventional symbols on Noto)
 
 Families:
-  - Gen Interface JP         : Inter       + proportional Noto, tracking +30 (kana/punct +45) at 1000 UPM
+  - Gen Interface JP         : Inter       + proportional Noto, tracking +30 (kana/punct +45, vertical JP +10) at 1000 UPM
   - Gen Interface JP Display : InterDisplay + proportional Noto, tracking +0
 
 Outputs TTF into dist/ttf/. Web delivery (subset WOFF2 chunks served via
@@ -39,7 +39,6 @@ from project_metadata import project_version as read_project_version
 from .proportional import (
     _install_ss09_punctuation_feature,
     _read_palt,
-    _read_vpal,
     _remove_prop_features,
     _scale_position_adjustment,
     make_proportional,
@@ -176,24 +175,12 @@ RUNTIME_PALT_BASE_SCALE = 0.34
 # weight, matching the historical Gen Interface JP spacing policy.
 _baseline_palt_cache: dict[str, tuple[int, int]] | None = None
 
-# Vertical yakumono glyphs also live under the ss09 "約物半角" feature. The
-# build uses Noto's vpal records as source data but bakes them into .ss09 vmtx
-# alternates instead of exposing a runtime vpal feature.
-SS09_VERTICAL_FEATURE_CHARS = (
-    "〒", "・",
-    "︐", "︑", "︒", "︗", "︘",
-    "︵", "︶", "︷", "︸", "︹", "︺",
-    "︻", "︼", "︽", "︾", "︿", "﹀",
-    "﹁", "﹂", "﹃", "﹄", "﹇", "﹈",
-    "！", "＃", "＄", "％", "＆", "＊", "？", "￥", "；",
-)
-
-# U+FF1A (：) vertically substitutes to unmapped glyph17071, so codepoint
-# retargeting cannot reach it. U+FF1B (；) has no Noto vpal record.
-SS09_VERTICAL_FEATURE_GLYPHS = ("glyph17071",)
-SS09_SYNTHETIC_VERTICAL_ADJUSTMENTS = {
-    "uniFF1B": (250, -500),
-}
+# Vertical writing is treated as a fallback path for this UI-focused family.
+# Keep it on basic full-width metrics: do not expose Noto vpal/vkrn behavior
+# through runtime features, and do not add vertical ss09 alternates.
+SS09_VERTICAL_FEATURE_CHARS: tuple[str, ...] = ()
+SS09_VERTICAL_FEATURE_GLYPHS: tuple[str, ...] = ()
+SS09_SYNTHETIC_VERTICAL_ADJUSTMENTS: dict[str, tuple[int, int]] = {}
 
 # Glyphs listed here get full Noto palt baked like every other non-optional
 # palt glyph, then receive explicit hmtx spacing after tracking. Keep this
@@ -229,8 +216,10 @@ PALT_SPACE_ADJUSTMENTS = {
 
 NORMAL_TRACKING = 30
 NORMAL_TRACKING_KANA = 45
+NORMAL_VERTICAL_TRACKING = 9
 DISPLAY_TRACKING = 0
 DISPLAY_TRACKING_KANA = 0
+DISPLAY_VERTICAL_TRACKING = 0
 
 NORMAL_PALT_SPACE_ADJUSTMENTS = {
     **PALT_SPACE_ADJUSTMENTS,
@@ -247,6 +236,7 @@ FAMILIES = {
         "interOpsz": 14,
         "tracking": NORMAL_TRACKING,
         "trackingKana": NORMAL_TRACKING_KANA,
+        "verticalTracking": NORMAL_VERTICAL_TRACKING,
         "trackingIgnore": TRACKING_IGNORE_CODEPOINTS,
         "runtimePalt": PALT_FEATURE_CHARS,
         "folderPrefix": "GenInterfaceJP",
@@ -267,6 +257,7 @@ FAMILIES = {
         "interOpsz": 32,
         "tracking": DISPLAY_TRACKING,
         "trackingKana": DISPLAY_TRACKING_KANA,
+        "verticalTracking": DISPLAY_VERTICAL_TRACKING,
         "trackingIgnore": TRACKING_IGNORE_CODEPOINTS,
         "runtimePalt": PALT_FEATURE_CHARS,
         "folderPrefix": "GenInterfaceJPDisplay",
@@ -1027,6 +1018,36 @@ def _scale_vertical_body_metrics_after_merge(
         source_font.close()
 
 
+def _apply_vertical_tracking(
+    font: TTFont,
+    tracking: int,
+    glyph_names: set[str] | None = None,
+) -> int:
+    """Add vertical advance to Japanese body glyphs without moving origins."""
+    if tracking == 0:
+        return 0
+    if "vmtx" not in font:
+        return 0
+
+    glyph_order = set(font.getGlyphOrder())
+    targets = glyph_names if glyph_names is not None else _vertical_body_glyphs(font)
+    adjusted = 0
+    for glyph_name in sorted(targets):
+        if glyph_name not in glyph_order:
+            continue
+        if glyph_name not in font["vmtx"].metrics:
+            continue
+        advance_height, top_side_bearing = font["vmtx"][glyph_name]
+        if advance_height == 0:
+            continue
+        font["vmtx"][glyph_name] = (
+            advance_height + tracking,
+            top_side_bearing,
+        )
+        adjusted += 1
+    return adjusted
+
+
 def _feature_adjustments_for_codepoints(
     font: TTFont,
     codepoint_entries: list | tuple | set | None,
@@ -1144,7 +1165,8 @@ def _refresh_ss09_feature_after_merge(
     codepoint-keyed optional punctuation behavior against the final cmap so
     characters such as U+FF40 (｀), which shares Noto's ``uni2035`` glyph before
     merge, keep their ss09 adjustment on the renamed final glyph. Horizontal
-    palt and vertical vpal are intentionally not reinstalled here.
+    palt is intentionally not reinstalled here. Production builds also pass
+    no vertical adjustments, so vertical ss09 remains disabled.
     """
     font = TTFont(final_path)
     ss09_adjustments = _retarget_feature_adjustments(
@@ -1341,8 +1363,8 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
        passed through font-baker with ``metadataMode: inheritBase`` and
        ``output.upm = 2048`` so the Noto identity records survive into the inst.
     2. **Proportionalise** the inst — read baseline palt from Noto Variable,
-       read vpal from the 2048-UPM baked output, bake those adjustments
-       into hmtx except selected ss09 yakumono, apply tracking,
+       bake those adjustments into hmtx except selected horizontal ss09
+       yakumono, apply tracking,
        apply per-glyph sidebearing tweaks from ``family["glyphSpacing"]``,
        strip extreme bbox glyphs, optionally apply x-scale.
     3. **Merge** the proportional Noto with the matching Inter master via
@@ -1404,6 +1426,8 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
         if tracking_kana_design is None
         else _scale_design_unit(tracking_kana_design, font_upm)
     )
+    vertical_tracking_design = family.get("verticalTracking", 0)
+    vertical_tracking = _scale_design_unit(vertical_tracking_design, font_upm)
     tracking_ignore = family.get("trackingIgnore")
     ss09_punctuation_chars = family.get("runtimePalt")
 
@@ -1415,6 +1439,11 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
         if font_upm != SOURCE_UPM:
             kana_desc += f" ({tracking_kana_design} at {SOURCE_UPM} UPM)"
         desc += f" ({kana_desc})"
+    if vertical_tracking:
+        vertical_desc = f"vertical JP +{vertical_tracking}"
+        if font_upm != SOURCE_UPM:
+            vertical_desc += f" ({vertical_tracking_design} at {SOURCE_UPM} UPM)"
+        desc += f" ({vertical_desc})"
     print(f"    [2/3] Proportional (palt) + {desc}...")
 
     # Split U+30FB from U+2027 before metrics work. Noto maps both to
@@ -1429,19 +1458,6 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     palt_data = _scale_design_adjustments(dict(_get_baseline_palt()), font_upm)
     if split_source in palt_data:
         palt_data["uni30FB"] = palt_data[split_source]
-    # Read vpal from the freshly baked 2048-UPM inst. font-baker owns the
-    # variable instantiation and UPM conversion here, so vertical records are
-    # already on the active build grid.
-    vpal_data = dict(_read_vpal(font))
-    if split_source in vpal_data:
-        vpal_data["uni30FB"] = vpal_data[split_source]
-    synthetic_vertical_adjustments = _scale_design_adjustments(
-        SS09_SYNTHETIC_VERTICAL_ADJUSTMENTS,
-        font_upm,
-    )
-    for glyph_name, value in synthetic_vertical_adjustments.items():
-        if glyph_name in font.getGlyphOrder() and glyph_name not in vpal_data:
-            vpal_data[glyph_name] = value
     ss09_punctuation_by_codepoint = _runtime_palt_residuals_by_codepoint(
         _feature_adjustments_for_codepoints(
             font,
@@ -1449,16 +1465,6 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
             palt_data,
         )
     )
-    ss09_vertical_by_codepoint = _feature_adjustments_for_codepoints(
-        font,
-        SS09_VERTICAL_FEATURE_CHARS,
-        vpal_data,
-    )
-    ss09_vertical_by_glyph = {
-        glyph_name: vpal_data[glyph_name]
-        for glyph_name in SS09_VERTICAL_FEATURE_GLYPHS
-        if glyph_name in font.getGlyphOrder() and glyph_name in vpal_data
-    }
 
     # Bake Noto palt entries at full strength except ss09 yakumono, which
     # receive a reduced baked base. Their residual is captured above and later
@@ -1478,6 +1484,9 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     if spacing_adjusted:
         print(f"          Per-glyph spacing: {spacing_adjusted} glyph(s) adjusted")
     _strip_extreme_glyphs(font)
+    vertical_tracking_adjusted = _apply_vertical_tracking(font, vertical_tracking)
+    if vertical_tracking_adjusted:
+        print(f"          Vertical tracking: {vertical_tracking_adjusted} glyph(s) adjusted")
     x_scale = family.get("xScale", 1.0)
     if x_scale != 1.0:
         _apply_x_scale(font, x_scale)
@@ -1530,8 +1539,8 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     _refresh_ss09_feature_after_merge(
         final_path,
         _scale_feature_adjustments(ss09_punctuation_by_codepoint, SCALE),
-        _scale_feature_adjustments(ss09_vertical_by_codepoint, SCALE),
-        _scale_feature_adjustments(ss09_vertical_by_glyph, SCALE),
+        {},
+        {},
     )
     return {
         "fontPath": final_path,

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -12,7 +12,7 @@ Shared pipeline per weight:
      subFont.excludeCodepoints to keep CJK-conventional symbols on Noto)
 
 Families:
-  - Gen Interface JP         : Inter       + proportional Noto, tracking +30 (kana/punct +45, vertical JP +10) at 1000 UPM
+  - Gen Interface JP         : Inter       + proportional Noto, tracking +30 (kana/punct +45, vertical JP +9) at 1000 UPM
   - Gen Interface JP Display : InterDisplay + proportional Noto, tracking +0
 
 Outputs TTF into dist/ttf/. Web delivery (subset WOFF2 chunks served via

--- a/src/font/proportional.py
+++ b/src/font/proportional.py
@@ -30,14 +30,18 @@ from fontTools.ttLib import TTFont, newTable
 from fontTools.ttLib.tables import otTables
 
 
-# GPOS features that provide proportional metric adjustments.
-# These become redundant once the font itself is proportional, so we strip
-# them to keep apps from double-applying the shrink.
+# GPOS features that provide proportional metric adjustments or vertical
+# pair tightening. These become redundant or undesirable once the font's
+# project-owned spacing policy has been baked, so we strip them to keep apps
+# from double-applying the shrink and to keep vertical writing on a basic
+# full-width grid.
 #   palt  - proportional alternate widths (horizontal)
 #   vpal  - proportional alternate widths (vertical)
 #   halt  - alternate metrics (horizontal, ½-width / pseudo-half)
 #   vhal  - alternate metrics (vertical)
-PROP_FEATURES = {"palt", "vpal", "halt", "vhal"}
+#   vkrn  - vertical kerning; disabled for Gen Interface JP's fallback
+#           vertical writing behavior
+PROP_FEATURES = {"palt", "vpal", "halt", "vhal", "vkrn"}
 
 SS09_FEATURE_TAG = "ss09"
 SS09_ALTERNATE_SUFFIX = ".ss09"
@@ -216,8 +220,9 @@ def make_proportional(
             new_aw = aw - lsb_remove - rsb_remove
             hmtx[glyph_name] = (new_aw, new_lsb)
 
-    # Remove proportional-metric GPOS features, then install minimal live
-    # palt/vpal lookups for glyphs intentionally kept at runtime.
+    # Remove proportional-metric GPOS features plus vertical kerning, then
+    # install minimal live palt/vpal lookups for glyphs intentionally kept at
+    # runtime.
     _remove_prop_features(font)
     if install_runtime_palt and runtime_palt_adjustments:
         _install_palt_feature(font, runtime_palt_adjustments)
@@ -352,7 +357,7 @@ def _shift_glyph_x(glyph, dx: int) -> None:
 # ---------------------------------------------------------------------------
 
 def _remove_prop_features(font: TTFont) -> None:
-    """Strip palt/vpal/halt/vhal from GPOS, keeping every other feature intact.
+    """Strip palt/vpal/halt/vhal/vkrn from GPOS, keeping other features intact.
 
     GPOS feature indices live in two places that must stay in sync:
     the FeatureRecord list itself (the data) and the FeatureIndex arrays
@@ -503,10 +508,13 @@ def _install_ss09_punctuation_feature(
 
     The default glyphs keep the reduced baked metrics. ``ss09`` substitutes
     to private alternate glyphs that carry the remaining palt delta in their
-    outline position and hmtx advance. In vertical writing, the same feature
-    substitutes vertical-form glyphs to alternates whose vmtx carries the
-    former vpal delta. PairPos kerning is extended to those alternates so
-    enabling ``ss09`` does not drop existing ``kern`` pairs.
+    outline position and hmtx advance. When vertical adjustments are supplied,
+    the same helper can create vertical-form alternates whose vmtx carries a
+    vertical metric delta. The production build intentionally passes none so
+    vertical writing stays on basic full-width metrics.
+
+    PairPos kerning is extended to alternates so enabling ``ss09`` does not
+    drop existing horizontal ``kern`` pairs.
     """
     alternates = _create_metric_alternates(font, adjustments)
     alternates.update(

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -17,6 +17,7 @@ from fontTools.ttLib import TTFont, newTable
 from font.build import (
     _apply_glyph_spacing,
     _apply_tracking,
+    _apply_vertical_tracking,
     _apply_x_scale,
     _EXTREME_YMAX,
     _EXTREME_YMIN,
@@ -53,11 +54,13 @@ from font.build import (
     _default_inter_static_path,
     _inter_source_path,
     DISPLAY_PALT_SPACE_ADJUSTMENTS,
+    DISPLAY_VERTICAL_TRACKING,
     FAMILIES,
     INTER_VARIABLE,
     INTER_VARIABLE_EDGE_WEIGHTS,
     NOTO_VARIABLE,
     NORMAL_PALT_SPACE_ADJUSTMENTS,
+    NORMAL_VERTICAL_TRACKING,
     PALT_FEATURE_CHARS,
     PALT_SPACE_ADJUSTMENTS,
     RUNTIME_PALT_BASE_SCALE,
@@ -73,13 +76,11 @@ from font.build import (
 from font.proportional import (
     _install_ss09_punctuation_feature,
     _read_palt,
-    _read_vpal,
 )
 from merge_fonts import parse_codepoint_list
 
 
 _vendor_palt_cache: dict[str, tuple[int, int]] | None = None
-_vendor_vpal_cache: dict[str, tuple[int, int]] | None = None
 
 
 def _vendor_palt() -> dict[str, tuple[int, int]]:
@@ -92,18 +93,6 @@ def _vendor_palt() -> dict[str, tuple[int, int]]:
         finally:
             font.close()
     return _vendor_palt_cache
-
-
-def _vendor_vpal() -> dict[str, tuple[int, int]]:
-    """Read full vendor Noto vpal data for policy assertions."""
-    global _vendor_vpal_cache
-    if _vendor_vpal_cache is None:
-        font = TTFont(NOTO_VARIABLE)
-        try:
-            _vendor_vpal_cache = _read_vpal(font)
-        finally:
-            font.close()
-    return _vendor_vpal_cache
 
 
 def _layout_feature_tags(font: TTFont, table_tag: str) -> set[str]:
@@ -911,39 +900,21 @@ class TestPaltSymbolPolicy:
         assert _runtime_palt_residual_adjustment((-250, -500)) == (-165, -330)
         assert _runtime_palt_residual_adjustment((-70, -140)) == (-46, -92)
 
-    def test_family_config_exposes_ss09_without_runtime_vpal(self):
+    def test_family_config_exposes_horizontal_ss09_only(self):
         for family in FAMILIES.values():
             assert family["runtimePalt"] == PALT_FEATURE_CHARS
             assert "runtimeVpal" not in family
 
-    def test_vertical_yakumono_uses_ss09_targets_not_runtime_vpal(self):
-        vpal = _vendor_vpal()
-        assert "glyph17071" in SS09_VERTICAL_FEATURE_GLYPHS
-        assert SS09_SYNTHETIC_VERTICAL_ADJUSTMENTS == {
-            "uniFF1B": (250, -500),
-        }
+    def test_vertical_yakumono_ss09_is_disabled(self):
+        assert SS09_VERTICAL_FEATURE_CHARS == ()
+        assert SS09_VERTICAL_FEATURE_GLYPHS == ()
+        assert SS09_SYNTHETIC_VERTICAL_ADJUSTMENTS == {}
 
-        for char in (
-            "〒・︐︑︒︗︘︵︶︷︸︹︺︻︼︽︾︿﹀﹁﹂﹃﹄﹇﹈"
-            "！＃＄％＆＊？￥；"
-        ):
-            assert char in SS09_VERTICAL_FEATURE_CHARS
-
-        expected_glyphs = {
-            "uni3012",  # 〒
-            "uni2027",  # ・ (Noto source glyph before U+30FB split)
-            "uniFE10",  # ︐
-            "uniFE11",  # ︑
-            "uniFE12",  # ︒
-            "uniFE35",  # ︵
-            "uniFE36",  # ︶
-            "uniFE41",  # ﹁
-            "uniFE42",  # ﹂
-            "uniFF01",  # ！
-            "uniFF05",  # ％
-        }
-
-        assert expected_glyphs <= set(vpal)
+    def test_vertical_tracking_is_normal_only(self):
+        assert NORMAL_VERTICAL_TRACKING == 9
+        assert DISPLAY_VERTICAL_TRACKING == 0
+        assert FAMILIES["normal"]["verticalTracking"] == NORMAL_VERTICAL_TRACKING
+        assert FAMILIES["display"]["verticalTracking"] == DISPLAY_VERTICAL_TRACKING
 
     def _add_vmtx(self, font: TTFont, metrics: dict[str, tuple[int, int]]) -> None:
         vmtx = newTable("vmtx")
@@ -979,6 +950,23 @@ class TestPaltSymbolPolicy:
         assert "uni4E00" in glyphs
         assert "uni3001" in glyphs
         assert "A" not in glyphs
+
+    def test_vertical_tracking_adds_advance_without_moving_origin(self, synthetic_ttf):
+        metrics = {
+            "A": (1000, 90),
+            "uni3042": (1000, 100),
+            "uni4E00": (1000, 120),
+            "uni3001": (1000, 130),
+        }
+        self._add_vmtx(synthetic_ttf, metrics)
+
+        adjusted = _apply_vertical_tracking(synthetic_ttf, tracking=10)
+
+        assert adjusted >= 3
+        assert synthetic_ttf["vmtx"]["uni3042"] == (1010, 100)
+        assert synthetic_ttf["vmtx"]["uni4E00"] == (1010, 120)
+        assert synthetic_ttf["vmtx"]["uni3001"] == (1010, 130)
+        assert synthetic_ttf["vmtx"]["A"] == (1000, 90)
 
     def test_vertical_body_metrics_scale_advance_and_origin(self, synthetic_ttf):
         source = synthetic_ttf

--- a/tests/test_proportional.py
+++ b/tests/test_proportional.py
@@ -377,7 +377,7 @@ class TestShiftGlyphX:
 # ---------------------------------------------------------------------------
 
 class TestRemovePropFeatures:
-    """Strip palt/vpal/halt/vhal from GPOS while keeping other features."""
+    """Strip palt/vpal/halt/vhal/vkrn from GPOS while keeping horizontal kern."""
 
     def test_palt_is_removed(self, noto_subset):
         gpos = noto_subset["GPOS"]
@@ -388,6 +388,16 @@ class TestRemovePropFeatures:
 
         after = {fr.FeatureTag for fr in gpos.table.FeatureList.FeatureRecord}
         assert "palt" not in after
+
+    def test_vertical_kerning_is_removed(self, noto_subset):
+        gpos = noto_subset["GPOS"]
+        before = {fr.FeatureTag for fr in gpos.table.FeatureList.FeatureRecord}
+        assert "vkrn" in before
+
+        _remove_prop_features(noto_subset)
+
+        after = {fr.FeatureTag for fr in gpos.table.FeatureList.FeatureRecord}
+        assert "vkrn" not in after
 
     def test_all_prop_features_removed(self, noto_subset):
         _remove_prop_features(noto_subset)
@@ -533,6 +543,52 @@ class TestInstallSS09Punctuation:
         ].Feature.LookupListIndex[0]
         lookup = synthetic_ttf["GSUB"].table.LookupList.Lookup[lookup_index]
         assert lookup.SubTable[0].mapping["uniFE11"] == "uniFE11.ss09"
+
+    def test_vertical_text_ignores_horizontal_ss09_without_vertical_adjustments(
+        self,
+        synthetic_ttf,
+    ):
+        hb = pytest.importorskip("uharfbuzz")
+        glyph_order = [*synthetic_ttf.getGlyphOrder(), "uniFE11"]
+        synthetic_ttf.setGlyphOrder(glyph_order)
+        synthetic_ttf["glyf"]["uniFE11"] = copy.deepcopy(
+            synthetic_ttf["glyf"]["uni3001"]
+        )
+        synthetic_ttf["hmtx"].metrics["uniFE11"] = synthetic_ttf["hmtx"]["uni3001"]
+        vmtx = newTable("vmtx")
+        vmtx.metrics = {
+            glyph_name: (1000, 100)
+            for glyph_name in synthetic_ttf.getGlyphOrder()
+        }
+        synthetic_ttf["vmtx"] = vmtx
+        _install_synthetic_gsub_single_subst_feature(
+            synthetic_ttf,
+            "vert",
+            {"uni3001": "uniFE11"},
+        )
+
+        _install_ss09_punctuation_feature(
+            synthetic_ttf,
+            {"uni3001": (0, -100)},
+        )
+
+        buffer = io.BytesIO()
+        synthetic_ttf.save(buffer)
+        font_data = buffer.getvalue()
+        glyph_order = synthetic_ttf.getGlyphOrder()
+        face = hb.Face(font_data)
+        hb_font = hb.Font(face)
+        hb_buffer = hb.Buffer()
+        hb_buffer.add_str("、")
+        hb_buffer.direction = "ttb"
+        hb_buffer.script = "kana"
+        hb_buffer.language = "ja"
+        hb.shape(hb_font, hb_buffer, {"ss09": 1})
+
+        assert [
+            glyph_order[info.codepoint]
+            for info in hb_buffer.glyph_infos
+        ] == ["uniFE11"]
 
     def test_harfbuzz_uses_ss09_only_when_feature_is_enabled(self, synthetic_ttf):
         hb = pytest.importorskip("uharfbuzz")
@@ -717,7 +773,7 @@ class TestMakeProportional:
             for fr in noto_subset["GPOS"].table.FeatureList.FeatureRecord
         }
         assert "palt" in tags
-        assert not ({"vpal", "halt", "vhal"} & tags)
+        assert not ({"vpal", "halt", "vhal", "vkrn"} & tags)
 
     def test_runtime_palt_can_bake_base_fraction_and_reinstall_residual(self, noto_subset):
         cmap = noto_subset.getBestCmap()
@@ -802,7 +858,7 @@ class TestMakeProportional:
             for fr in noto_subset["GPOS"].table.FeatureList.FeatureRecord
         }
         assert {"palt", "vpal"} <= tags
-        assert not ({"halt", "vhal"} & tags)
+        assert not ({"halt", "vhal", "vkrn"} & tags)
 
     def test_runtime_palt_does_not_keep_baked_glyphs_in_feature(self, noto_subset):
         cmap = noto_subset.getBestCmap()


### PR DESCRIPTION
## Summary

- Disable vertical `kern`/`vkrn` behavior in the proportional Noto processing path.
- Keep `ss09` horizontal-only by removing vertical punctuation alternates from the generated feature.
- Add normal-family vertical Japanese tracking at 9 design units while leaving Display unchanged.
- Update architecture docs and regression tests for the vertical writing policy.

## Why

Gen Interface JP is primarily a UI/body font for horizontal text. Vertical writing should remain a simple fallback, with beta-style Japanese vertical composition and no optional punctuation tightening through `ss09`.

## Validation

- `PYTHONPATH=src python3 -m pytest -q` -> `198 passed`
- `PYTHONPATH=src python3 -m font.build --jobs 16` -> built all 16 TTFs
- Spot checked current TTFs against `GenInterfaceJP-0.6.0.zip`: normal Regular `uni3001` vertical advance delta is `+17 / TSB +0`; Display Regular remains `+0 / +0`.