### PR TITLE
Remove dead glyph classifiers and inline trivial tracking wrapper

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -219,6 +219,9 @@ inst に対して 4 つのサブパスを in-place で実行:
    `U+FE49-U+FE4F`)、two-/three-em dash (`U+2E3A`, `U+2E3B`)、全角
    low line (`U+FF3F`)、全角 macron (`U+FFE3`) を除外し、隙間なしで
    反復される記号のリズムを保つ。
+   ユーザー向けコードポイント方針から glyph 名が必要な場合は、`uniXXXX`
+   glyph 名 parse を信用せず cmap で解決する。Noto の Han glyph には
+   `cidNNNNN` や post-substitution 名が含まれるため。
 3. **個別グリフのスペーシング** (`_apply_glyph_spacing`) — palt + 一律
    トラッキングだけでは追い込めない稀なグリフのための手動レイヤー。
    ファミリー設定の `glyphSpacing` がコードポイント (または 1 文字) を
@@ -512,8 +515,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
   forwarding
   (`SOURCE_UPM = 1000`, `TARGET_UPM = 2048`)、`_glyph_codepoint`, `_reverse_cmap`,
   `_is_kana_or_punct`, `_is_kana_or_punct_codepoint`,
-  `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
-  `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
+  `_is_cjk_codepoint`, `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
   `_apply_tracking`, `_apply_vertical_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
   `_split_cmap_codepoint_glyph`、明示的な palt/ss09 spacing 方針、
   縦方向 ss09 無効化ポリシーの確認、final TTF integrity validation、
@@ -541,7 +543,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 126 | CLI build selection / parallel intermediate path separation、和文 vertical body scaling/tracking、UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、reverse-cmap kana / 句読点分類、CJK 分類、GSUB/GPOS 走査、baseline palt 方針、x-scale、bbox 除去、tracking、final TTF integrity validation、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
+| `test_font_build.py` | 114 | CLI build selection / parallel intermediate path separation、和文 vertical body scaling/tracking、UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、reverse-cmap kana / 句読点分類、CJK 分類、GSUB/GPOS 走査、baseline palt 方針、x-scale、bbox 除去、tracking、final TTF integrity validation、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
 | `test_proportional.py` | 39 | palt/vpal 抽出、SinglePos lookup の加算読み取り、グリフ平行移動、vkrn を含む GPOS feature 削除、runtime-palt/vpal helper coverage + base/residual 分割 + optional squeeze helper、ss09 生成 + 縦方向 no-op を含む shaping |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -220,6 +220,9 @@ Four sub-passes, all in-place on the inst:
    forms (`U+FE19`, `U+FE30-U+FE34`, `U+FE49-U+FE4F`), two-/three-em
    dashes (`U+2E3A`, `U+2E3B`), fullwidth low line (`U+FF3F`), and
    fullwidth macron (`U+FFE3`).
+   Any build policy that needs glyph names from user-facing codepoints
+   resolves through cmap rather than trusting `uniXXXX` glyph-name parsing:
+   Noto can ship Han glyphs as `cidNNNNN` or post-substitution names.
 3. **Per-glyph spacing** (`_apply_glyph_spacing`) — manual fallback for
    the rare glyph whose sidebearings still read off after palt + uniform
    tracking. The family's `glyphSpacing` dict maps a codepoint or
@@ -521,8 +524,7 @@ Tests live under `tests/`, split by surface:
   metadata forwarding
   (`SOURCE_UPM = 1000`, `TARGET_UPM = 2048`), `_glyph_codepoint`, `_reverse_cmap`,
   `_is_kana_or_punct`, `_is_kana_or_punct_codepoint`,
-  `_is_cjk_codepoint`, `_is_kana_letter`, `_get_cjk_glyphs`,
-  `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
+  `_is_cjk_codepoint`, `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
   `_apply_tracking`, `_apply_vertical_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
   `_split_cmap_codepoint_glyph`, explicit palt/ss09 spacing policy, vertical
   ss09-disabled policy checks, final TTF integrity validation, and
@@ -550,7 +552,7 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 126 | CLI build selection and parallel intermediate path separation, Japanese vertical body scaling/tracking, UPM scaling policy, project-version metadata forwarding, glyph-name parsing, reverse-cmap kana / punctuation classification, CJK classification, GSUB/GPOS walk, baseline palt policy, x-scale, bbox strip, tracking, final TTF integrity validation, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
+| `test_font_build.py` | 114 | CLI build selection and parallel intermediate path separation, Japanese vertical body scaling/tracking, UPM scaling policy, project-version metadata forwarding, glyph-name parsing, reverse-cmap kana / punctuation classification, CJK classification, GSUB/GPOS walk, baseline palt policy, x-scale, bbox strip, tracking, final TTF integrity validation, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
 | `test_proportional.py` | 39 | palt/vpal extraction, cumulative SinglePos lookup reading, glyph translation, GPOS feature removal including vkrn, runtime-palt/vpal helper coverage + base/residual split + optional squeeze helper, ss09 construction + shaping including vertical no-op coverage |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -625,20 +625,6 @@ def _is_cjk_codepoint(cp: int) -> bool:
     )
 
 
-def _get_cjk_glyphs(font: TTFont) -> set[str]:
-    """Resolve CJK ideograph glyph names through the font's cmap.
-
-    cmap-driven lookup (rather than glyph-name parsing) catches ideographs
-    whose names don't follow ``uniXXXX`` — Noto ships some Han glyphs as
-    ``cidNNNNN`` or post-substitution names that wouldn't match a
-    ``uni``-prefix check.
-    """
-    cmap = font.getBestCmap()
-    if cmap is None:
-        return set()
-    return {gname for cp, gname in cmap.items() if _is_cjk_codepoint(cp)}
-
-
 def _split_cmap_codepoint_glyph(
     font: TTFont,
     codepoint: int,
@@ -671,26 +657,6 @@ def _split_cmap_codepoint_glyph(
             table.cmap[codepoint] = new_glyph_name
 
     return source_glyph
-
-
-def _is_kana_letter(glyph_name: str) -> bool:
-    """Return True for hiragana / katakana *letters*, excluding punctuation.
-
-    Stricter than :func:`_is_kana_or_punct`: this helper answers whether a
-    glyph is an actual kana letter rather than CJK punctuation or fullwidth
-    symbols.
-    Notable exclusion: U+30FB (・) is punctuation, not a letter.
-    """
-    cp = _glyph_codepoint(glyph_name)
-    if cp is None:
-        return False
-    return (
-        0x3041 <= cp <= 0x3096    # Hiragana letters (ぁ-ゖ)
-        or 0x3099 <= cp <= 0x309F  # Hiragana combining/iteration marks
-        or 0x30A1 <= cp <= 0x30FA  # Katakana letters (ァ-ヺ), excludes ・(30FB)
-        or 0x30FC <= cp <= 0x30FF  # Katakana prolonged sound / iteration marks
-        or 0x31F0 <= cp <= 0x31FF  # Katakana Phonetic Extensions
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -889,7 +855,12 @@ def _glyphs_for_codepoints(
     font: TTFont,
     codepoint_entries: list | tuple | set | None,
 ) -> set[str]:
-    """Resolve codepoint / single-character entries to glyph names via cmap."""
+    """Resolve codepoint / single-character entries to glyph names via cmap.
+
+    Used for user-facing codepoint policies such as runtime palt targets and
+    tracking-ignore ranges. cmap resolution is the correct source of truth
+    for those policies rather than glyph-name parsing.
+    """
     codepoints = _codepoints_for_entries(codepoint_entries)
     cmap = font.getBestCmap() or {}
     return {glyph_name for cp, glyph_name in cmap.items() if cp in codepoints}
@@ -1236,19 +1207,6 @@ def _refresh_ss09_feature_after_merge(
     font.save(final_path)
 
 
-def _tracking_ignore_glyphs(
-    font: TTFont,
-    tracking_ignore: list | tuple | set | None,
-) -> set[str]:
-    """Resolve tracking-ignore codepoints to glyph names via cmap.
-
-    Ignore rules are a user-facing codepoint policy (ranges like box drawing
-    and leaders), so cmap resolution is the correct source of truth rather
-    than glyph-name parsing.
-    """
-    return _glyphs_for_codepoints(font, tracking_ignore)
-
-
 def _apply_tracking(
     font: TTFont,
     tracking: int,
@@ -1285,7 +1243,7 @@ def _apply_tracking(
     glyph.
     """
     hmtx = font["hmtx"]
-    ignore_glyphs = _tracking_ignore_glyphs(font, tracking_ignore)
+    ignore_glyphs = _glyphs_for_codepoints(font, tracking_ignore)
     reverse_cmap = _reverse_cmap(font)
     for glyph_name in font.getGlyphOrder():
         aw, lsb = hmtx[glyph_name]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,6 @@ mutate without poisoning the shared state.
 
 import copy
 import io
-import os
 from pathlib import Path
 
 import pytest
@@ -54,7 +53,7 @@ _TEST_CODEPOINTS = [
     0x3038,                   # 〸 CJK numerals (range 3038..303B)
     0x3042, 0x304B,           # あ か (hiragana letters)
     0x30A2, 0x30AB,           # ア カ (katakana letters)
-    0x30FB,                   # ・ middle dot (katakana-block punct, excluded from _is_kana_letter)
+    0x30FB,                   # ・ middle dot (katakana-block punctuation)
     0x4E00, 0x6F22,           # 一 漢 (CJK ideographs)
     0xFF21,                   # Ａ fullwidth A
 ]

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -25,14 +25,12 @@ from font.build import (
     _feature_adjustments_for_codepoints,
     _final_ttf_path,
     _final_output_metadata,
-    _get_cjk_glyphs,
     _get_vert_alternates,
     _get_baseline_palt,
     _glyphs_for_codepoints,
     _glyph_codepoint,
     _intermediate_paths,
     _is_cjk_codepoint,
-    _is_kana_letter,
     _is_kana_or_punct,
     _is_kana_or_punct_codepoint,
     _parallel_task_command,
@@ -483,87 +481,6 @@ class TestIsCjkCodepoint:
         # only the narrow CJK numeral / ideograph-symbol slices are CJK.
         assert not _is_cjk_codepoint(0x3001)  # 、
         assert not _is_cjk_codepoint(0x3000)  # ideographic space
-
-
-# ---------------------------------------------------------------------------
-# _is_kana_letter
-# ---------------------------------------------------------------------------
-
-class TestIsKanaLetter:
-    """Kana *letter* classification — strict subset of _is_kana_or_punct."""
-
-    def test_hiragana_letters(self):
-        assert _is_kana_letter("uni3042")  # あ
-        assert _is_kana_letter("uni3093")  # ん
-
-    def test_katakana_letters(self):
-        assert _is_kana_letter("uni30A2")  # ア
-        assert _is_kana_letter("uni30F3")  # ン
-
-    def test_hiragana_iteration_marks_included(self):
-        # ゛ ゜ ゝ ゞ ゟ (U+309B-309F) — hiragana combining / iteration block,
-        # treated as letter-class.
-        assert _is_kana_letter("uni309D")  # ゝ
-        assert _is_kana_letter("uni309E")  # ゞ
-
-    def test_cjk_block_iteration_marks_excluded(self):
-        # 〱 〲 (U+3031, U+3032) live in the CJK Symbols & Punctuation
-        # block, not the kana blocks — _is_kana_letter excludes them so
-        # they do not receive full kana palt treatment.
-        assert not _is_kana_letter("uni3031")
-        assert not _is_kana_letter("uni3032")
-
-    def test_middle_dot_excluded(self):
-        # ・ (U+30FB) is in the katakana block but counts as punctuation,
-        # not a letter — it should NOT receive full kana palt.
-        assert not _is_kana_letter("uni30FB")
-
-    def test_cjk_punct_excluded(self):
-        assert not _is_kana_letter("uni3001")  # 、
-        assert not _is_kana_letter("uni3000")  # ideographic space
-
-    def test_latin_excluded(self):
-        assert not _is_kana_letter("A")
-        assert not _is_kana_letter("uni0041")
-
-    def test_cjk_ideograph_excluded(self):
-        assert not _is_kana_letter("uni4E00")
-
-
-# ---------------------------------------------------------------------------
-# _get_cjk_glyphs
-# ---------------------------------------------------------------------------
-
-class TestGetCjkGlyphs:
-    """cmap-based CJK glyph lookup."""
-
-    def test_returns_ideograph_glyphs(self, noto_subset):
-        cjk_glyphs = _get_cjk_glyphs(noto_subset)
-        cmap = noto_subset.getBestCmap()
-        # 一 (U+4E00) and 漢 (U+6F22) are CJK ideographs in our subset.
-        # Look up their glyph names via the actual cmap (subsetter may
-        # have remapped to canonical Adobe names like uni2F00 for U+4E00).
-        assert cmap[0x4E00] in cjk_glyphs
-        assert cmap[0x6F22] in cjk_glyphs
-
-    def test_excludes_kana_glyphs(self, noto_subset):
-        cjk_glyphs = _get_cjk_glyphs(noto_subset)
-        cmap = noto_subset.getBestCmap()
-        assert cmap[0x3042] not in cjk_glyphs  # あ
-        assert cmap[0x30A2] not in cjk_glyphs  # ア
-
-    def test_excludes_latin(self, noto_subset):
-        cjk_glyphs = _get_cjk_glyphs(noto_subset)
-        cmap = noto_subset.getBestCmap()
-        assert cmap[0x0041] not in cjk_glyphs
-
-    def test_empty_when_no_cmap(self, synthetic_ttf):
-        # Drop the cmap and verify graceful fallback to empty set.
-        synthetic_ttf["cmap"].tables = []
-        # getBestCmap returns {} when there are no tables; we accept either
-        # empty dict or None.
-        result = _get_cjk_glyphs(synthetic_ttf)
-        assert result == set()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Behavior-preserving cleanup of the build pipeline plus a test-suite audit. No output changes — verified by rebuilding the normal Regular and comparing against the pre-refactor build.

## Changes

- **Remove dead code**: `_is_kana_letter` and `_get_cjk_glyphs` were referenced only by their own tests (nothing in `src/` uses them). Deleted along with their test classes.
- **Inline trivial wrapper**: `_tracking_ignore_glyphs` only delegated to `_glyphs_for_codepoints`; callers now use the latter directly, and the codepoint-policy rationale from its docstring moved into `_glyphs_for_codepoints`.
- **Test cleanup**: drop imports/tests of the removed functions, prune an unused import and a stale comment in `conftest.py`.
- **Docs sync**: update the test-count tables and function lists in `ARCHITECTURE.md` / `ARCHITECTURE.ja.md`.

Deliberately skipped (risk outweighs benefit for a zero-diff refactor): merging `_scale_design_adjustment` with proportional's `_scale_position_adjustment` (different rounding paths), and extracting helpers from `build_one()` (pure churn).

## Verification

- `pytest tests/` — **197 passed** (12 tests removed with the dead code)
- Rebuilt normal Regular and diffed against the pre-refactor build: **zero differences** in glyph set (19,498), cmap, hmtx, vmtx, outlines, and head bbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)