### PR TITLE
Write ss09 UI label as Windows-only name records

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -191,7 +191,9 @@ inst に対して 4 つのサブパスを in-place で実行:
    原則として全量で焼き込むが、`PALT_FEATURE_CHARS` の約物は分割する。
    palt 調整量の 34% を `hmtx` に焼き込んでデフォルトでもある程度
    詰まる base metrics にし、残り 66% は final の yakumono-only `ss09`
-   stylistic set「約物半角」用に保持する。Noto の典型的な 1000-UPM source
+   stylistic set「約物半角」用に保持する。ss09 の UI 名は Windows Unicode
+   name レコードのみ (en 0x409 / ja 0x411、`mac=False`) で書く —
+   ofl-font-baker 0.4.8+ の「Mac name レコードを出荷しない」方針に合わせる。Noto の典型的な 1000-UPM source
    scale の `XAdvance=-500` 約物は 2048-UPM では `-1024` 相当になり、
    palt-off で `-348` が base advance に焼かれ、`ss09` 有効時に残り
    `-676` が適用される。runtime `vpal` は再生成せず、縦方向の `vkrn` も

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -189,7 +189,10 @@ Four sub-passes, all in-place on the inst:
    baked at full strength, but yakumono listed in `PALT_FEATURE_CHARS`
    is split: 34% of the palt adjustment is baked into `hmtx` so the glyph is
    still tightened by default, and the remaining 66% is held for a final
-   yakumono-only `ss09` stylistic set named "約物半角". For Noto's common
+   yakumono-only `ss09` stylistic set named "約物半角". The ss09 UI label
+   is written as Windows Unicode name records only (en 0x409 / ja 0x411,
+   `mac=False`), matching ofl-font-baker 0.4.8+'s policy of shipping no
+   Macintosh name records. For Noto's common
    `XAdvance=-500` yakumono records at the 1000-UPM source scale, the
    equivalent 2048-UPM record is `-1024`; palt-off gets `-348` baked into
    the base advance and enabling `ss09` applies the remaining `-676`.

--- a/src/font/proportional.py
+++ b/src/font/proportional.py
@@ -698,10 +698,17 @@ def _install_single_subst_feature(
 
 def _stylistic_set_feature_params(font: TTFont):
     """Return FeatureParams for the Japanese UI label of ss09."""
+    # mac=False: fontTools would otherwise add Macintosh (platformID 1)
+    # records alongside the Windows ones. ofl-font-baker 0.4.8+ strips all
+    # Mac name records from merged output, and this UI label is installed
+    # after the merge — keep the font consistently Windows-Unicode-only.
+    # Illustrator/InDesign read stylistic-set labels from the Windows
+    # records (en 0x409 / ja 0x411), so the visible ss09 name is unchanged.
     name_id = font["name"].addMultilingualName(
         SS09_UI_NAMES,
         ttFont=font,
         minNameID=256,
+        mac=False,
     )
     params = otTables.FeatureParamsStylisticSet()
     params.Version = 0

--- a/tests/test_proportional.py
+++ b/tests/test_proportional.py
@@ -489,6 +489,29 @@ class TestInstallSS09Punctuation:
         assert "約物半角" in names
         assert _feature_record(synthetic_ttf, "GPOS", "kern")
 
+    def test_ss09_ui_name_is_windows_only(self, synthetic_ttf):
+        # ofl-font-baker 0.4.8+ strips all Macintosh name records from
+        # merged output; the post-merge ss09 label must not reintroduce
+        # platformID 1 records while keeping the en/ja Windows labels.
+        _install_ss09_punctuation_feature(
+            synthetic_ttf,
+            {"uni3001": (-25, -100)},
+        )
+
+        _, record = _feature_record(synthetic_ttf, "GSUB", "ss09")
+        ui_name_id = record.Feature.FeatureParams.UINameID
+        ui_records = [
+            name for name in synthetic_ttf["name"].names
+            if name.nameID == ui_name_id
+        ]
+        assert ui_records, "ss09 UI name records missing"
+        assert all(name.platformID == 3 for name in ui_records)
+        langs = {
+            (name.langID, name.toUnicode()) for name in ui_records
+        }
+        assert (0x409, "Half-width punctuation") in langs
+        assert (0x411, "約物半角") in langs
+
     def test_installs_ss09_alternates_with_vmtx_metrics(self, synthetic_ttf):
         vmtx = newTable("vmtx")
         vmtx.metrics = {


### PR DESCRIPTION
## Background

ofl-font-baker 0.4.8 ([#40](https://github.com/yamatoiizuka/ofl-font-baker/pull/40)) stops shipping Macintosh (platformID 1) name records. But Gen installs the ss09 "約物半角" UI label **after** the merge via fontTools' `addMultilingualName`, which writes Mac records alongside the Windows ones by default — so the final fonts carried exactly two stray Mac records (en 1,0,0 + ja 1,1,11), recreating the inconsistent partial-Mac state the baker fix removed.

## Changes

- `addMultilingualName(..., mac=False)` so the ss09 UI label is written as Windows Unicode records only (en 0x409 / ja 0x411). Illustrator/InDesign read stylistic-set labels from Windows records, so the visible feature name (約物半角 / Half-width punctuation) is unchanged.
- Test pinning the ss09 UI name to platformID 3 with both language records present.
- `ARCHITECTURE.md` / `ARCHITECTURE.ja.md` note the Windows-only policy.

## Verification

- `pytest tests/` relevant suite passing (incl. new test)
- Full 16-face rebuild against ofl-font-baker 0.4.8: **zero platformID 1 records in every face**, GF static naming (`id1="… Thin"` / `id2=Regular` / correct fsSelection) and fwid retargeting (`A→Ａ`) confirmed across the matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)