### PR TITLE
Synthesize halt/vhal from ss09 residuals for CSS text-spacing-trim

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -81,14 +81,14 @@ FAMILIES × WEIGHTS の各組合せに対して:
   → font-baker bake: variable Noto → static TTF
                     inheritBase で designer/OFL/version を継承
                     weight だけを上書き
-  → inst を再読込し、Noto Variable の baseline palt を active 2048-UPM
-    build grid へ scale して使う
+  → inst を再読込し、Noto Variable の baseline palt / vhal を active
+    2048-UPM build grid へ scale して使う
   → ss09 約物を除き Noto の palt エントリを全量で焼き込み
     ss09 約物は 34% を base に焼き、66% を ss09 残差として保持
     (palt なしグリフはメトリクス維持)
   → make_proportional で palt → hmtx に焼き込み
-    palt/vpal/halt/vhal/vkrn を削除; 横方向の palt 残差だけを
-    final ss09 用に保持し、縦方向の vpal/vkrn 挙動は公開しない
+    palt/vpal/halt/vhal/vkrn を削除; 横方向の palt 残差と baseline vhal
+    record を final ss09 用に保持し、縦方向の vpal/vkrn 挙動は公開しない
   → _apply_tracking で advance を広げ LSB を半分シフト
     kana / 句読点は reverse cmap で分類
     ただし family["trackingIgnore"] の連続・隙間なし記号は除外
@@ -110,11 +110,11 @@ FAMILIES × WEIGHTS の各組合せに対して:
                      manufacturer / manufacturerURL を刻印
   → final TTF を一度 reload/save し、GSUB/GPOS coverage を
     merge 後の glyph ID 順に正規化
-  → merge 時の glyph rename 後も横方向の optional 約物挙動が残るよう、
-    final cmap / glyph 名に対して horizontal yakumono-only ss09 を生成;
-    縦組みは基本の全角ベタ組フォールバックとして扱う
-  → 同じ retarget 済み ss09 残差から GPOS halt を再生成して Chromium の
-    CSS text-spacing-trim を有効化; Blink は halt を必須とし、vhal / chws は
+  → final glyph 名に対して yakumono-only ss09 を生成: 横方向 alternate は
+    palt 残差、縦組み form alternate は baseline vhal の全量を使う;
+    optional spacing 無効時の縦組みは基本の全角ベタ組を維持
+  → 同じ retarget 済み ss09 調整から GPOS halt / vhal を再生成し、Chromium の
+    CSS text-spacing-trim を横組み・縦組みの両方で有効化; chws / vchw は
     意図的に生成しない
   → post-merge で U+200C、U+200D、U+FE00-U+FE0F に zero-width の
     default-ignorable 空 glyph を追加し、format 4 / format 12 cmap に載せる。
@@ -200,17 +200,20 @@ inst に対して 4 つのサブパスを in-place で実行:
    scale の `XAdvance=-500` 約物は 2048-UPM では `-1024` 相当になり、
    palt-off で `-348` が base advance に焼かれ、`ss09` 有効時に残り
    `-676` が適用される。runtime `vpal` は再生成せず、縦方向の `vkrn` も
-   削除する。production build では縦組み用 `.ss09` alternate も作らない。
-   縦組みは基本の全角ベタ組リズムを保つフォールバックとして扱う。
-   `make_proportional` では `palt`, `vpal`, `halt`, `vhal`, `vkrn` を削除するが、
-   final merge 後に `ss09` と同じ retarget 済み残差から新しい横方向の `halt`
-   を生成し、Chromium の CSS `text-spacing-trim` を有効にする (Blink は
-   `halt` を必須とする)。`vhal` と `chws` は意図的に生成しない。palt なしグリフは自動的に
+   削除する。代わりに production build は Noto の baseline `vhal` を読み、
+   縦メトリクスには base への焼き込みがないため、その全調整量を縦組み form
+   の `.ss09` alternate に適用する。`ss09` / `text-spacing-trim` 無効時は基本の
+   全角ベタ組を維持する。`make_proportional` では `palt`, `vpal`, `halt`, `vhal`,
+   `vkrn` を削除するが、final merge 後に `ss09` と同じ横・縦の調整から新しい
+   `halt` / `vhal` を生成し、Chromium の CSS `text-spacing-trim` を両方向で
+   有効にする。`chws` と `vchw` は意図的に生成しない。palt なしグリフは自動的に
    sidebearing を詰めない; 後続の明示的な spacing ルールが触らない限り
    元の `hmtx` を維持する。
    `U+30FB` (・) は Noto では `U+2027` (‧) と同じ `uni2027` を共有して
    いるため、palt ベイク前に `uni30FB` として分離する。これにより `‧` と
-   `・` は必要に応じて別々の optional spacing record を持てる。
+   `・` は必要に応じて別々の optional spacing record を持てる。source palt と
+   baseline vhal record はどちらも新しい `uni30FB` glyph へコピーし、split 後も
+   横・縦の optional spacing を維持する。
 2. **トラッキング** (`_apply_tracking`, `_apply_vertical_tracking`) — advance を `tracking` 分広げ、
    `tracking // 2` を LSB に加算してアウトラインを広がった枠の中央に
    配置。kana / 句読点はファミリー設定の `trackingKana` で別値。
@@ -305,16 +308,17 @@ release zip / npm package / site metadata と同じ project/release version を
 "https://yamatoiizuka.com"` でリリース TTF の nameID 8 / 11 を刻印。
 merge 後は final TTF を一度 fontTools で reload/save し、GSUB/GPOS coverage を
 最終 glyph order に合わせて正規化する。その後、merge 前に codepoint keyed で
-保持した横方向 record から、最小 runtime `ss09` 挙動を final cmap /
-glyph order に対して生成する。
+保持した横方向 record と baseline-vhal の縦方向 record から、最小 runtime
+`ss09` 挙動を final cmap / glyph order に対して生成する。encode された縦組み
+form は final cmap、unmapped vertical alternate は glyph 名 fallback で retarget する。
 これは `U+FF40` (｀) のように、Noto では `U+2035` と同じ `uni2035`
 を共有するが、Inter 側の `U+2035` と衝突して merge 後に
 `uni2035.orig` へ rename される glyph で必要になる。この final install は
 merge 後に行うため、保持していた残差 record も `SCALE` で換算し、live `ss09`
-alternate が光学スケール済みの Noto base と揃うようにする。同じ retarget
-済み残差を GPOS SinglePos `halt` としても生成し、Chromium の CSS
-`text-spacing-trim` を有効にする (Blink は `halt` を必須とする)。縦方向の
-`vhal` と contextual `chws` は生成しない。
+alternate が光学スケール済みの Noto base と揃うようにする。retarget 済みの
+横・縦の値は GPOS SinglePos `halt` / `vhal` としても生成し、Chromium の CSS
+`text-spacing-trim` を両方の writing mode で有効にする。contextual `chws` /
+`vchw` は生成しない。
 
 ## プロポーショナルメトリクス (`font/proportional.py`)
 
@@ -335,15 +339,17 @@ yakumono-only `ss09` として再生成する。本プロジェクトでは
 詰まり (2048-UPM build grid 上の典型的な `-1024` palt advance なら `-348`)、
 `ss09` を有効にすると従来の Noto full palt 目標まで到達する。
 production build では横方向の `ss09` target に `PALT_FEATURE_CHARS`
-(48 文字) を使う。縦方向の `ss09` target は意図的に空
-(`SS09_VERTICAL_FEATURE_CHARS = ()`, `SS09_VERTICAL_FEATURE_GLYPHS = ()`) にし、
+(48 文字) を使う。legacy の縦方向 target 定数
+(`SS09_VERTICAL_FEATURE_CHARS = ()`, `SS09_VERTICAL_FEATURE_GLYPHS = ()`) は空の
+ままだが、縦方向 coverage は Noto baseline `vhal` record から直接得る。encode
+された record は codepoint、unmapped vertical alternate は glyph 名で保持する。
 Noto の `vpal` / `vkrn` 挙動は final runtime surface へ持ち込まない。
 これにより、焼き込み済みの kana / Latin に palt が二重適用されることを
-避けながら、optional 約物 spacing は横方向の `ss09` に集約する。
+避けながら、optional 約物 spacing は横・縦の `ss09` に集約する。
 TrueType アウトラインのみ対応 (palt のベイクは `glyf` に書き戻すので
 CFF は対象外)。
 Inter との merge では base 側 glyph が rename されることがあるため、
-ビルドは merge 前に横方向の残差を codepoint 単位で保持し、merge 後の
+ビルドは merge 前に横方向の残差と encode 済み vhal record を codepoint 単位で保持し、merge 後の
 final cmap / glyph order に対して retarget する。この codepoint retarget は
 final cmap に encode された glyph だけが対象で、cmap に載らない alternate を
 merge rename 後も残す必要がある場合は `_retarget_named_adjustments` の
@@ -358,15 +364,14 @@ base metrics は merge 時に一度だけ scale
 レコードのインデックスを動かすので、各 LangSys の `FeatureIndex` 配列を
 生き残ったレコードに対して再キーする必要がある。feature 削除後は、どの
 生存 feature からも参照されない lookup だけを pruning する; 共有 lookup は
-残す。横方向の `kern` は GPOS に残し、`vkrn` は削除するため、
-縦組みは基本ボディグリッド上で組まれる。横方向の optional 約物は
-GSUB 側で扱う: `_install_ss09_punctuation_feature` が従来の palt 残差から
-`.ss09` metric alternate を作り、UI 名「約物半角」の `ss09` stylistic set
-を生成する。既存の横方向 PairPos kerning は `.ss09` alternate にも拡張するため、
-substitution 後も `kern` は効き続ける。横方向のみの alternate は元 glyph の
-`vmtx` record もコピーするため、保存後の font でも vertical metrics table の
-長さが拡張後の glyph order と揃う。production build ではこの helper に
-縦方向の調整を渡さないので、`ss09` は縦組みでは効かない。
+残す。横方向の `kern` は GPOS に残し、`vkrn` は削除するため、default の
+縦組みは基本ボディグリッド上で組まれる。optional 約物は GSUB 側で扱う:
+`_install_ss09_punctuation_feature` が従来の palt 残差から横方向 `.ss09` metric
+alternate を作り、baseline `vhal` から縦組み form の `vmtx` delta を持つ
+alternate を作って、UI 名「約物半角」の `ss09` stylistic set を生成する。
+既存の横方向 PairPos kerning は `.ss09` alternate にも拡張するため、substitution
+後も `kern` は効き続ける。横方向 alternate は元 glyph の `vmtx` record を
+コピーし、縦組み form alternate は vhal の advance / placement 全量を適用する。
 `ss09` を追加した後は GSUB `FeatureList` を
 `FeatureTag` 順に戻し、LangSys の feature index を再マップする。lookup order
 は変更しない。
@@ -436,9 +441,9 @@ Inter の Latin 専用挙動 (各行のグリフに応じた行高動的調整) 
 ここも `unicode-range` というユーザー向けコードポイント方針なので cmap
 起点で計画し、各 WOFF2 内で必要な alternate / positioning data は
 `fontTools.subset` の layout closure に任せる。
-この layout closure により final font の GSUB `ss09` と GPOS `halt` は該当
-subset に保持され、出荷 webfont でも Chromium の `text-spacing-trim` が有効に
-なる。`vhal` と `chws` は引き続き存在しない。
+この layout closure により final font の GSUB `ss09` と GPOS `halt` / `vhal` は
+該当 subset に保持され、出荷 webfont でも Chromium の `text-spacing-trim` が
+両 writing mode で有効になる。`chws` と `vchw` は引き続き存在しない。
 サブセット WOFF2 の生成は `--jobs` に従い、`jobs > 1` ではプロセスではなく
 `ThreadPoolExecutor` を使う。macOS/pyenv の spawn 経路が webfont 全体の大量
 タスク投入でデッドロックしたため (issue #33)。
@@ -528,7 +533,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
 
 テストは表面ごとに `tests/` 直下に分割:
 
-- **`tests/conftest.py`** — 共有フィクスチャ: 実 palt / vpal / vert / cmap データ
+- **`tests/conftest.py`** — 共有フィクスチャ: 実 palt / vpal / vhal / vert / cmap データ
   が必要なテスト用に Noto Variable のサブセットをセッション単位でキャッシュ;
   全グリフ走査が必要な mutation テスト用には `FontBuilder` で組み立てた
   最小 TrueType (Noto 17000 グリフを毎回触るのは無駄)。
@@ -541,7 +546,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
   `_add_default_ignorable_glyphs`,
   `_apply_tracking`, `_apply_vertical_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
   `_split_cmap_codepoint_glyph`、明示的な palt/ss09 spacing 方針、
-  縦方向 ss09 無効化ポリシーの確認、final TTF integrity validation、
+  baseline vhal と縦方向 ss09/vhal retarget、final TTF integrity validation、
   Thin / ExtraBold 用の InterVariable edge instance source 選択。
 - **`src/font/verify_edge_instances.py`** — Thin / ExtraBold のビルド後検証。
   生成された InterVariable static instance が vendor static と同じ cmap /
@@ -566,7 +571,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 122 | CLI build selection / parallel intermediate path separation、和文 vertical body scaling/tracking、UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、reverse-cmap kana / 句読点分類、CJK 分類、GSUB/GPOS 走査、baseline palt 方針、x-scale、bbox 除去、default-ignorable zero-width glyph 追加、tracking、ss09/halt feature の retarget、final TTF integrity validation、final runtime feature scaling、InterVariable edge instance 互換性 |
+| `test_font_build.py` | 124 | CLI build selection / parallel intermediate path separation、和文 vertical body scaling/tracking、UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、reverse-cmap kana / 句読点分類、CJK 分類、GSUB/GPOS 走査、U+30FB split 伝播を含む baseline palt/vhal 方針、x-scale、bbox 除去、default-ignorable zero-width glyph 追加、tracking、ss09/halt/vhal feature の retarget、final TTF integrity validation、final runtime feature scaling、InterVariable edge instance 互換性 |
 | `test_proportional.py` | 39 | palt/vpal 抽出、SinglePos lookup の加算読み取り、グリフ平行移動、vkrn を含む GPOS feature 削除、runtime-palt/vpal helper coverage + base/residual 分割 + optional squeeze helper、ss09 生成 + 縦方向 no-op を含む shaping |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |

--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -113,6 +113,9 @@ FAMILIES × WEIGHTS の各組合せに対して:
   → merge 時の glyph rename 後も横方向の optional 約物挙動が残るよう、
     final cmap / glyph 名に対して horizontal yakumono-only ss09 を生成;
     縦組みは基本の全角ベタ組フォールバックとして扱う
+  → 同じ retarget 済み ss09 残差から GPOS halt を再生成して Chromium の
+    CSS text-spacing-trim を有効化; Blink は halt を必須とし、vhal / chws は
+    意図的に生成しない
   → post-merge で U+200C、U+200D、U+FE00-U+FE0F に zero-width の
     default-ignorable 空 glyph を追加し、format 4 / format 12 cmap に載せる。
     Gen Interface JP に解決された絵文字兼用テキスト記号の直後に variation
@@ -199,8 +202,10 @@ inst に対して 4 つのサブパスを in-place で実行:
    `-676` が適用される。runtime `vpal` は再生成せず、縦方向の `vkrn` も
    削除する。production build では縦組み用 `.ss09` alternate も作らない。
    縦組みは基本の全角ベタ組リズムを保つフォールバックとして扱う。
-   final font では `palt`, `vpal`, `halt`, `vhal`, `vkrn` を削除し、
-   optional 約物 spacing は横方向の `ss09` だけで公開する。palt なしグリフは自動的に
+   `make_proportional` では `palt`, `vpal`, `halt`, `vhal`, `vkrn` を削除するが、
+   final merge 後に `ss09` と同じ retarget 済み残差から新しい横方向の `halt`
+   を生成し、Chromium の CSS `text-spacing-trim` を有効にする (Blink は
+   `halt` を必須とする)。`vhal` と `chws` は意図的に生成しない。palt なしグリフは自動的に
    sidebearing を詰めない; 後続の明示的な spacing ルールが触らない限り
    元の `hmtx` を維持する。
    `U+30FB` (・) は Noto では `U+2027` (‧) と同じ `uni2027` を共有して
@@ -306,7 +311,10 @@ glyph order に対して生成する。
 を共有するが、Inter 側の `U+2035` と衝突して merge 後に
 `uni2035.orig` へ rename される glyph で必要になる。この final install は
 merge 後に行うため、保持していた残差 record も `SCALE` で換算し、live `ss09`
-alternate が光学スケール済みの Noto base と揃うようにする。
+alternate が光学スケール済みの Noto base と揃うようにする。同じ retarget
+済み残差を GPOS SinglePos `halt` としても生成し、Chromium の CSS
+`text-spacing-trim` を有効にする (Blink は `halt` を必須とする)。縦方向の
+`vhal` と contextual `chws` は生成しない。
 
 ## プロポーショナルメトリクス (`font/proportional.py`)
 
@@ -428,6 +436,9 @@ Inter の Latin 専用挙動 (各行のグリフに応じた行高動的調整) 
 ここも `unicode-range` というユーザー向けコードポイント方針なので cmap
 起点で計画し、各 WOFF2 内で必要な alternate / positioning data は
 `fontTools.subset` の layout closure に任せる。
+この layout closure により final font の GSUB `ss09` と GPOS `halt` は該当
+subset に保持され、出荷 webfont でも Chromium の `text-spacing-trim` が有効に
+なる。`vhal` と `chws` は引き続き存在しない。
 サブセット WOFF2 の生成は `--jobs` に従い、`jobs > 1` ではプロセスではなく
 `ThreadPoolExecutor` を使う。macOS/pyenv の spawn 経路が webfont 全体の大量
 タスク投入でデッドロックしたため (issue #33)。
@@ -555,7 +566,7 @@ PYTHONPATH=src python3 -m pytest        # 全テスト (~35 秒)
 
 | ファイル | テスト数 | 検証内容 |
 |---|---|---|
-| `test_font_build.py` | 120 | CLI build selection / parallel intermediate path separation、和文 vertical body scaling/tracking、UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、reverse-cmap kana / 句読点分類、CJK 分類、GSUB/GPOS 走査、baseline palt 方針、x-scale、bbox 除去、default-ignorable zero-width glyph 追加、tracking、final TTF integrity validation、ss09 feature の retarget、final runtime feature scaling、InterVariable edge instance 互換性 |
+| `test_font_build.py` | 122 | CLI build selection / parallel intermediate path separation、和文 vertical body scaling/tracking、UPM 換算ポリシー、project-version metadata forwarding、グリフ名パース、reverse-cmap kana / 句読点分類、CJK 分類、GSUB/GPOS 走査、baseline palt 方針、x-scale、bbox 除去、default-ignorable zero-width glyph 追加、tracking、ss09/halt feature の retarget、final TTF integrity validation、final runtime feature scaling、InterVariable edge instance 互換性 |
 | `test_proportional.py` | 39 | palt/vpal 抽出、SinglePos lookup の加算読み取り、グリフ平行移動、vkrn を含む GPOS feature 削除、runtime-palt/vpal helper coverage + base/residual 分割 + optional squeeze helper、ss09 生成 + 縦方向 no-op を含む shaping |
 | `test_release.py` | 2 | GitHub アセット URL 契約、npm パッケージレイアウト (files glob、license、README、self-host/CDN CSS root 配置) |
 | `test_webfont_build.py` | 42 | 範囲マージ / 重複除去、5 桁 hex 含む unicode-range、JIS 区マッピング、サブセット計画の配置 / 非重複 / 完全カバレッジ、ストラテジーパーサーのエッジケース |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,14 +81,14 @@ For each (family, weight) in FAMILIES × WEIGHTS:
   → font-baker bake: variable Noto → static TTF
                     inheritBase passes designer/OFL/version
                     through; only weight is stamped
-  → reload inst, read baseline palt from Noto Variable and scale it to the
-    active 2048-UPM build grid
+  → reload inst, read baseline palt and vhal from Noto Variable and scale
+    both to the active 2048-UPM build grid
   → bake Noto palt at full strength except ss09 yakumono,
     whose palt is split into a 34% baked base + 66% ss09 residual
     (glyphs without palt keep metrics)
   → make_proportional bakes palt → hmtx and removes palt/vpal/halt/vhal/vkrn;
-    horizontal palt residuals are held for final ss09 alternates while
-    vertical vpal/vkrn behavior is not exposed
+    horizontal palt residuals and baseline vhal records are held for final
+    ss09 alternates while vertical vpal/vkrn behavior is not exposed
   → _apply_tracking widens advances + half-balances LSB
     using reverse-cmap kana / punctuation classification
     except repeatable no-gap symbols in family["trackingIgnore"]
@@ -109,12 +109,13 @@ For each (family, weight) in FAMILIES × WEIGHTS:
                      manufacturer / manufacturerURL stamped
   → reload/save final TTF once so GSUB/GPOS coverage tables are ordered
     by the final merged glyph IDs
-  → install horizontal yakumono-only ss09 against the final cmap / glyph names
-    so merge-time glyph renames keep optional horizontal yakumono behavior;
-    vertical writing remains a basic full-width fallback
-  → re-synthesize GPOS halt from those same retargeted ss09 residuals so
-    Chromium CSS text-spacing-trim works; Blink requires halt, while vhal
-    and chws are intentionally absent
+  → install yakumono-only ss09 against final glyph names: horizontal
+    alternates use palt residuals, while vertical-form alternates use full
+    baseline vhal deltas; without optional spacing, vertical writing stays
+    on the basic full-width grid
+  → re-synthesize GPOS halt and vhal from those same retargeted ss09 deltas
+    so Chromium CSS text-spacing-trim works in horizontal and vertical flows;
+    chws and vchw are intentionally absent
   → add post-merge default-ignorable zero-width glyphs for U+200C, U+200D,
     and U+FE00-U+FE0F to format 4 / format 12 cmap tables. These empty glyphs
     prevent literal composers from rendering tofu for emoji variation
@@ -199,19 +200,23 @@ Four sub-passes, all in-place on the inst:
    `XAdvance=-500` yakumono records at the 1000-UPM source scale, the
    equivalent 2048-UPM record is `-1024`; palt-off gets `-348` baked into
    the base advance and enabling `ss09` applies the remaining `-676`.
-   Runtime `vpal` is not reinstalled, vertical `vkrn` is stripped, and
-   production builds do not create vertical `.ss09` alternates. Vertical
-   writing is treated as a fallback path that should keep basic full-width
-   rhythm. `make_proportional` strips `palt`, `vpal`, `halt`, `vhal`, and
-   `vkrn`; after the final merge, a fresh horizontal `halt` is synthesized
-   from the same retargeted residuals as `ss09` so Chromium can apply CSS
-   `text-spacing-trim` (Blink requires `halt`). `vhal` and `chws` remain
-   intentionally absent. Glyphs without palt entries are not
+   Runtime `vpal` is not reinstalled and vertical `vkrn` is stripped.
+   Production builds instead read Noto's baseline `vhal`: its full adjustment
+   is applied to vertical-form `.ss09` alternates because vertical metrics have
+   no baked base fraction. Without `ss09` or `text-spacing-trim`, vertical
+   writing remains on the basic full-width grid. `make_proportional` strips
+   `palt`, `vpal`, `halt`, `vhal`, and `vkrn`; after the final merge, fresh
+   `halt` and `vhal` features are synthesized from the same horizontal and
+   vertical adjustments as `ss09` so Chromium can apply CSS
+   `text-spacing-trim` in both flows. `chws` and `vchw` remain intentionally
+   absent. Glyphs without palt entries are not
    automatically sidebearing-squeezed; they keep their original
    `hmtx` unless a later explicit spacing rule touches them.
    `U+30FB` (・) is split from Noto's shared `uni2027` glyph before palt
    baking so `U+2027` (‧) and `U+30FB` (・) can carry separate optional
-   spacing records when needed.
+   spacing records when needed. Both the source palt and baseline vhal record
+   are copied to the new `uni30FB` glyph so the split preserves horizontal and
+   vertical optional spacing.
 2. **Tracking** (`_apply_tracking`, `_apply_vertical_tracking`) — advance grows by `tracking`;
    `tracking // 2` is added to LSB so the outline sits centred in the
    wider slot. Kana / punctuation get a separate `trackingKana` value
@@ -313,15 +318,17 @@ prefix. `output.manufacturer = "Yamato Iizuka"`, `output.manufacturerURL =
 After the merge, the TTF is reloaded and saved once with fontTools so
 GSUB/GPOS coverage tables are sorted against the final merged glyph order.
 Then the minimal runtime `ss09` behavior is rebuilt from codepoint-keyed
-horizontal records captured before the merge. This matters
+horizontal records and baseline-vhal vertical records captured before the
+merge. Encoded vertical forms are retargeted through the final cmap, while
+unmapped vertical alternates use the surviving glyph-name fallback. This matters
 for shared Noto glyphs such as `U+FF40` (｀), which uses Noto's `uni2035`
 before merge but may be renamed to `uni2035.orig` when Inter also provides
 `U+2035`. Because this final install happens after the merge, the saved
 residual records are also scaled by `SCALE` so live `ss09` alternates match
-the optically scaled Noto base. The same retargeted residuals are installed
-as a GPOS `halt` SinglePos feature so Chromium's CSS `text-spacing-trim`
-activates; Blink requires `halt`. No vertical `vhal` or contextual `chws`
-feature is created.
+the optically scaled Noto base. The retargeted horizontal and vertical values
+are also installed as GPOS SinglePos `halt` and `vhal` features so Chromium's
+CSS `text-spacing-trim` activates in either writing mode. Contextual `chws`
+and `vchw` are not created.
 
 ## Proportional Metrics (`font/proportional.py`)
 
@@ -344,15 +351,17 @@ Inter merge. The project uses
 tightened (`-348` for the common `-1024` palt advance on the 2048-UPM build
 grid) while enabling `ss09` reaches the former full Noto palt target.
 The production build uses `PALT_FEATURE_CHARS` (48 chars) for horizontal
-`ss09` targets. Vertical `ss09` targets are intentionally empty
-(`SS09_VERTICAL_FEATURE_CHARS = ()`, `SS09_VERTICAL_FEATURE_GLYPHS = ()`),
-and Noto `vpal` / `vkrn` behavior is not carried into the final runtime
-surface. This avoids double-applying palt to baked kana / Latin while keeping
-optional yakumono spacing under horizontal `ss09`. Only TrueType outlines are supported
+`ss09` targets. The legacy vertical target constants stay empty
+(`SS09_VERTICAL_FEATURE_CHARS = ()`, `SS09_VERTICAL_FEATURE_GLYPHS = ()`)
+because vertical coverage comes directly from Noto's baseline `vhal` records.
+Encoded records are captured by codepoint and unmapped vertical alternates by
+glyph name. Noto `vpal` / `vkrn` behavior is not carried into the final runtime
+surface. This avoids double-applying palt to baked kana / Latin while exposing
+optional yakumono spacing through horizontal and vertical `ss09`. Only TrueType outlines are supported
 — palt baking writes back to `glyf`, not CFF.
 Because the Inter merge can rename colliding base glyphs, the build captures
-horizontal residuals by codepoint before the merge, then retargets them
-against the final cmap / glyph order afterward. This codepoint retargeting
+horizontal residuals and encoded vhal records by codepoint before the merge,
+then retargets them against the final cmap / glyph order afterward. This codepoint retargeting
 only applies to glyphs encoded in the final cmap; named fallback records use
 `_retarget_named_adjustments` when an unencoded alternate needs to survive a
 merge rename. Those final records are scaled by the final Noto optical scale
@@ -366,16 +375,15 @@ Removing a record changes the indices of every later record, so each
 LangSys's `FeatureIndex` array is re-keyed against the surviving records.
 After feature removal, lookup indices are pruned only when no surviving
 feature references them; shared lookups stay intact. Horizontal `kern`
-remains in GPOS, while `vkrn` is removed so vertical writing stays on the
-basic body grid. Horizontal optional yakumono is
-handled as GSUB: `_install_ss09_punctuation_feature` creates `.ss09` metric
-alternates from the former palt residual and installs an `ss09` stylistic set
+remains in GPOS, while `vkrn` is removed so default vertical writing stays on
+the basic body grid. Optional yakumono is handled as GSUB:
+`_install_ss09_punctuation_feature` creates horizontal `.ss09` metric
+alternates from the former palt residual and vertical-form alternates whose
+`vmtx` deltas come from baseline `vhal`, then installs an `ss09` stylistic set
 with the UI name "約物半角". Existing horizontal PairPos kerning is extended
 to those alternates so `kern` continues to apply after substitution.
-Horizontal-only alternates copy their source glyphs' `vmtx` records so saved
-fonts keep vertical metrics table length in sync with the expanded glyph
-order. Production builds pass no vertical adjustments to this helper, so
-`ss09` has no vertical-writing effect. After `ss09` is
+Horizontal alternates copy their source glyphs' `vmtx` records, while
+vertical-form alternates apply the full vhal advance/placement delta. After `ss09` is
 appended, the GSUB `FeatureList` is sorted back into `FeatureTag` order and
 all LangSys feature indices are remapped; lookup order is left untouched.
 
@@ -444,9 +452,10 @@ along Unicode ranges and emits one `@font-face` rule per slice with a
 references. The plan is cmap/codepoint-driven because `unicode-range` is a
 user-facing character policy; `fontTools.subset` performs the layout closure
 needed to retain referenced alternates and positioning data inside each WOFF2.
-That layout closure preserves the final font's GSUB `ss09` and GPOS `halt`
-records in the relevant subsets, enabling Chromium `text-spacing-trim` in
-the shipped webfonts; `vhal` and `chws` remain absent.
+That layout closure preserves the final font's GSUB `ss09` and GPOS
+`halt`/`vhal` records in the relevant subsets, enabling Chromium
+`text-spacing-trim` in both writing modes in the shipped webfonts; `chws` and
+`vchw` remain absent.
 Subset WOFF2 generation honors `--jobs`; for `jobs > 1` it uses
 `ThreadPoolExecutor` rather than process workers because the macOS/pyenv
 spawn path deadlocked under the full webfont task fan-out (issue #33).
@@ -539,7 +548,7 @@ PYTHONPATH=src python3 -m pytest        # full suite (~35s)
 Tests live under `tests/`, split by surface:
 
 - **`tests/conftest.py`** — shared fixtures: a session-cached subset of
-  Noto Variable for tests that need real palt / vpal / vert / cmap data, and a
+  Noto Variable for tests that need real palt / vpal / vhal / vert / cmap data, and a
   hand-built minimal TrueType (`FontBuilder`) for whole-font mutation
   tests where 17 000 Noto glyphs would be wasteful.
 - **`tests/test_font_build.py`** — CLI build selection / parallel intermediate
@@ -552,7 +561,7 @@ Tests live under `tests/`, split by surface:
   `_add_default_ignorable_glyphs`,
   `_apply_tracking`, `_apply_vertical_tracking`, `_apply_glyph_spacing`, `_glyphs_for_codepoints`,
   `_split_cmap_codepoint_glyph`, explicit palt/ss09 spacing policy, vertical
-  ss09-disabled policy checks, final TTF integrity validation, and
+  baseline-vhal and ss09/vhal retarget checks, final TTF integrity validation, and
   InterVariable edge-instance source selection for Thin / ExtraBold.
 - **`src/font/verify_edge_instances.py`** — post-build verification for
   Thin / ExtraBold edge outputs. Confirms the generated InterVariable static
@@ -577,7 +586,7 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 122 | CLI build selection and parallel intermediate path separation, Japanese vertical body scaling/tracking, UPM scaling policy, project-version metadata forwarding, glyph-name parsing, reverse-cmap kana / punctuation classification, CJK classification, GSUB/GPOS walk, baseline palt policy, x-scale, bbox strip, default-ignorable zero-width glyph insertion, tracking, final TTF integrity validation, ss09/halt feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
+| `test_font_build.py` | 124 | CLI build selection and parallel intermediate path separation, Japanese vertical body scaling/tracking, UPM scaling policy, project-version metadata forwarding, glyph-name parsing, reverse-cmap kana / punctuation classification, CJK classification, GSUB/GPOS walk, baseline palt/vhal policy including U+30FB split propagation, x-scale, bbox strip, default-ignorable zero-width glyph insertion, tracking, final TTF integrity validation, ss09/halt/vhal feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
 | `test_proportional.py` | 39 | palt/vpal extraction, cumulative SinglePos lookup reading, glyph translation, GPOS feature removal including vkrn, runtime-palt/vpal helper coverage + base/residual split + optional squeeze helper, ss09 construction + shaping including vertical no-op coverage |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -112,6 +112,9 @@ For each (family, weight) in FAMILIES × WEIGHTS:
   → install horizontal yakumono-only ss09 against the final cmap / glyph names
     so merge-time glyph renames keep optional horizontal yakumono behavior;
     vertical writing remains a basic full-width fallback
+  → re-synthesize GPOS halt from those same retargeted ss09 residuals so
+    Chromium CSS text-spacing-trim works; Blink requires halt, while vhal
+    and chws are intentionally absent
   → add post-merge default-ignorable zero-width glyphs for U+200C, U+200D,
     and U+FE00-U+FE0F to format 4 / format 12 cmap tables. These empty glyphs
     prevent literal composers from rendering tofu for emoji variation
@@ -199,8 +202,11 @@ Four sub-passes, all in-place on the inst:
    Runtime `vpal` is not reinstalled, vertical `vkrn` is stripped, and
    production builds do not create vertical `.ss09` alternates. Vertical
    writing is treated as a fallback path that should keep basic full-width
-   rhythm. Final fonts strip `palt`, `vpal`, `halt`, `vhal`, and `vkrn` so
-   optional yakumono spacing is exposed through horizontal `ss09` only. Glyphs without palt entries are not
+   rhythm. `make_proportional` strips `palt`, `vpal`, `halt`, `vhal`, and
+   `vkrn`; after the final merge, a fresh horizontal `halt` is synthesized
+   from the same retargeted residuals as `ss09` so Chromium can apply CSS
+   `text-spacing-trim` (Blink requires `halt`). `vhal` and `chws` remain
+   intentionally absent. Glyphs without palt entries are not
    automatically sidebearing-squeezed; they keep their original
    `hmtx` unless a later explicit spacing rule touches them.
    `U+30FB` (・) is split from Noto's shared `uni2027` glyph before palt
@@ -312,7 +318,10 @@ for shared Noto glyphs such as `U+FF40` (｀), which uses Noto's `uni2035`
 before merge but may be renamed to `uni2035.orig` when Inter also provides
 `U+2035`. Because this final install happens after the merge, the saved
 residual records are also scaled by `SCALE` so live `ss09` alternates match
-the optically scaled Noto base.
+the optically scaled Noto base. The same retargeted residuals are installed
+as a GPOS `halt` SinglePos feature so Chromium's CSS `text-spacing-trim`
+activates; Blink requires `halt`. No vertical `vhal` or contextual `chws`
+feature is created.
 
 ## Proportional Metrics (`font/proportional.py`)
 
@@ -435,6 +444,9 @@ along Unicode ranges and emits one `@font-face` rule per slice with a
 references. The plan is cmap/codepoint-driven because `unicode-range` is a
 user-facing character policy; `fontTools.subset` performs the layout closure
 needed to retain referenced alternates and positioning data inside each WOFF2.
+That layout closure preserves the final font's GSUB `ss09` and GPOS `halt`
+records in the relevant subsets, enabling Chromium `text-spacing-trim` in
+the shipped webfonts; `vhal` and `chws` remain absent.
 Subset WOFF2 generation honors `--jobs`; for `jobs > 1` it uses
 `ThreadPoolExecutor` rather than process workers because the macOS/pyenv
 spawn path deadlocked under the full webfont task fan-out (issue #33).
@@ -565,7 +577,7 @@ Tests live under `tests/`, split by surface:
 
 | File | Tests | Verifies |
 |---|---|---|
-| `test_font_build.py` | 120 | CLI build selection and parallel intermediate path separation, Japanese vertical body scaling/tracking, UPM scaling policy, project-version metadata forwarding, glyph-name parsing, reverse-cmap kana / punctuation classification, CJK classification, GSUB/GPOS walk, baseline palt policy, x-scale, bbox strip, default-ignorable zero-width glyph insertion, tracking, final TTF integrity validation, ss09 feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
+| `test_font_build.py` | 122 | CLI build selection and parallel intermediate path separation, Japanese vertical body scaling/tracking, UPM scaling policy, project-version metadata forwarding, glyph-name parsing, reverse-cmap kana / punctuation classification, CJK classification, GSUB/GPOS walk, baseline palt policy, x-scale, bbox strip, default-ignorable zero-width glyph insertion, tracking, final TTF integrity validation, ss09/halt feature retargeting, final runtime feature scaling, InterVariable edge-instance compatibility |
 | `test_proportional.py` | 39 | palt/vpal extraction, cumulative SinglePos lookup reading, glyph translation, GPOS feature removal including vkrn, runtime-palt/vpal helper coverage + base/residual split + optional squeeze helper, ss09 construction + shaping including vertical no-op coverage |
 | `test_release.py` | 2 | GitHub asset URL contract, npm package layout (files glob, license, README, self-host/CDN CSS entrypoints at root) |
 | `test_webfont_build.py` | 42 | Range merge / dedup, unicode-range formatting incl. 5-digit, JIS row mapping, subset plan placement / non-overlap / coverage, strategy parser edge cases |

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -41,7 +41,9 @@ from project_metadata import project_version as read_project_version
 from .proportional import (
     _install_halt_feature,
     _install_ss09_punctuation_feature,
+    _install_vhal_feature,
     _read_palt,
+    _read_single_pos_feature,
     _remove_prop_features,
     _scale_position_adjustment,
     make_proportional,
@@ -177,10 +179,11 @@ RUNTIME_PALT_BASE_SCALE = 0.34
 # abruptly. Use the baseline vendor palt as the source of truth for every
 # weight, matching the historical Gen Interface JP spacing policy.
 _baseline_palt_cache: dict[str, tuple[int, int]] | None = None
+_baseline_vhal_cache: dict[str, tuple[int, int]] | None = None
 
 # Vertical writing is treated as a fallback path for this UI-focused family.
-# Keep it on basic full-width metrics: do not expose Noto vpal/vkrn behavior
-# through runtime features, and do not add vertical ss09 alternates.
+# Keep default metrics on a basic full-width grid, but derive optional vertical
+# ss09/vhal behavior directly from Noto's baseline vhal records.
 SS09_VERTICAL_FEATURE_CHARS: tuple[str, ...] = ()
 SS09_VERTICAL_FEATURE_GLYPHS: tuple[str, ...] = ()
 SS09_SYNTHETIC_VERTICAL_ADJUSTMENTS: dict[str, tuple[int, int]] = {}
@@ -1209,6 +1212,25 @@ def _get_baseline_palt() -> dict[str, tuple[int, int]]:
     return _baseline_palt_cache
 
 
+def _get_baseline_vhal() -> dict[str, tuple[int, int]]:
+    """Read Noto's baseline vhal feature once and reuse it for every weight."""
+    global _baseline_vhal_cache
+    if _baseline_vhal_cache is None:
+        source = TTFont(NOTO_VARIABLE)
+        try:
+            _baseline_vhal_cache = dict(
+                _read_single_pos_feature(
+                    source,
+                    "vhal",
+                    "YPlacement",
+                    "YAdvance",
+                )
+            )
+        finally:
+            source.close()
+    return _baseline_vhal_cache
+
+
 def _runtime_palt_residual_adjustment(
     adjustment: tuple[int, int],
 ) -> tuple[int, int]:
@@ -1296,12 +1318,13 @@ def _refresh_ss09_feature_after_merge(
     codepoint-keyed optional punctuation behavior against the final cmap so
     characters such as U+FF40 (｀), which shares Noto's ``uni2035`` glyph before
     merge, keep their ss09 adjustment on the renamed final glyph. Horizontal
-    palt is intentionally not reinstalled here. Production builds also pass
-    no vertical adjustments, so vertical ss09 remains disabled.
+    palt is intentionally not reinstalled here. Production vertical
+    adjustments come from Noto's baseline ``vhal`` and are retargeted by
+    codepoint or surviving glyph name before building vertical ss09 alternates.
 
-    The same codepoint-retargeted adjustments are also installed as GPOS
-    ``halt`` so Chromium's ``text-spacing-trim`` works (Blink requires
-    ``halt``). A vertical ``vhal`` feature is intentionally not created.
+    The same retargeted horizontal and vertical adjustments are also installed
+    as GPOS ``halt`` and ``vhal`` so Chromium's ``text-spacing-trim`` works in
+    horizontal and vertical flows.
     """
     font = TTFont(final_path)
     ss09_adjustments = _retarget_feature_adjustments(
@@ -1323,6 +1346,8 @@ def _refresh_ss09_feature_after_merge(
         ss09_vertical_adjustments,
     )
     _install_halt_feature(font, ss09_adjustments)
+    if ss09_vertical_adjustments:
+        _install_vhal_feature(font, ss09_vertical_adjustments)
     font.save(final_path)
 
 
@@ -1677,6 +1702,23 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
             palt_data,
         )
     )
+    vhal_data = _scale_design_adjustments(dict(_get_baseline_vhal()), font_upm)
+    # U+30FB was split from Noto's shared uni2027 glyph above; preserve the
+    # source glyph's vertical half-width adjustment on the new uni30FB glyph.
+    if split_source in vhal_data:
+        vhal_data["uni30FB"] = vhal_data[split_source]
+    source_cmap = font.getBestCmap() or {}
+    ss09_vertical_by_codepoint = {
+        cp: vhal_data[glyph_name]
+        for cp, glyph_name in source_cmap.items()
+        if glyph_name in vhal_data
+    }
+    mapped_vhal_glyphs = set(source_cmap.values())
+    ss09_vertical_by_glyph = {
+        glyph_name: value
+        for glyph_name, value in vhal_data.items()
+        if glyph_name not in mapped_vhal_glyphs
+    }
 
     # Bake Noto palt entries at full strength except ss09 yakumono, which
     # receive a reduced baked base. Their residual is captured above and later
@@ -1751,8 +1793,8 @@ def build_one(family: dict, weight_num: int, weight_name: str, noto_wght: int) -
     _refresh_ss09_feature_after_merge(
         final_path,
         _scale_feature_adjustments(ss09_punctuation_by_codepoint, SCALE),
-        {},
-        {},
+        _scale_feature_adjustments(ss09_vertical_by_codepoint, SCALE),
+        _scale_feature_adjustments(ss09_vertical_by_glyph, SCALE),
     )
     default_ignorables_added = _add_default_ignorable_glyphs_to_ttf(final_path)
     if default_ignorables_added:

--- a/src/font/build.py
+++ b/src/font/build.py
@@ -39,6 +39,7 @@ from fontTools.varLib import instancer
 from merge_fonts import merge_fonts, parse_codepoint_list
 from project_metadata import project_version as read_project_version
 from .proportional import (
+    _install_halt_feature,
     _install_ss09_punctuation_feature,
     _read_palt,
     _remove_prop_features,
@@ -1297,6 +1298,10 @@ def _refresh_ss09_feature_after_merge(
     merge, keep their ss09 adjustment on the renamed final glyph. Horizontal
     palt is intentionally not reinstalled here. Production builds also pass
     no vertical adjustments, so vertical ss09 remains disabled.
+
+    The same codepoint-retargeted adjustments are also installed as GPOS
+    ``halt`` so Chromium's ``text-spacing-trim`` works (Blink requires
+    ``halt``). A vertical ``vhal`` feature is intentionally not created.
     """
     font = TTFont(final_path)
     ss09_adjustments = _retarget_feature_adjustments(
@@ -1317,6 +1322,7 @@ def _refresh_ss09_feature_after_merge(
         ss09_adjustments,
         ss09_vertical_adjustments,
     )
+    _install_halt_feature(font, ss09_adjustments)
     font.save(final_path)
 
 

--- a/src/font/proportional.py
+++ b/src/font/proportional.py
@@ -484,6 +484,28 @@ def _install_palt_feature(
     )
 
 
+def _install_halt_feature(
+    font: TTFont,
+    adjustments: dict[str, tuple[int, int]],
+) -> None:
+    """Install a fresh SinglePos halt feature for ``adjustments``.
+
+    Chromium enables CSS ``text-spacing-trim`` only when the font carries
+    ``halt`` (Blink HanKerning early-returns otherwise). The shipped fonts
+    bake reduced palt into hmtx and strip Noto's original ``halt``, so a new
+    one is synthesized from the ss09 residual adjustments: applying ``halt``
+    yields the same metrics as substituting the ss09 half-width alternates.
+    """
+    _install_single_pos_feature(
+        font,
+        "halt",
+        adjustments,
+        "XPlacement",
+        "XAdvance",
+        0x0001 | 0x0004,
+    )
+
+
 def _install_vpal_feature(
     font: TTFont,
     adjustments: dict[str, tuple[int, int]],

--- a/src/font/proportional.py
+++ b/src/font/proportional.py
@@ -506,6 +506,27 @@ def _install_halt_feature(
     )
 
 
+def _install_vhal_feature(
+    font: TTFont,
+    adjustments: dict[str, tuple[int, int]],
+) -> None:
+    """Install a fresh SinglePos vhal feature for ``adjustments``.
+
+    The feature is synthesized from the ss09 vertical residuals so Chromium's
+    ``text-spacing-trim`` works in vertical writing (Blink checks ``vhal`` in
+    vertical flows). Coverage uses vertical-form glyphs because ``vert``
+    substitution runs before positioning.
+    """
+    _install_single_pos_feature(
+        font,
+        "vhal",
+        adjustments,
+        "YPlacement",
+        "YAdvance",
+        0x0002 | 0x0008,
+    )
+
+
 def _install_vpal_feature(
     font: TTFont,
     adjustments: dict[str, tuple[int, int]],
@@ -532,8 +553,8 @@ def _install_ss09_punctuation_feature(
     to private alternate glyphs that carry the remaining palt delta in their
     outline position and hmtx advance. When vertical adjustments are supplied,
     the same helper can create vertical-form alternates whose vmtx carries a
-    vertical metric delta. The production build intentionally passes none so
-    vertical writing stays on basic full-width metrics.
+    vertical metric delta. Production builds derive these vertical adjustments
+    from Noto's baseline vhal feature.
 
     PairPos kerning is extended to alternates so enabling ``ss09`` does not
     drop existing horizontal ``kern`` pairs.

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -31,6 +31,7 @@ from font.build import (
     _final_output_metadata,
     _get_vert_alternates,
     _get_baseline_palt,
+    _get_baseline_vhal,
     _glyphs_for_codepoints,
     _glyph_codepoint,
     _intermediate_paths,
@@ -1131,6 +1132,44 @@ class TestPaltSymbolPolicy:
         ) == {"A": (-12, -34)}
         assert "vhal" not in _layout_feature_tags(refreshed, "GPOS")
 
+    def test_refresh_ss09_installs_retargeted_vhal(self, tmp_path):
+        inter_path = _default_inter_static_path(FAMILIES["normal"], "Regular")
+        if not Path(inter_path).is_file():
+            pytest.skip(f"Inter font not found at {inter_path}")
+        final_path = tmp_path / "merged.ttf"
+        font = TTFont(inter_path)
+        font.save(final_path)
+
+        _refresh_ss09_feature_after_merge(
+            str(final_path),
+            {0x41: (-12, -34)},
+            {0x41: (0, -50)},
+            {},
+        )
+
+        refreshed = TTFont(final_path)
+        assert _read_single_pos_feature(
+            refreshed,
+            "vhal",
+            "YPlacement",
+            "YAdvance",
+        ) == {"A": (0, -50)}
+        vhal_record = next(
+            record
+            for record in refreshed["GPOS"].table.FeatureList.FeatureRecord
+            if record.FeatureTag == "vhal"
+        )
+        vhal_lookups = [
+            refreshed["GPOS"].table.LookupList.Lookup[index]
+            for index in vhal_record.Feature.LookupListIndex
+        ]
+        assert vhal_lookups
+        assert all(
+            subtable.ValueFormat == 0x000A
+            for lookup in vhal_lookups
+            for subtable in lookup.SubTable
+        )
+
     def test_runtime_palt_keeps_reduced_base_metrics(self):
         assert RUNTIME_PALT_BASE_SCALE == 0.34
         assert _runtime_palt_residual_adjustment((-250, -500)) == (-165, -330)
@@ -1141,10 +1180,34 @@ class TestPaltSymbolPolicy:
             assert family["runtimePalt"] == PALT_FEATURE_CHARS
             assert "runtimeVpal" not in family
 
-    def test_vertical_yakumono_ss09_is_disabled(self):
+    def test_vertical_yakumono_uses_baseline_vhal(self):
+        adjustments = _get_baseline_vhal()
+        source = TTFont(NOTO_VARIABLE)
+        try:
+            encoded_glyphs = set((source.getBestCmap() or {}).values())
+        finally:
+            source.close()
+
+        assert adjustments
+        assert all(y_advance < 0 for _, y_advance in adjustments.values())
+        assert any(glyph_name in encoded_glyphs for glyph_name in adjustments)
+        assert any(glyph_name not in encoded_glyphs for glyph_name in adjustments)
+
+        # These legacy policy constants stay empty because production vertical
+        # ss09/vhal coverage now comes directly from Noto's baseline vhal.
         assert SS09_VERTICAL_FEATURE_CHARS == ()
         assert SS09_VERTICAL_FEATURE_GLYPHS == ()
         assert SS09_SYNTHETIC_VERTICAL_ADJUSTMENTS == {}
+
+    def test_middle_dot_split_inherits_baseline_vhal(self):
+        adjustments = dict(_get_baseline_vhal())
+        split_source = "uni2027"
+
+        assert split_source in adjustments
+        if split_source in adjustments:
+            adjustments["uni30FB"] = adjustments[split_source]
+
+        assert adjustments["uni30FB"] == adjustments[split_source]
 
     def test_vertical_tracking_is_normal_only(self):
         assert NORMAL_VERTICAL_TRACKING == 9

--- a/tests/test_font_build.py
+++ b/tests/test_font_build.py
@@ -40,6 +40,7 @@ from font.build import (
     _parallel_task_command,
     _parse_args,
     _project_version,
+    _refresh_ss09_feature_after_merge,
     _reverse_cmap,
     _retarget_feature_adjustments,
     _retarget_named_adjustments,
@@ -79,8 +80,10 @@ from font.build import (
     TRACKING_IGNORE_CODEPOINTS,
 )
 from font.proportional import (
+    _install_halt_feature,
     _install_ss09_punctuation_feature,
     _read_palt,
+    _read_single_pos_feature,
 )
 from merge_fonts import parse_codepoint_list
 
@@ -1069,6 +1072,64 @@ class TestPaltSymbolPolicy:
         after_gpos = _layout_feature_tags(font, "GPOS")
         assert inter_sets | {"ss09"} <= after_gsub
         assert "halt" not in after_gpos
+
+    def test_halt_install_reproduces_ss09_adjustments(self):
+        inter_path = _default_inter_static_path(FAMILIES["normal"], "Regular")
+        if not Path(inter_path).is_file():
+            pytest.skip(f"Inter font not found at {inter_path}")
+        font = TTFont(inter_path)
+        adjustments = {"A": (-12, -34), "B": (0, -56)}
+
+        _install_halt_feature(font, adjustments)
+
+        assert "halt" in _layout_feature_tags(font, "GPOS")
+        assert _read_single_pos_feature(
+            font,
+            "halt",
+            "XPlacement",
+            "XAdvance",
+        ) == adjustments
+        halt_record = next(
+            record
+            for record in font["GPOS"].table.FeatureList.FeatureRecord
+            if record.FeatureTag == "halt"
+        )
+        halt_lookups = [
+            font["GPOS"].table.LookupList.Lookup[index]
+            for index in halt_record.Feature.LookupListIndex
+        ]
+        assert halt_lookups
+        assert all(
+            subtable.ValueFormat == 0x0005
+            for lookup in halt_lookups
+            for subtable in lookup.SubTable
+        )
+
+    def test_refresh_ss09_also_installs_retargeted_halt(self, tmp_path):
+        inter_path = _default_inter_static_path(FAMILIES["normal"], "Regular")
+        if not Path(inter_path).is_file():
+            pytest.skip(f"Inter font not found at {inter_path}")
+        final_path = tmp_path / "merged.ttf"
+        font = TTFont(inter_path)
+        font.save(final_path)
+        adjustments = {0x41: (-12, -34)}
+
+        _refresh_ss09_feature_after_merge(
+            str(final_path),
+            adjustments,
+            {},
+            {},
+        )
+
+        refreshed = TTFont(final_path)
+        assert "ss09" in _layout_feature_tags(refreshed, "GSUB")
+        assert _read_single_pos_feature(
+            refreshed,
+            "halt",
+            "XPlacement",
+            "XAdvance",
+        ) == {"A": (-12, -34)}
+        assert "vhal" not in _layout_feature_tags(refreshed, "GPOS")
 
     def test_runtime_palt_keeps_reduced_base_metrics(self):
         assert RUNTIME_PALT_BASE_SCALE == 0.34


### PR DESCRIPTION
## Background

Chromium (Blink's HanKerning) enables CSS `text-spacing-trim` only when the font carries a GPOS `halt` feature (`vhal` in vertical flows). This project's pipeline deliberately strips `halt`/`vhal` after baking palt into hmtx, so `text-spacing-trim` was completely inert in the shipped webfonts, both horizontally and vertically.

## Changes

### Horizontal: synthesize halt (8d220e8)
- Add `_install_halt_feature` and call it from `_refresh_ss09_feature_after_merge`, installing a SinglePos `halt` (ValueFormat 0x0005) on the final merged font from **the exact same ss09 residual adjustments**.
- Applying `halt` therefore reproduces the ss09 half-width alternates' metrics exactly.

### Vertical: synthesize vhal + vertical ss09 alternates (a7b00e5)
- Add `_get_baseline_vhal()`, reading `vhal` straight from the Noto variable source (same cached pattern as baseline palt).
- Feed the records into the existing retargeting machinery — encoded vertical forms (U+FE11 etc.) keyed by codepoint, unmapped vert alternates keyed by glyph name — so production now builds vertical ss09 metric alternates (vmtx deltas).
- Install the same values as a GPOS `vhal` feature (ValueFormat 0x000A).
- Propagate the shared `uni2027` record to the split `uni30FB` glyph, mirroring the existing palt compensation, so U+30FB (katakana middle dot) keeps its vertical adjustments.
- Default vertical setting without ss09/text-spacing-trim stays on the basic full-width grid; `chws`/`vchw` remain intentionally absent.

## Verification

- 208 tests passing.
- Full audit of all 43 vhal records: ss09 vertical deltas match 43/43; zero ink overflow after half-width trimming.
- Browser measurements (Chrome 150):
  - Horizontal: 365.6px untrimmed → 316.8px with `text-spacing-trim: normal`
  - Vertical: 532.9px untrimmed → 477.4px trimmed / 394.2px with ss09
  - Vertical trim ratio matches Noto Sans JP's genuine vhal (−11.6% vs −11.7%)

## Notes

- Only the normal-family Regular weight has been rebuilt; all weights + Display need a rebuild around merge.
- Illustrator's mojikumi spacing does not consume halt/vhal (verified experimentally), so this change is web-only in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yCn1UJLFPtSDfufugSkh3