### PR TITLE
Add zero-width glyphs for variation selectors and ZWNJ/ZWJ

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -36,6 +36,7 @@ Gen Interface JP はフォントビルドパイプライン (アプリ/UI なし
         │         output.upm=2048, metricsSource=sub      │
         │         project version + manufacturer 刻印      │
         │         GSUB/GPOS coverage order 正規化          │
+        │         default-ignorable cmap filler 追加       │
         │         final cmap / glyph reference 検証        │
         │             ↓                                   │
         │   dist/ttf/  (ファミリー × ウェイトごとに TTF)    │
@@ -112,6 +113,11 @@ FAMILIES × WEIGHTS の各組合せに対して:
   → merge 時の glyph rename 後も横方向の optional 約物挙動が残るよう、
     final cmap / glyph 名に対して horizontal yakumono-only ss09 を生成;
     縦組みは基本の全角ベタ組フォールバックとして扱う
+  → post-merge で U+200C、U+200D、U+FE00-U+FE0F に zero-width の
+    default-ignorable 空 glyph を追加し、format 4 / format 12 cmap に載せる。
+    Gen Interface JP に解決された絵文字兼用テキスト記号の直後に variation
+    selector や ZWJ が来たとき、literal なコンポーザーが tofu 表示するのを防ぐ。
+    format 14 UVS は変更しない
   → final TTF の整合性を検証: .notdef が GID 0、maxp count、cmap target、
     composite component、GSUB/GPOS compile
 ```
@@ -516,6 +522,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
   (`SOURCE_UPM = 1000`, `TARGET_UPM = 2048`)、`_glyph_codepoint`, `_reverse_cmap`,
   `_is_kana_or_punct`, `_is_kana_or_punct_codepoint`,
   `_is_cjk_codepoint`, `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
+  `_add_default_ignorable_glyphs`,
   `_apply_tracking`, `_apply_vertical_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
   `_split_cmap_codepoint_glyph`、明示的な palt/ss09 spacing 方針、
   縦方向 ss09 無効化ポリシーの確認、final TTF integrity validation、
@@ -543,7 +550,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 114 | CLI build selection / parallel intermediate path separation、和文 vertical body scaling/tracking、UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、reverse-cmap kana / 句読点分類、CJK 分類、GSUB/GPOS 走査、baseline palt 方針、x-scale、bbox 除去、tracking、final TTF integrity validation、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
+| `test_font_build.py` | 120 | CLI build selection / parallel intermediate path separation、和文 vertical body scaling/tracking、UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、reverse-cmap kana / 句読点分類、CJK 分類、GSUB/GPOS 走査、baseline palt 方針、x-scale、bbox 除去、default-ignorable zero-width glyph 追加、tracking、final TTF integrity validation、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
 | `test_proportional.py` | 39 | palt/vpal 抽出、SinglePos lookup の加算読み取り、グリフ平行移動、vkrn を含む GPOS feature 削除、runtime-palt/vpal helper coverage + base/residual 分割 + optional squeeze helper、ss09 生成 + 縦方向 no-op を含む shaping |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,6 +36,7 @@ consumes the published webfont package.
         │         output.upm=2048, metricsSource=sub      │
         │         project version + manufacturer stamp    │
         │         normalize GSUB/GPOS coverage order      │
+        │         add default-ignorable cmap fillers      │
         │         validate final cmap / glyph references  │
         │             ↓                                   │
         │   dist/ttf/  (one TTF per family × weight)      │
@@ -111,6 +112,11 @@ For each (family, weight) in FAMILIES × WEIGHTS:
   → install horizontal yakumono-only ss09 against the final cmap / glyph names
     so merge-time glyph renames keep optional horizontal yakumono behavior;
     vertical writing remains a basic full-width fallback
+  → add post-merge default-ignorable zero-width glyphs for U+200C, U+200D,
+    and U+FE00-U+FE0F to format 4 / format 12 cmap tables. These empty glyphs
+    prevent literal composers from rendering tofu for emoji variation
+    selectors or ZWJ after a base text symbol resolved to Gen Interface JP;
+    format 14 UVS data is not modified.
   → validate final TTF integrity: .notdef at GID 0, maxp count, cmap targets,
     composite components, and GSUB/GPOS compilation
 ```
@@ -525,6 +531,7 @@ Tests live under `tests/`, split by surface:
   (`SOURCE_UPM = 1000`, `TARGET_UPM = 2048`), `_glyph_codepoint`, `_reverse_cmap`,
   `_is_kana_or_punct`, `_is_kana_or_punct_codepoint`,
   `_is_cjk_codepoint`, `_get_vert_alternates`, `_apply_x_scale`, `_strip_extreme_glyphs`,
+  `_add_default_ignorable_glyphs`,
   `_apply_tracking`, `_apply_vertical_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
   `_split_cmap_codepoint_glyph`, explicit palt/ss09 spacing policy, vertical
   ss09-disabled policy checks, final TTF integrity validation, and
@@ -552,7 +559,7 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 114 | CLI build selection and parallel intermediate path separation, Japanese vertical body scaling/tracking, UPM scaling policy, project-version metadata forwarding, glyph-name parsing, reverse-cmap kana / punctuation classification, CJK classification, GSUB/GPOS walk, baseline palt policy, x-scale, bbox strip, tracking, final TTF integrity validation, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
+| `test_font_build.py` | 120 | CLI build selection and parallel intermediate path separation, Japanese vertical body scaling/tracking, UPM scaling policy, project-version metadata forwarding, glyph-name parsing, reverse-cmap kana / punctuation classification, CJK classification, GSUB/GPOS walk, baseline palt policy, x-scale, bbox strip, default-ignorable zero-width glyph insertion, tracking, final TTF integrity validation, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
 | `test_proportional.py` | 39 | palt/vpal extraction, cumulative SinglePos lookup reading, glyph translation, GPOS feature removal including vkrn, runtime-palt/vpal helper coverage + base/residual split + optional squeeze helper, ss09 construction + shaping including vertical no-op coverage |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -10,7 +10,8 @@ Shared pipeline per weight:
   3. Apply tracking                            (horizontal hmtx + vertical vmtx)
   4. Merge Inter/InterDisplay + proportional Noto  (font-baker, with
      subFont.excludeCodepoints to keep CJK-conventional symbols on Noto)
-  5. Validate final cmap / glyph order / layout-table integrity
+  5. Add zero-width default-ignorable glyphs    (VS1-16 + ZWNJ/ZWJ)
+  6. Validate final cmap / glyph order / layout-table integrity
 
 Families:
   - Gen Interface JP         : Inter       + proportional Noto, tracking +30 (kana/punct +45, vertical JP +9) at 1000 UPM
@@ -471,6 +472,15 @@ SUB_EXCLUDE_CODEPOINTS = [
 # Negative-circled families (❶-❿ U+2776-U+277F, ➊-➓ U+278A-U+2793) are
 # absent from Inter entirely, so they fall through to Noto without help.
 
+# Default-ignorable controls needed to avoid tofu in literal composers when
+# Gen owns an emoji-capable base text symbol followed by a variation selector
+# (for example U+2764 U+FE0F). U+200B and U+FEFF already come from Inter.
+DEFAULT_IGNORABLE_CODEPOINTS = frozenset((
+    0x200C,  # ZERO WIDTH NON-JOINER
+    0x200D,  # ZERO WIDTH JOINER
+    *range(0xFE00, 0xFE10),  # VARIATION SELECTOR-1..16
+))
+
 # Vertical alignment between Inter and Noto.
 #
 # When the merged font hands its baseline to Inter (`metricsSource: "sub"`),
@@ -845,6 +855,109 @@ def _strip_extreme_glyphs(font: TTFont) -> None:
                         k: v for k, v in st.mapping.items()
                         if k not in to_remove and v not in to_remove
                     }
+
+
+# ---------------------------------------------------------------------------
+# Default-ignorable cmap fillers
+# ---------------------------------------------------------------------------
+
+def _adobe_bmp_glyph_name(codepoint: int) -> str:
+    """Return the Adobe-style glyph name used for a BMP codepoint."""
+    return f"uni{codepoint:04X}"
+
+
+def _available_default_ignorable_glyph_name(codepoint: int, glyphs: set[str]) -> str:
+    """Return an unused glyph name for a default-ignorable codepoint."""
+    base_name = _adobe_bmp_glyph_name(codepoint)
+    if base_name not in glyphs:
+        return base_name
+
+    # Inter currently maps U+FEFF to a glyph named ``uni200D``. Keep that
+    # existing glyph untouched and append a codepoint-specific suffixed glyph
+    # so U+200D still has its own reverse-cmap target.
+    suffix = "defaultIgnorable"
+    candidate = f"{base_name}.{suffix}"
+    if candidate not in glyphs:
+        return candidate
+    index = 1
+    while True:
+        candidate = f"{base_name}.{suffix}{index}"
+        if candidate not in glyphs:
+            return candidate
+        index += 1
+
+
+def _encoded_cmap_codepoints(font: TTFont) -> set[int]:
+    """Return codepoints already encoded in non-UVS cmap subtables."""
+    encoded: set[int] = set()
+    for table in font["cmap"].tables:
+        if table.format == 14:
+            continue
+        encoded.update(table.cmap)
+    return encoded
+
+
+def _add_default_ignorable_glyphs(font: TTFont) -> int:
+    """Add empty zero-width glyphs for selected default-ignorable controls.
+
+    The glyphs are appended after the post-merge font-baker output so they do
+    not pass through proportionalisation or tracking. Existing cmap entries
+    are left untouched, making the step future-proof if a vendor source later
+    encodes any of these controls itself.
+    """
+    from fontTools.ttLib.tables._g_l_y_f import Glyph
+
+    existing_codepoints = _encoded_cmap_codepoints(font)
+    to_add = [
+        cp for cp in sorted(DEFAULT_IGNORABLE_CODEPOINTS)
+        if cp not in existing_codepoints
+    ]
+    if not to_add:
+        return 0
+
+    glyph_order = font.getGlyphOrder()
+    glyphs = set(glyph_order)
+    additions = {}
+    for cp in to_add:
+        glyph_name = _available_default_ignorable_glyph_name(cp, glyphs)
+        additions[cp] = glyph_name
+        glyphs.add(glyph_name)
+
+    new_glyphs = list(additions.values())
+    font.setGlyphOrder([*glyph_order, *new_glyphs])
+
+    for glyph_name in new_glyphs:
+        empty = Glyph()
+        empty.numberOfContours = 0
+        empty.xMin = empty.yMin = empty.xMax = empty.yMax = 0
+        font["glyf"][glyph_name] = empty
+        font["hmtx"].metrics[glyph_name] = (0, 0)
+        if "vmtx" in font:
+            font["vmtx"].metrics[glyph_name] = (0, 0)
+
+    if "maxp" in font:
+        font["maxp"].numGlyphs = len(font.getGlyphOrder())
+
+    for table in font["cmap"].tables:
+        if table.format not in (4, 12):
+            continue
+        if table.platformID not in (0, 3):
+            continue
+        table.cmap.update(additions)
+
+    return len(to_add)
+
+
+def _add_default_ignorable_glyphs_to_ttf(font_path: str) -> int:
+    """Load a final TTF, add default-ignorable glyphs, and save if changed."""
+    font = TTFont(font_path)
+    try:
+        added = _add_default_ignorable_glyphs(font)
+        if added:
+            font.save(font_path)
+        return added
+    finally:
+        font.close()
 
 
 # ---------------------------------------------------------------------------
@@ -1464,7 +1577,10 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
        the merged hhea (``metricsSource: "sub"``), and our manufacturer /
        URL plus the project version get stamped into the final name/head
        metadata.
-    4. **Validate** the final TTF's glyph order, cmap targets, composite
+    4. **Patch** the merged TTF with zero-width default-ignorable glyphs
+       for ZWNJ/ZWJ and VS1-16 so literal composers do not show tofu after
+       emoji-capable text symbols.
+    5. **Validate** the final TTF's glyph order, cmap targets, composite
        components, and layout table compilation after all post-merge rewrites.
     """
     os.makedirs(INTERMEDIATE, exist_ok=True)
@@ -1632,6 +1748,12 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
         {},
         {},
     )
+    default_ignorables_added = _add_default_ignorable_glyphs_to_ttf(final_path)
+    if default_ignorables_added:
+        print(
+            "          Default-ignorable glyphs: "
+            f"{default_ignorables_added} glyph(s) added"
+        )
     _validate_final_ttf(final_path)
     return {
         "fontPath": final_path,

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -8,13 +8,17 @@ inspection, horizontal scaling, bbox stripping, and tracking.
 from __future__ import annotations
 
 import copy
+import io
 import re
 from pathlib import Path
 
 import pytest
 from fontTools.ttLib import TTFont, newTable
+from fontTools.ttLib.tables._c_m_a_p import CmapSubtable
 
 from font.build import (
+    DEFAULT_IGNORABLE_CODEPOINTS,
+    _add_default_ignorable_glyphs,
     _apply_glyph_spacing,
     _apply_tracking,
     _apply_vertical_tracking,
@@ -111,6 +115,25 @@ def _add_glyph_copy(font: TTFont, source_glyph: str, new_glyph: str) -> None:
     font.setGlyphOrder([*font.getGlyphOrder(), new_glyph])
     font["glyf"][new_glyph] = copy.deepcopy(font["glyf"][source_glyph])
     font["hmtx"].metrics[new_glyph] = font["hmtx"][source_glyph]
+
+
+def _add_format12_cmap_tables(font: TTFont) -> None:
+    """Add standard platform 0/3 format 12 cmap tables to a synthetic font."""
+    existing_keys = {
+        (table.platformID, table.platEncID, table.format)
+        for table in font["cmap"].tables
+    }
+    base_cmap = dict(font.getBestCmap() or {})
+    for platform_id, platform_encoding_id in ((0, 4), (3, 10)):
+        key = (platform_id, platform_encoding_id, 12)
+        if key in existing_keys:
+            continue
+        table = CmapSubtable.newSubtable(12)
+        table.platformID = platform_id
+        table.platEncID = platform_encoding_id
+        table.language = 0
+        table.cmap = dict(base_cmap)
+        font["cmap"].tables.append(table)
 
 
 # ---------------------------------------------------------------------------
@@ -624,6 +647,137 @@ class TestStripExtremeGlyphs:
 
     def test_vertical_repeat_mark_policy_matches_unicode_range(self):
         assert _VERTICAL_REPEAT_MARK_CODEPOINTS == tuple(range(0x3031, 0x3036))
+
+
+# ---------------------------------------------------------------------------
+# default-ignorable glyphs
+# ---------------------------------------------------------------------------
+
+class TestDefaultIgnorableGlyphs:
+    """Post-merge zero-width fillers for emoji selectors and joiners."""
+
+    def test_constant_covers_joiners_and_variation_selectors_only(self):
+        assert DEFAULT_IGNORABLE_CODEPOINTS == frozenset((
+            0x200C,
+            0x200D,
+            *range(0xFE00, 0xFE10),
+        ))
+        assert len(DEFAULT_IGNORABLE_CODEPOINTS) == 18
+        assert 0x200B not in DEFAULT_IGNORABLE_CODEPOINTS
+        assert 0xFEFF not in DEFAULT_IGNORABLE_CODEPOINTS
+
+    def test_adds_all_codepoints_to_format_4_and_12_cmaps(self, synthetic_ttf):
+        _add_format12_cmap_tables(synthetic_ttf)
+
+        added = _add_default_ignorable_glyphs(synthetic_ttf)
+
+        assert added == 18
+        target_tables = [
+            table for table in synthetic_ttf["cmap"].tables
+            if table.platformID in (0, 3) and table.format in (4, 12)
+        ]
+        assert {
+            (table.platformID, table.platEncID, table.format)
+            for table in target_tables
+        } == {
+            (0, 3, 4),
+            (0, 4, 12),
+            (3, 1, 4),
+            (3, 10, 12),
+        }
+        for table in target_tables:
+            for cp in DEFAULT_IGNORABLE_CODEPOINTS:
+                assert table.cmap[cp] == f"uni{cp:04X}"
+
+    def test_added_glyphs_are_empty_and_zero_width(self, synthetic_ttf):
+        _add_format12_cmap_tables(synthetic_ttf)
+        vmtx = newTable("vmtx")
+        vmtx.metrics = {
+            glyph_name: (1000, 100)
+            for glyph_name in synthetic_ttf.getGlyphOrder()
+        }
+        synthetic_ttf["vmtx"] = vmtx
+
+        _add_default_ignorable_glyphs(synthetic_ttf)
+
+        for cp in DEFAULT_IGNORABLE_CODEPOINTS:
+            glyph_name = f"uni{cp:04X}"
+            glyph = synthetic_ttf["glyf"][glyph_name]
+            assert glyph.numberOfContours == 0
+            assert (glyph.xMin, glyph.yMin, glyph.xMax, glyph.yMax) == (0, 0, 0, 0)
+            assert synthetic_ttf["hmtx"][glyph_name] == (0, 0)
+            assert synthetic_ttf["vmtx"][glyph_name] == (0, 0)
+
+    def test_existing_codepoints_are_not_overwritten(self, synthetic_ttf):
+        _add_format12_cmap_tables(synthetic_ttf)
+        for table in synthetic_ttf["cmap"].tables:
+            if table.platformID in (0, 3) and table.format in (4, 12):
+                table.cmap[0xFE0F] = "A"
+
+        added = _add_default_ignorable_glyphs(synthetic_ttf)
+
+        assert added == 17
+        assert "uniFE0F" not in synthetic_ttf.getGlyphOrder()
+        for table in synthetic_ttf["cmap"].tables:
+            if table.platformID in (0, 3) and table.format in (4, 12):
+                assert table.cmap[0xFE0F] == "A"
+
+    def test_existing_glyph_name_collision_gets_individual_suffixed_glyph(
+        self,
+        synthetic_ttf,
+    ):
+        _add_format12_cmap_tables(synthetic_ttf)
+        _add_glyph_copy(synthetic_ttf, "A", "uni200D")
+        for table in synthetic_ttf["cmap"].tables:
+            if table.platformID in (0, 3) and table.format in (4, 12):
+                table.cmap[0xFEFF] = "uni200D"
+        before_glyph = copy.deepcopy(synthetic_ttf["glyf"]["uni200D"])
+        before_hmtx = synthetic_ttf["hmtx"]["uni200D"]
+
+        _add_default_ignorable_glyphs(synthetic_ttf)
+
+        zwj_targets = {
+            table.cmap[0x200D]
+            for table in synthetic_ttf["cmap"].tables
+            if table.platformID in (0, 3) and table.format in (4, 12)
+        }
+        assert len(zwj_targets) == 1
+        zwj_glyph = next(iter(zwj_targets))
+        assert zwj_glyph.startswith("uni200D.")
+        assert zwj_glyph != "uni200D"
+        assert synthetic_ttf["hmtx"]["uni200D"] == before_hmtx
+        assert (
+            synthetic_ttf["glyf"]["uni200D"].numberOfContours
+            == before_glyph.numberOfContours
+        )
+        assert synthetic_ttf["glyf"][zwj_glyph].numberOfContours == 0
+        assert synthetic_ttf["hmtx"][zwj_glyph] == (0, 0)
+        for table in synthetic_ttf["cmap"].tables:
+            if table.platformID in (0, 3) and table.format in (4, 12):
+                assert table.cmap[0xFEFF] == "uni200D"
+
+    def test_glyph_order_and_maxp_stay_consistent_after_roundtrip(self, synthetic_ttf):
+        _add_format12_cmap_tables(synthetic_ttf)
+        before_order = synthetic_ttf.getGlyphOrder()
+        expected_new_glyphs = [
+            f"uni{cp:04X}" for cp in sorted(DEFAULT_IGNORABLE_CODEPOINTS)
+        ]
+
+        _add_default_ignorable_glyphs(synthetic_ttf)
+
+        assert synthetic_ttf.getGlyphOrder() == [*before_order, *expected_new_glyphs]
+        assert synthetic_ttf["maxp"].numGlyphs == len(synthetic_ttf.getGlyphOrder())
+        _validate_font_integrity(synthetic_ttf, "synthetic default-ignorables")
+
+        buf = io.BytesIO()
+        synthetic_ttf.save(buf)
+        buf.seek(0)
+        reloaded = TTFont(buf)
+        try:
+            assert reloaded["maxp"].numGlyphs == len(reloaded.getGlyphOrder())
+            _validate_font_integrity(reloaded, "reloaded default-ignorables")
+        finally:
+            reloaded.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Background

Gen inherits Noto's cmap, which does not encode U+200C (ZWNJ), U+200D (ZWJ), or U+FE00–FE0F (variation selectors 1–16). At the same time Gen covers emoji-capable text symbols such as ❤ U+2764 and ☎ U+260E, so a sequence like ❤️ (U+2764 + U+FE0F) resolves its base character to Gen and leaves the selector unsupported. Modern shapers hide unsupported default-ignorables, but literal composers — notably Illustrator's — render them as .notdef tofu. (U+200B and U+FEFF were already covered via Inter.)

## Changes

- New post-merge build step appends empty zero-width glyphs for the 18 codepoints and maps them in the format 4 and format 12 cmap subtables (platforms 0 and 3); runs before final TTF validation
- Codepoints already encoded by a vendor source are skipped, so the step stays a no-op if Noto/Inter add coverage later
- Glyph-name collisions fall back to a `.defaultIgnorable` suffix — Inter already uses the name `uni200D` for its U+FEFF glyph, so U+200D lands on `uni200D.defaultIgnorable`
- UVS (cmap format 14) untouched; webfont unicode-range subsets pick the new codepoints up automatically
- 6 new tests; `ARCHITECTURE.md` / `ARCHITECTURE.ja.md` synced

## Verification

- `pytest tests/` — **203 passed**
- Rebuilt normal Regular and diffed against the previous build: **exactly +18 glyphs / +18 cmap entries**; existing glyph metrics, outlines, vmtx, and head bbox all unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)